### PR TITLE
fix(instagram): only show "Show More" button when more images available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 0.52.1
+
+### 🐛 Bug Fixes
+
+- **Instagram Widget**: Fixed "Show More" button to only appear when there are actually more images to display
+  - Button now only renders when there are more than 8 images available
+  - Prevents confusing UX for users with small image collections (≤8 images)
+  - "Show Less" functionality continues to work correctly when expanded
+
+### 🧪 Testing
+
+- Added test coverage for button visibility logic with different image counts
+- Updated existing tests to work with new conditional button rendering
+- All 180 widget tests continue to pass
+
 ## 0.52.0
 
 ### ✨ Features

--- a/theme/package.json
+++ b/theme/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-theme-chronogrove",
   "description": "My personal blog and website.",
-  "version": "0.52.0",
+  "version": "0.52.1",
   "author": "Chris Vogt <mail@chrisvogt.me> (https://www.chrisvogt.me)",
   "main": "index.js",
   "license": "MIT",

--- a/theme/src/components/widgets/instagram/instagram-widget.js
+++ b/theme/src/components/widgets/instagram/instagram-widget.js
@@ -140,7 +140,7 @@ export default () => {
         </Grid>
       </div>
 
-      {!isLoading && (
+      {!isLoading && media?.length > MAX_IMAGES.default && (
         <div sx={{ my: 4, textAlign: 'center' }}>
           <Button onClick={() => setIsShowingMore(!isShowingMore)}>{isShowingMore ? 'Show Less' : 'Show More'}</Button>
         </div>

--- a/theme/src/components/widgets/instagram/instagram-widget.spec.js
+++ b/theme/src/components/widgets/instagram/instagram-widget.spec.js
@@ -126,9 +126,44 @@ describe('InstagramWidget', () => {
     )
   })
 
-  it('toggles between "Show More" and "Show Less"', () => {
+  it('does not show "Show More" button when there are 8 or fewer images', () => {
     render(
       <ReduxProvider store={store}>
+        <ThemeUIProvider theme={theme}>
+          <InstagramWidget />
+        </ThemeUIProvider>
+      </ReduxProvider>
+    )
+
+    expect(screen.queryByText(/Show More/i)).not.toBeInTheDocument()
+  })
+
+  it('shows and toggles "Show More"/"Show Less" button when there are more than 8 images', () => {
+    const storeWithManyImages = mockStore({
+      widgets: {
+        instagram: {
+          state: 'SUCCESS',
+          data: {
+            collections: {
+              media: Array.from({ length: 10 }, (_, i) => ({
+                id: `image-${i}`,
+                caption: `Test Caption ${i}`,
+                cdnMediaURL: `https://cdn.chrisvogt.me/images/fake-instagram-image-${i}.jpg`,
+                mediaType: 'IMAGE',
+                permalink: `https://instagram.com/p/test${i}`
+              }))
+            },
+            metrics: [
+              { displayName: 'Followers', id: '1', value: 100 },
+              { displayName: 'Following', id: '2', value: 50 }
+            ]
+          }
+        }
+      }
+    })
+
+    render(
+      <ReduxProvider store={storeWithManyImages}>
         <ThemeUIProvider theme={theme}>
           <InstagramWidget />
         </ThemeUIProvider>
@@ -160,8 +195,28 @@ describe('InstagramWidget', () => {
   })
 
   it('calls VanillaTilt.init when isShowingMore or !isLoading is true', () => {
+    const storeWithManyImages = mockStore({
+      widgets: {
+        instagram: {
+          state: 'SUCCESS',
+          data: {
+            collections: {
+              media: Array.from({ length: 10 }, (_, i) => ({
+                id: `image-${i}`,
+                caption: `Test Caption ${i}`,
+                cdnMediaURL: `https://cdn.chrisvogt.me/images/fake-instagram-image-${i}.jpg`,
+                mediaType: 'IMAGE',
+                permalink: `https://instagram.com/p/test${i}`
+              }))
+            },
+            metrics: []
+          }
+        }
+      }
+    })
+
     render(
-      <ReduxProvider store={store}>
+      <ReduxProvider store={storeWithManyImages}>
         <ThemeUIProvider theme={theme}>
           <InstagramWidget />
         </ThemeUIProvider>
@@ -173,7 +228,7 @@ describe('InstagramWidget', () => {
 
     VanillaTilt.init.mockClear()
 
-    store = mockStore({
+    const storeWithNoImages = mockStore({
       widgets: {
         instagram: {
           state: 'SUCCESS',
@@ -186,7 +241,7 @@ describe('InstagramWidget', () => {
     })
 
     render(
-      <ReduxProvider store={store}>
+      <ReduxProvider store={storeWithNoImages}>
         <ThemeUIProvider theme={theme}>
           <InstagramWidget />
         </ThemeUIProvider>


### PR DESCRIPTION
## 🐛 Bug Fix: Instagram Widget "Show More" Button Logic

### Problem
The Instagram widget's "Show More" button was appearing for all users regardless of how many images they had. Users with 8 or fewer images would see a button that didn't do anything when clicked, creating a confusing user experience.

### Solution
- Button now only renders when `media.length > 8` (the default display limit)
- Users with small image collections get a cleaner interface without unnecessary buttons
- All existing "Show More"/"Show Less" functionality preserved for users with larger collections

### Changes
- **Fixed**: Conditional rendering logic in `instagram-widget.js`
- **Added**: Test coverage for button visibility with different image counts
- **Updated**: Existing tests to work with new conditional logic
- **Verified**: All 180 widget tests continue to pass

### Test Cases
✅ Button hidden when ≤8 images  
✅ Button shown when >8 images  
✅ Toggle functionality works correctly  
✅ "Show Less" behavior preserved  

### Impact
- Better UX for users with small Instagram collections
- No breaking changes for existing functionality
- Improved test coverage for edge cases

### Version
- Bumped to `v0.52.1` (patch version)
- Updated CHANGELOG.md with details