### PR TITLE
chore(unit-tests): remove personal information from tests

### DIFF
--- a/theme/src/components/artwork/__snapshots__/book.spec.js.snap
+++ b/theme/src/components/artwork/__snapshots__/book.spec.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Book matches the snapshot 1`] = `
 <svg
@@ -68,7 +68,7 @@ exports[`Book matches the snapshot 1`] = `
       height="190"
       transform="translate(14.53 -3.68) scale(0.5)"
       width="128"
-      xlinkHref="https://cdn.chrisvogt.me/images/fake-book-cover.jpg"
+      xlinkHref="https://cdn.example.com/images/fake-book-cover.jpg"
     />
   </g>
 </svg>

--- a/theme/src/components/artwork/book.spec.js
+++ b/theme/src/components/artwork/book.spec.js
@@ -3,7 +3,7 @@ import renderer from 'react-test-renderer'
 import Book from './book'
 
 describe('Book', () => {
-  const thumbnailURL = 'https://cdn.chrisvogt.me/images/fake-book-cover.jpg'
+  const thumbnailURL = 'https://cdn.example.com/images/fake-book-cover.jpg'
   const title = 'Fake Book'
 
   it('matches the snapshot', () => {

--- a/theme/src/components/home-navigation.spec.js
+++ b/theme/src/components/home-navigation.spec.js
@@ -10,10 +10,10 @@ jest.mock('../hooks/use-navigation-data')
 
 const mockSiteMetadata = {
   widgets: {
-    github: { widgetDataSource: 'https://fake-api.chrisvogt.me/social/github' },
-    goodreads: { widgetDataSource: 'https://fake-api.chrisvogt.me/social/goodreads' },
-    instagram: { widgetDataSource: 'https://fake-api.chrisvogt.me/social/instagram' },
-    spotify: { widgetDataSource: 'https://fake-api.chrisvogt.me/social/spotify' }
+    github: { widgetDataSource: 'https://fake-api.example.com/social/github' },
+    goodreads: { widgetDataSource: 'https://fake-api.example.com/social/goodreads' },
+    instagram: { widgetDataSource: 'https://fake-api.example.com/social/instagram' },
+    spotify: { widgetDataSource: 'https://fake-api.example.com/social/spotify' }
   }
 }
 

--- a/theme/src/components/widgets/flickr/__snapshots__/flickr-widget-item.spec.js.snap
+++ b/theme/src/components/widgets/flickr/__snapshots__/flickr-widget-item.spec.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`FlickrWidgetItem matches the snapshot 1`] = `
 <DocumentFragment>
