### PR TITLE
feat: optimize lightgallery thumbnails via CDN params

### DIFF
--- a/theme/package.json
+++ b/theme/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-theme-chrisvogt",
   "description": "My personal blog and website.",
-  "version": "0.36.2",
+  "version": "0.37.0",
   "author": "Chris Vogt <mail@chrisvogt.me> (https://www.chrisvogt.me)",
   "main": "index.js",
   "license": "MIT",

--- a/theme/src/components/widgets/instagram/instagram-widget.js
+++ b/theme/src/components/widgets/instagram/instagram-widget.js
@@ -153,7 +153,7 @@ export default () => {
           download={false}
           dynamic
           dynamicEl={media.map(post => ({
-            thumb: post.cdnMediaURL,
+            thumb: `${post.cdnMediaURL}?auto=compress&auto=enhance&auto=format&fit=clip&w=100&h=100`,
             subHtml: post.caption || '',
             ...(post.mediaType !== 'VIDEO'
               ? { src: `${post.cdnMediaURL}?auto=compress&auto=enhance&auto=format` }


### PR DESCRIPTION
This PR updates the image URLs used for the [lightgallery](https://www.lightgalleryjs.com/) thumbnails so that they use [Imgix cropping and resizing](https://docs.imgix.com/en-US/apis/rendering/size/crop-mode) to fetch images that are the same size as the thumbnail container.

> [!NOTE]
> This change reduces the initial page load from 7.8MB (❗) to ~500kb because we are no longer downloading the full-sized images just for the thumbnails.

Here's a demonstration.

<img width="1691" alt="Screenshot of issue and explanation of images being downloaded by the browser while the gallery isn't visible yet." src="https://github.com/user-attachments/assets/888e6350-6c29-47ed-9200-c49dcecc706e" />

----

It would be great to lazy load these images, but I haven't yet found a good way to add [the loading='lazy' attribute](https://developer.mozilla.org/en-US/docs/Web/Performance/Guides/Lazy_loading) to those thumbnails. Looking through PRs on the plugin I'm using, it seems like @principis has attempted to open a PR twice, but didn't get any reviews for those PRs and they were eventually closed and marked stale over time. 😭 These are those PRs:

* sachinchoolur/lightGallery#1691
* sachinchoolur/lightGallery#1668

Since @sachinchoolur owns this plugin and is the #​1 contributor, maybe we can reach out to him and ask what he thinks about that change.