### PR TITLE
docs(chronogrove): allow manual triggering of Chronogrove deploy

### DIFF
--- a/.github/workflows/deploy-chronogrove-website.yml
+++ b/.github/workflows/deploy-chronogrove-website.yml
@@ -6,6 +6,13 @@ on:
     paths:
       - 'www.chronogrove.com/**'
       - 'theme/**'
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch to deploy'
+        required: true
+        default: 'main'
+        type: string
 
 jobs:
   build-and-deploy:

--- a/.github/workflows/deploy-chronogrove-website.yml
+++ b/.github/workflows/deploy-chronogrove-website.yml
@@ -6,6 +6,11 @@ on:
     paths:
       - 'www.chronogrove.com/**'
       - 'theme/**'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'www.chronogrove.com/**'
+      - 'theme/**'
   workflow_dispatch:
     inputs:
       branch:
@@ -26,6 +31,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.inputs.branch || github.ref }}
           submodules: true
 
       - name: Setup Node.js

--- a/.github/workflows/deploy-chronogrove-website.yml
+++ b/.github/workflows/deploy-chronogrove-website.yml
@@ -6,11 +6,6 @@ on:
     paths:
       - 'www.chronogrove.com/**'
       - 'theme/**'
-  pull_request:
-    branches: [main]
-    paths:
-      - 'www.chronogrove.com/**'
-      - 'theme/**'
   workflow_dispatch:
     inputs:
       branch:

--- a/.github/workflows/deploy-chronogrove-website.yml
+++ b/.github/workflows/deploy-chronogrove-website.yml
@@ -53,5 +53,5 @@ jobs:
           port: 22
           user: ${{ secrets.CPANEL_USER }}
           pass: ${{ secrets.CPANEL_PASSWORD }}
-          localDir: public
+          localDir: www.chronogrove.com/public/
           remoteDir: public_html/

--- a/www.chronogrove.com/README.md
+++ b/www.chronogrove.com/README.md
@@ -39,9 +39,6 @@ The site uses demo data that showcases the theme's capabilities while remaining 
 The site includes demo widget configurations that point to mock endpoints. You can:
 
 1. Set up real API endpoints for live demos
-2. Use mock data for development and testing
-3. Test widget error states and loading states
-4. Showcase widget functionality to potential users
 
 ## Development Workflow
 

--- a/www.chronogrove.com/gatsby-config.js
+++ b/www.chronogrove.com/gatsby-config.js
@@ -29,11 +29,11 @@ module.exports = {
     widgets: {
       github: {
         username: 'chrisvogt',
-        widgetDataSource: 'https://api.chronogrove.com/api/widgets/github?timestamp=1752542186'
+        widgetDataSource: 'https://api.chronogrove.com/api/widgets/github?timestamp=1752551337'
       },
       instagram: {
         username: 'chronogrove',
-        widgetDataSource: 'https://api.chronogrove.com/api/widgets/instagram?timestamp=1752542186'
+        widgetDataSource: 'https://api.chronogrove.com/api/widgets/instagram?timestamp=1752551337'
       }
     }
   },


### PR DESCRIPTION
## Overview

This PR makes updates to the Chronogrove deploy action to stop triggering on PRs while allowing manual triggering via github.com.