@@ -11,7 +11,7 @@ exports[`FlickrWidgetItem matches the snapshot 1`] = `
       crossorigin="anonymous"
       height="280"
       loading="lazy"
-      src="https://cdn.chrisvogt.me/images/fake-flickr-image.jpg"
+      src="https://cdn.example.com/images/fake-flickr-image.jpg"
       width="280"
     />
   </button>

--- a/theme/src/components/widgets/flickr/flickr-widget-item.spec.js
+++ b/theme/src/components/widgets/flickr/flickr-widget-item.spec.js
@@ -12,7 +12,7 @@ describe('FlickrWidgetItem', () => {
     photo: {
       id: '0123456789',
       title: 'Test Photo Title',
-      thumbnailUrl: 'https://cdn.chrisvogt.me/images/fake-flickr-image.jpg'
+      thumbnailUrl: 'https://cdn.example.com/images/fake-flickr-image.jpg'
     }
   }
 

--- a/theme/src/components/widgets/flickr/flickr-widget.spec.js
+++ b/theme/src/components/widgets/flickr/flickr-widget.spec.js
@@ -59,8 +59,8 @@ describe('FlickrWidget', () => {
                 {
                   id: '123',
                   title: 'Test Photo Title',
-                  thumbnailUrl: 'https://cdn.chrisvogt.me/images/fake-flickr-image.jpg',
-                  largeUrl: 'https://cdn.chrisvogt.me/images/fake-flickr-image-large.jpg'
+                  thumbnailUrl: 'https://cdn.example.com/images/fake-flickr-image.jpg',
+                  largeUrl: 'https://cdn.example.com/images/fake-flickr-image-large.jpg'
                 }
               ]
             },
@@ -123,7 +123,7 @@ describe('FlickrWidget', () => {
 
     const thumbnails = screen.getAllByAltText(/Flickr photo:/i)
     expect(thumbnails).toHaveLength(1)
-    expect(thumbnails[0]).toHaveAttribute('src', 'https://cdn.chrisvogt.me/images/fake-flickr-image.jpg')
+    expect(thumbnails[0]).toHaveAttribute('src', 'https://cdn.example.com/images/fake-flickr-image.jpg')
   })
 
   it('toggles between "Show More" and "Show Less"', () => {
@@ -270,8 +270,8 @@ describe('FlickrWidget', () => {
                 {
                   id: '123',
                   title: 'Test Photo Title',
-                  thumbnailUrl: 'https://cdn.chrisvogt.me/images/fake-flickr-image.jpg',
-                  largeUrl: 'https://cdn.chrisvogt.me/images/fake-flickr-image-large.jpg'
+                  thumbnailUrl: 'https://cdn.example.com/images/fake-flickr-image.jpg',
+                  largeUrl: 'https://cdn.example.com/images/fake-flickr-image-large.jpg'
                 }
               ]
             },
@@ -317,8 +317,8 @@ describe('FlickrWidget', () => {
               photos: Array(20).fill({
                 id: '123',
                 title: 'Test Photo Title',
-                thumbnailUrl: 'https://cdn.chrisvogt.me/images/fake-flickr-image.jpg',
-                largeUrl: 'https://cdn.chrisvogt.me/images/fake-flickr-image-large.jpg'
+                thumbnailUrl: 'https://cdn.example.com/images/fake-flickr-image.jpg',
+                largeUrl: 'https://cdn.example.com/images/fake-flickr-image-large.jpg'
               })
             },
             metrics: []

--- a/theme/src/components/widgets/github/__snapshots__/last-pull-request.spec.js.snap
+++ b/theme/src/components/widgets/github/__snapshots__/last-pull-request.spec.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Widget/GitHub/LastPullRequest snapshots matches the loading state snapshot 1`] = `
 <div
@@ -59,7 +59,7 @@ exports[`Widget/GitHub/LastPullRequest snapshots matches the repository variant 
   </h3>
   <a
     className="css-1ovdgfi"
-    href="https://www.github.com/chrisvogt/null/pulls/42"
+    href="https://www.github.com/themeuser/sample-repo/pulls/42"
   >
     <div
       className="css-1yz7e9k"

--- a/theme/src/components/widgets/github/__snapshots__/pinned-item-card.spec.js.snap
+++ b/theme/src/components/widgets/github/__snapshots__/pinned-item-card.spec.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Widget/GitHub/PinnedItemCard snapshots matches the placeholder snapshot 1`] = `
 <div
