### PR TITLE
feat(chronogrove): update config to use new API endpoints

### DIFF
--- a/www.chronogrove.com/gatsby-config.js
+++ b/www.chronogrove.com/gatsby-config.js
@@ -27,29 +27,13 @@ module.exports = {
     title: 'Chronogrove',
     titleTemplate: '%s · A GatsbyJS Theme for Personal Websites',
     widgets: {
-      flickr: {
-        username: 'chronogrove',
-        widgetDataSource: 'https://metrics.chrisvogt.me/api/flickr/chronogrove'
-      },
       github: {
-        username: 'chronogrove',
-        widgetDataSource: 'https://metrics.chrisvogt.me/api/github/chronogrove'
-      },
-      goodreads: {
-        username: 'chronogrove',
-        widgetDataSource: 'https://metrics.chrisvogt.me/api/goodreads/chronogrove'
+        username: 'chrisvogt',
+        widgetDataSource: 'https://api.chronogrove.com/api/widgets/github?timestamp=1752542186'
       },
       instagram: {
         username: 'chronogrove',
-        widgetDataSource: 'https://metrics.chrisvogt.me/api/instagram/chronogrove'
-      },
-      spotify: {
-        username: 'chronogrove',
-        widgetDataSource: 'https://metrics.chrisvogt.me/api/spotify/chronogrove'
-      },
-      steam: {
-        username: 'chronogrove',
-        widgetDataSource: 'https://metrics.chrisvogt.me/api/steam/chronogrove'
+        widgetDataSource: 'https://api.chronogrove.com/api/widgets/instagram?timestamp=1752542186'
       }
     }
   },


### PR DESCRIPTION
## Overview

This PR updates the www.chronogrove.com config to use the new endpoints published under api.chronogrove.com/*. This change relates to chrisvogt/metrics#77.

## Screenshots

<img width="1639" height="1084" alt="Screenshot 2025-07-14 at 7 00 34 PM" src="https://github.com/user-attachments/assets/5e3d740e-0782-4781-8d51-9310dffb164d" />

## AI summary

This pull request updates the widget configuration in the `gatsby-config.js` file for the Chronogrove website. The changes focus on removing unused widgets and updating the data source for the remaining widgets.

### Widget configuration updates:

* Removed the following widgets: `flickr`, `goodreads`, `spotify`, and `steam`. These widgets are no longer included in the configuration.
* Updated the `github` widget to use a new username (`chrisvogt`) and a new data source URL (`https://api.chronogrove.com/api/widgets/github?timestamp=1752542186`).
* Updated the `instagram` widget to use a new data source URL (`https://api.chronogrove.com/api/widgets/instagram?timestamp=1752542186`).