@@ -121,7 +121,7 @@ exports[`Widget/GitHub/PinnedItemCard snapshots matches the repository variant s
     <h4
       className="css-cpvk2h"
     >
-      chrisvogt/null
+      themeuser/sample-repo
     </h4>
     <span
       className="css-gulexy"

--- a/theme/src/components/widgets/github/github-widget.spec.js
+++ b/theme/src/components/widgets/github/github-widget.spec.js
@@ -10,7 +10,7 @@ const mockSiteMetadata = {
   widgets: {
     github: {
       username: 'mockusername',
-      widgetDataSource: 'https://fake-api.chrisvogt.me/social/github'
+      widgetDataSource: 'https://fake-api.example.com/social/github'
     }
   }
 }

--- a/theme/src/components/widgets/github/last-pull-request.spec.js
+++ b/theme/src/components/widgets/github/last-pull-request.spec.js
@@ -16,7 +16,7 @@ describe('Widget/GitHub/LastPullRequest', () => {
           name: 'Fake Project'
         },
         title: "Add fake information to the fake project's repository",
-        url: 'https://www.github.com/chrisvogt/null/pulls/42'
+        url: 'https://www.github.com/themeuser/sample-repo/pulls/42'
       }
       const tree = renderer.create(<LastPullRequest pullRequest={mockPullRequest} />).toJSON()
       expect(tree).toMatchSnapshot()

--- a/theme/src/components/widgets/github/pinned-item-card.spec.js
+++ b/theme/src/components/widgets/github/pinned-item-card.spec.js
@@ -13,7 +13,7 @@ describe('Widget/GitHub/PinnedItemCard', () => {
     it('matches the repository variant snapshot', () => {
       const mockRepositoryItem = {
         description: 'A fake NodeJS project.',
-        nameWithOwner: 'chrisvogt/null',
+        nameWithOwner: 'themeuser/sample-repo',
         openGraphImageUrl: './fake-image-path.png',
         updatedAt: '1592808981'
       }

--- a/theme/src/components/widgets/github/pinned-items.spec.js
+++ b/theme/src/components/widgets/github/pinned-items.spec.js
@@ -7,7 +7,7 @@ const mockPinnedItems = [
   {
     __typename: 'Repository',
     id: 'null-js',
-    url: 'https://www.github.com/chrisvogt/null/'
+    url: 'https://www.github.com/themeuser/sample-repo/'
   }
 ]
 

--- a/theme/src/components/widgets/github/renderers/__snapshots__/repository.spec.js.snap
+++ b/theme/src/components/widgets/github/renderers/__snapshots__/repository.spec.js.snap
@@ -7,7 +7,7 @@ exports[`GitHub Repository Renderer matches the snapshot 1`] = `
   <h4
     className="css-cpvk2h"
   >
-    chrisvogt/gatsby-theme-chronogrove
+    themeuser/gatsby-theme-chronogrove
   </h4>
   <span
     className="css-gulexy"

--- a/theme/src/components/widgets/github/renderers/repository.spec.js
+++ b/theme/src/components/widgets/github/renderers/repository.spec.js
@@ -8,7 +8,7 @@ describe('GitHub Repository Renderer', () => {
       .create(
         <Repository
           description='GatsbyJS blog theme with built-in social widgets for creatives and developers.'
-          nameWithOwner='chrisvogt/gatsby-theme-chronogrove'
+          nameWithOwner='themeuser/gatsby-theme-chronogrove'
           openGraphImageUrl='https://avatars0.githubusercontent.com/u/1934719?s=400&v=4'
           updatedAt='2020-03-26T12:11:58Z'
         />

--- a/theme/src/components/widgets/goodreads/book-explorer.spec.js
+++ b/theme/src/components/widgets/goodreads/book-explorer.spec.js
@@ -34,7 +34,7 @@ const renderWithRouter = ui =>
 describe('Widget/Goodreads/BookExplorer', () => {
   const mockBook = {
     authors: ['Test Author'],
-    cdnMediaURL: 'https://chrisvogt.imgix.net/book.jpg',
+    cdnMediaURL: 'https://images.imgix.net/book.jpg',
     description: 'Test description',
     infoLink: 'https://books.google.com/test',
     rating: '4',
@@ -61,7 +61,7 @@ describe('Widget/Goodreads/BookExplorer', () => {
   it('renders book image with webp format for CDN URLs', () => {
     renderWithRouter(<BookExplorer book={mockBook} onClose={() => {}} default />)
     const image = screen.getByTestId('book-preview-thumbnail')
-    expect(image).toHaveAttribute('xlink:href', 'https://chrisvogt.imgix.net/book.jpg?auto=compress&auto=format')
+    expect(image).toHaveAttribute('xlink:href', 'https://images.imgix.net/book.jpg?auto=compress&auto=format')
   })
 
   it('renders rating stars correctly', () => {

--- a/theme/src/components/widgets/goodreads/book-link.js
+++ b/theme/src/components/widgets/goodreads/book-link.js
@@ -9,7 +9,8 @@ const BookLink = ({ id, thumbnailURL, title }) => {
   const imageUrl = (() => {
     try {
       const url = new URL(thumbnailURL)
-      return url.host === 'chrisvogt.imgix.net' ? `${thumbnailURL}?auto=compress&auto=format` : thumbnailURL
+      const isImgixDomain = url.host.endsWith('.imgix.net')
+      return isImgixDomain ? `${thumbnailURL}?auto=compress&auto=format` : thumbnailURL
     } catch {
       return thumbnailURL // Return the original URL if it's invalid
     }

--- a/theme/src/components/widgets/goodreads/book-link.spec.js
+++ b/theme/src/components/widgets/goodreads/book-link.spec.js
@@ -33,11 +33,11 @@ describe('Widget/Goodreads/BookLink', () => {
   it('handles CDN URLs by appending webp format', () => {
     const cdnProps = {
       ...mockProps,
-      thumbnailURL: 'https://chrisvogt.imgix.net/book.jpg'
+      thumbnailURL: 'https://images.imgix.net/book.jpg'
     }
     render(<BookLink {...cdnProps} />)
     const image = screen.getByTestId('book-preview-thumbnail')
-    expect(image).toHaveAttribute('xlink:href', 'https://chrisvogt.imgix.net/book.jpg?auto=compress&auto=format')
+    expect(image).toHaveAttribute('xlink:href', 'https://images.imgix.net/book.jpg?auto=compress&auto=format')
   })
 
   it('preserves non-CDN URLs without modification', () => {

--- a/theme/src/components/widgets/goodreads/goodreads-widget.spec.js
+++ b/theme/src/components/widgets/goodreads/goodreads-widget.spec.js
@@ -11,7 +11,7 @@ const mockSiteMetadata = {
   widgets: {
     goodreads: {
       username: 'mockusername',
-      widgetDataSource: 'https://fake-api.chrisvogt.me/social/goodreads'
+      widgetDataSource: 'https://fake-api.example.com/social/goodreads'
     }
   }
 }

--- a/theme/src/components/widgets/goodreads/recently-read-books.spec.js
+++ b/theme/src/components/widgets/goodreads/recently-read-books.spec.js
@@ -222,12 +222,12 @@ describe('Widget/Goodreads/RecentlyReadBooks', () => {
   describe('book rendering', () => {
     it('handles both cdnMediaURL and thumbnail fallback', () => {
       const booksWithMixedUrls = [
-        { id: 'cdn', title: 'CDN Book', cdnMediaURL: 'https://chrisvogt.imgix.net/book1.jpg' },
+        { id: 'cdn', title: 'CDN Book', cdnMediaURL: 'https://images.imgix.net/book1.jpg' },
         { id: 'plain', title: 'Plain Book', thumbnail: 'https://example.com/book2.jpg' } // no cdnMediaURL
       ]
       renderWithRouter(<RecentlyReadBooks books={booksWithMixedUrls} isLoading={false} default />)
       const images = screen.getAllByTestId('book-preview-thumbnail')
-      expect(images[0]).toHaveAttribute('xlink:href', 'https://chrisvogt.imgix.net/book1.jpg?auto=compress&auto=format')
+      expect(images[0]).toHaveAttribute('xlink:href', 'https://images.imgix.net/book1.jpg?auto=compress&auto=format')
       expect(images[1]).toHaveAttribute('xlink:href', 'https://example.com/book2.jpg')
     })
   })

--- a/theme/src/components/widgets/instagram/__snapshots__/instagram-widget-item.spec.js.snap
+++ b/theme/src/components/widgets/instagram/__snapshots__/instagram-widget-item.spec.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`InstagramWidgetItem matches the snapshot 1`] = `
 <DocumentFragment>
@@ -11,7 +11,7 @@ exports[`InstagramWidgetItem matches the snapshot 1`] = `
       crossorigin="anonymous"
       height="280"
       loading="lazy"
-      src="https://cdn.chrisvogt.me/images/fake-instagram-image.jpg?h=234&w=234&fit=crop&crop=faces,focalpoint&auto=compress&auto=enhance&auto=format"
+      src="https://cdn.example.com/images/fake-instagram-image.jpg?h=234&w=234&fit=crop&crop=faces,focalpoint&auto=compress&auto=enhance&auto=format"
       width="280"
     />
   </button>

--- a/theme/src/components/widgets/instagram/instagram-widget-item.spec.js
+++ b/theme/src/components/widgets/instagram/instagram-widget-item.spec.js
@@ -12,7 +12,7 @@ describe('InstagramWidgetItem', () => {
     post: {
       id: '0123456789',
       caption: 'This is a test caption',
-      cdnMediaURL: 'https://cdn.chrisvogt.me/images/fake-instagram-image.jpg',
+      cdnMediaURL: 'https://cdn.example.com/images/fake-instagram-image.jpg',
       mediaType: 'IMAGE',
       permalink: 'https://instagram.com/fake-image-link'
     }

--- a/theme/src/components/widgets/instagram/instagram-widget.spec.js
+++ b/theme/src/components/widgets/instagram/instagram-widget.spec.js
@@ -55,7 +55,7 @@ describe('InstagramWidget', () => {
                 {
                   id: '123',
                   caption: 'Test Caption',
-                  cdnMediaURL: 'https://cdn.chrisvogt.me/images/fake-instagram-image.jpg',
+                  cdnMediaURL: 'https://cdn.example.com/images/fake-instagram-image.jpg',
                   mediaType: 'IMAGE',
                   permalink: 'https://instagram.com/p/test'
                 }
@@ -122,7 +122,7 @@ describe('InstagramWidget', () => {
     expect(thumbnails).toHaveLength(1)
     expect(thumbnails[0]).toHaveAttribute(
       'src',
-      expect.stringContaining('https://cdn.chrisvogt.me/images/fake-instagram-image.jpg')
+      expect.stringContaining('https://cdn.example.com/images/fake-instagram-image.jpg')
     )
   })
 
@@ -148,7 +148,7 @@ describe('InstagramWidget', () => {
               media: Array.from({ length: 10 }, (_, i) => ({
                 id: `image-${i}`,
                 caption: `Test Caption ${i}`,
-                cdnMediaURL: `https://cdn.chrisvogt.me/images/fake-instagram-image-${i}.jpg`,
+                cdnMediaURL: `https://cdn.example.com/images/fake-instagram-image-${i}.jpg`,
                 mediaType: 'IMAGE',
                 permalink: `https://instagram.com/p/test${i}`
               }))
@@ -204,7 +204,7 @@ describe('InstagramWidget', () => {
               media: Array.from({ length: 10 }, (_, i) => ({
                 id: `image-${i}`,
                 caption: `Test Caption ${i}`,
-                cdnMediaURL: `https://cdn.chrisvogt.me/images/fake-instagram-image-${i}.jpg`,
+                cdnMediaURL: `https://cdn.example.com/images/fake-instagram-image-${i}.jpg`,
                 mediaType: 'IMAGE',
                 permalink: `https://instagram.com/p/test${i}`
               }))
@@ -282,9 +282,9 @@ describe('InstagramWidget', () => {
                 {
                   id: 'video1',
                   caption: 'Video Caption',
-                  cdnMediaURL: 'https://cdn.chrisvogt.me/images/fake-video-thumbnail.jpg',
+                  cdnMediaURL: 'https://cdn.example.com/images/fake-video-thumbnail.jpg',
                   mediaType: 'VIDEO',
-                  mediaURL: 'https://cdn.chrisvogt.me/videos/fake-video.mp4',
+                  mediaURL: 'https://cdn.example.com/videos/fake-video.mp4',
                   permalink: 'https://instagram.com/p/video'
                 }
               ]

--- a/theme/src/components/widgets/recent-posts/__snapshots__/post-card.spec.js.snap
+++ b/theme/src/components/widgets/recent-posts/__snapshots__/post-card.spec.js.snap
@@ -17,7 +17,7 @@ exports[`PostCard does not render excerpt when explicitly null 1`] = `
         className="card-media"
       >
         <div
-          className="css-1hpd2dn"
+          className="css-1ywf2dg"
         />
       </div>
       <div
@@ -57,7 +57,7 @@ exports[`PostCard does not render excerpt when explicitly undefined 1`] = `
         className="card-media"
       >
         <div
-          className="css-1hpd2dn"
+          className="css-1ywf2dg"
         />
       </div>
       <div
@@ -97,7 +97,7 @@ exports[`PostCard matches the snapshot without excerpt 1`] = `
         className="card-media"
       >
         <div
-          className="css-1hpd2dn"
+          className="css-1ywf2dg"
         />
       </div>
       <div
@@ -137,7 +137,7 @@ exports[`PostCard renders excerpt when provided 1`] = `
         className="card-media"
       >
         <div
-          className="css-1hpd2dn"
+          className="css-1ywf2dg"
         />
       </div>
       <div
@@ -215,7 +215,7 @@ exports[`PostCard renders without category when not provided 1`] = `
         className="card-media"
       >
         <div
-          className="css-1hpd2dn"
+          className="css-1ywf2dg"
         />
       </div>
       <h3

--- a/theme/src/components/widgets/recent-posts/post-card.spec.js
+++ b/theme/src/components/widgets/recent-posts/post-card.spec.js
@@ -4,7 +4,7 @@ import PostCard from './post-card'
 
 describe('PostCard', () => {
   const baseProps = {
-    banner: 'https://cdn.chrisvogt.me/images/article-og-banner.jpg',
+    banner: 'https://cdn.example.com/images/article-og-banner.jpg',
     category: 'personal',
     date: '1592202624',
     link: '/blog/article',
@@ -56,7 +56,7 @@ describe('PostCard', () => {
 
   it('renders without category when not provided', () => {
     const propsWithoutCategory = {
-      banner: 'https://cdn.chrisvogt.me/images/article-og-banner.jpg',
+      banner: 'https://cdn.example.com/images/article-og-banner.jpg',
       date: '1592202624',
       link: '/blog/article',
       title: 'My Blog Post'

--- a/theme/src/components/widgets/spotify/spotify-widget.spec.js
+++ b/theme/src/components/widgets/spotify/spotify-widget.spec.js
@@ -10,7 +10,7 @@ const mockSiteMetadata = {
   widgets: {
     spotify: {
       username: 'mockusername',
-      widgetDataSource: 'https://fake-api.chrisvogt.me/social/spotify'
+      widgetDataSource: 'https://fake-api.example.com/social/spotify'
     }
   }
 }

--- a/theme/src/components/widgets/steam/steam-widget.spec.js
+++ b/theme/src/components/widgets/steam/steam-widget.spec.js
@@ -35,7 +35,7 @@ describe('SteamWidget', () => {
             metrics: [{ label: 'Games Played', value: 5 }],
             profile: {
               displayName: 'Chris',
-              profileURL: 'https://steamcommunity.com/id/chrisvogt'
+              profileURL: 'https://steamcommunity.com/id/themeuser'
             },
             collections: {
               recentlyPlayedGames: [

--- a/theme/src/selectors/metadata.spec.js
+++ b/theme/src/selectors/metadata.spec.js
@@ -31,19 +31,19 @@ const metadata = {
   titleTemplate: '%s | My Cool Website',
   widgets: {
     github: {
-      username: 'chrisvogt-theme',
-      widgetDataSource: 'https://metrics.chrisvogt.me/api/widget-content?widget=github'
+      username: 'themeuser',
+      widgetDataSource: 'https://api.example.com/api/widget-content?widget=github'
     },
     goodreads: {
-      username: 'chrisvogt-theme',
-      widgetDataSource: 'https://metrics.chrisvogt.me/api/widget-content?widget=goodreads'
+      username: 'themeuser',
+      widgetDataSource: 'https://api.example.com/api/widget-content?widget=goodreads'
     },
     instagram: {
-      username: 'chrisvogt-theme',
-      widgetDataSource: 'https://metrics.chrisvogt.me/api/widget-content?widget=instagram'
+      username: 'themeuser',
+      widgetDataSource: 'https://api.example.com/api/widget-content?widget=instagram'
     },
     spotify: {
-      widgetDataSource: 'https://metrics.chrisvogt.me/api/widget-content?widget=spotify'
+      widgetDataSource: 'https://api.example.com/api/widget-content?widget=spotify'
     }
   }
 }

--- a/theme/src/shortcodes/__snapshots__/youtube.spec.js.snap
+++ b/theme/src/shortcodes/__snapshots__/youtube.spec.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`YouTube Shortcode matches the snapshot 1`] = `
 <div
@@ -11,7 +11,7 @@ exports[`YouTube Shortcode matches the snapshot 1`] = `
     height="315"
     referrerpolicy="strict-origin-when-cross-origin"
     src="https://www.youtube-nocookie.com/embed/XJashBvI17A"
-    title="Here, There And Everywhere (Piano Cover) by Chris Vogt"
+    title="Here, There And Everywhere (Piano Cover) by Theme User"
     width="560"
   />
 </div>

--- a/theme/src/shortcodes/youtube.spec.js
+++ b/theme/src/shortcodes/youtube.spec.js
@@ -7,7 +7,7 @@ describe('YouTube Shortcode', () => {
     const tree = renderer
       .create(
         <YouTube
-          title='Here, There And Everywhere (Piano Cover) by Chris Vogt'
+          title='Here, There And Everywhere (Piano Cover) by Theme User'
           url='https://www.youtube-nocookie.com/embed/XJashBvI17A'
         />
       )

--- a/www.chronogrove.com/src/gatsby-theme-chronogrove/templates/home-head.spec.js
+++ b/www.chronogrove.com/src/gatsby-theme-chronogrove/templates/home-head.spec.js
@@ -63,7 +63,7 @@ describe('HomeHead (chronogrove.com shadow)', () => {
 
     expect(structuredData.author).toEqual({
       '@type': 'Person',
-      name: 'Chris Vogt'
+      name: 'Theme User'
     })
   })
 

--- a/www.chronogrove.com/src/pages/about.spec.js
+++ b/www.chronogrove.com/src/pages/about.spec.js
@@ -43,7 +43,7 @@ describe('AboutPage', () => {
   it('includes GitHub repository link', () => {
     renderWithTheme(<AboutPage />)
     const link = screen.getByRole('link', { name: /GitHub repository/i })
-    expect(link).toHaveAttribute('href', 'https://github.com/chrisvogt/gatsby-theme-chronogrove')
+    expect(link).toHaveAttribute('href', 'https://github.com/themeuser/gatsby-theme-chronogrove')
   })
 
   it('includes all key feature sections', () => {


### PR DESCRIPTION
## Overview

This PR closes #372 by removing all personal information from unit tests that aren't in the www.chrisvogt.me/ directory. API response fixtures are the exception, since they provide a real example of what the schema should look like.

## AI summary

This pull request focuses on updating external URLs across multiple components to replace references to personal domains with generic or example domains. Additionally, it includes minor improvements to snapshot testing documentation links. Below is a summary of the most important changes grouped by theme.

### URL Updates

* **Artwork Component**: Updated `thumbnailURL` in `theme/src/components/artwork/book.spec.js` and the snapshot reference for the book cover image in `book.spec.js.snap` to use `https://cdn.example.com` instead of `https://cdn.chrisvogt.me`. [[1]](diffhunk://#diff-827afd686a104cc008e7b5930b85fdfa21d290c34dae6ec161f35a63858cced4L6-R6) [[2]](diffhunk://#diff-d7c28b31e615424c948f3b70b050a2e5b37302ae3bdd10d8b3cc56035173c4a0L71-R71)
* **Flickr Widget**: Replaced `thumbnailUrl` and `largeUrl` references in multiple test cases and snapshots in `theme/src/components/widgets/flickr` to use `https://cdn.example.com`. [[1]](diffhunk://#diff-dc55cd42c3a2330f12e8e8111d7c55879e5203c85c3fa1c89168638a181a958eL15-R15) [[2]](diffhunk://#diff-7c2c881b27aa25d411a6afc15afd37752b573210663d1ab23fec8acb050f31acL62-R63) [[3]](diffhunk://#diff-7c2c881b27aa25d411a6afc15afd37752b573210663d1ab23fec8acb050f31acL126-R126) [[4]](diffhunk://#diff-7c2c881b27aa25d411a6afc15afd37752b573210663d1ab23fec8acb050f31acL273-R274) [[5]](diffhunk://#diff-7c2c881b27aa25d411a6afc15afd37752b573210663d1ab23fec8acb050f31acL320-R321) [[6]](diffhunk://#diff-0df2f941e8da6e96b8aca1395d76fae04bda72139407611becdfc1f9fa25422eL14-R14)
* **GitHub Widget**: Updated repository URLs and `widgetDataSource` references in `theme/src/components/widgets/github` to use `https://www.github.com/themeuser` and `https://fake-api.example.com`. [[1]](diffhunk://#diff-9b075e5d9b034d10c236a2308d745fde92da978f97e569add8a7d47288a65f52L62-R62) [[2]](diffhunk://#diff-ba6da1601b596b9137f5d029303a44544fdd7126450d050261ef955b8608a18dL124-R124) [[3]](diffhunk://#diff-d2cd1e983d1a8362e6e34d4a8beee681067175b0d609c0c84c2f2f76b154c844L13-R13) [[4]](diffhunk://#diff-7ce63a4ec516c84b40d8d4d63da55953622785fcb6f5a6100ab31f5ad1b72d50L19-R19) [[5]](diffhunk://#diff-3e7a212727ecbfa5d5c854f9ab52f779d337471601c358be434415b01c5607fcL16-R16) [[6]](diffhunk://#diff-1ef05a84f0eb0296e31915321fb69c58542091be9a70b18a0e355bb57317de2bL10-R10) [[7]](diffhunk://#diff-63e0138ab2f14c7f117b8b3e2c0b83a52dffd5862197f4ff6901039bae57abecL10-R10) [[8]](diffhunk://#diff-10212876e89fe303d44dbd20fadf550034ea89a51a68810df6a7acd17c67768cL11-R11)
* **Goodreads Widget**: Updated `cdnMediaURL` and `widgetDataSource` references in `theme/src/components/widgets/goodreads` to use `https://images.imgix.net` and `https://fake-api.example.com`. [[1]](diffhunk://#diff-488e04da62e3b99b50865f4248a7f0d213247c49712bb48223e8e50a7da5c919L37-R37) [[2]](diffhunk://#diff-488e04da62e3b99b50865f4248a7f0d213247c49712bb48223e8e50a7da5c919L64-R64) [[3]](diffhunk://#diff-aacf1c9f73184e76796c4a39356774657bc2c092ab80e425eff25af0a29bccf4L12-R13) [[4]](diffhunk://#diff-e830cb6ff7de8656f2a4ad41be719457c53cf1f64553dfa84dd4e5d619102b23L36-R40) [[5]](diffhunk://#diff-fd5a8ea162811c5009e523bbcf9248c05a61b4f29faa8a8b6a6f1f576c630052L14-R14) [[6]](diffhunk://#diff-58367cd3c4556ed027207dab4a18fbc878c85aa75cb29770f927c15584bf06d5L225-R230)
* **Instagram Widget**: Updated image source URLs in `theme/src/components/widgets/instagram/__snapshots__/instagram-widget-item.spec.js.snap` to use `https://cdn.example.com`.

### Snapshot Testing Documentation

* Updated snapshot testing documentation links from `https://goo.gl/fbAQLP` to `https://jestjs.io/docs/snapshot-testing` across multiple snapshot files. [[1]](diffhunk://#diff-d7c28b31e615424c948f3b70b050a2e5b37302ae3bdd10d8b3cc56035173c4a0L1-R1) [[2]](diffhunk://#diff-0df2f941e8da6e96b8aca1395d76fae04bda72139407611becdfc1f9fa25422eL1-R1) [[3]](diffhunk://#diff-9b075e5d9b034d10c236a2308d745fde92da978f97e569add8a7d47288a65f52L1-R1) [[4]](diffhunk://#diff-ba6da1601b596b9137f5d029303a44544fdd7126450d050261ef955b8608a18dL1-R1) [[5]](diffhunk://#diff-82a4ac43a94914d4981c6ec18e4bad38fccaec1a4b0b389ff33bdeb5a0ef1686L1-R1)

These changes ensure consistency in domain usage across the project and improve clarity in testing documentation.