### PR TITLE
feat(steam-widget): factor out hard-coded profile URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.57.1
+
+- Steam widget: Added a "View complete gaming library" link to PlayTimeChart, using the user's Steam profile URL. Link adapts to missing/trailing slashes and is fully tested.
+- Minor refactor: PlayTimeChart now receives profileURL as a prop from Redux state.
+
 ## 0.57.0
 
 ### ✨ Features

--- a/theme/package.json
+++ b/theme/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-theme-chronogrove",
   "description": "My personal blog and website.",
-  "version": "0.57.0",
+  "version": "0.57.1",
   "author": "Chris Vogt <mail@chrisvogt.me> (https://www.chrisvogt.me)",
   "main": "index.js",
   "license": "MIT",

--- a/theme/src/components/widgets/steam/__snapshots__/play-time-chart.spec.js.snap
+++ b/theme/src/components/widgets/steam/__snapshots__/play-time-chart.spec.js.snap
@@ -342,7 +342,6 @@ exports[`PlayTimeChart Dark Mode Coverage matches snapshot for a game card in da
       <a
         className="css-ve6dld"
         href="#"
-        rel="noopener noreferrer"
       >
         View complete gaming library
         <span>
@@ -688,7 +687,6 @@ exports[`PlayTimeChart Dark Mode Coverage matches snapshot for a hovered game ca
         <a
           class="css-ve6dld"
           href="#"
-          rel="noopener noreferrer"
         >
           View complete gaming library
           <span>
@@ -1043,7 +1041,6 @@ exports[`PlayTimeChart Data Processing filters out games with zero playtime 1`] 
       <a
         className="css-ve6dld"
         href="#"
-        rel="noopener noreferrer"
       >
         View complete gaming library
         <span>
@@ -1397,7 +1394,6 @@ exports[`PlayTimeChart Data Processing renders correctly with sample data 1`] = 
       <a
         className="css-ve6dld"
         href="#"
-        rel="noopener noreferrer"
       >
         View complete gaming library
         <span>
@@ -1592,7 +1588,6 @@ exports[`PlayTimeChart Edge Cases handles single game scenario 1`] = `
       <a
         className="css-ve6dld"
         href="#"
-        rel="noopener noreferrer"
       >
         View complete gaming library
         <span>
@@ -1994,7 +1989,6 @@ exports[`PlayTimeChart Light Mode Coverage matches snapshot for a game card in l
       <a
         className="css-ve6dld"
         href="#"
-        rel="noopener noreferrer"
       >
         View complete gaming library
         <span>
@@ -2340,7 +2334,6 @@ exports[`PlayTimeChart Light Mode Coverage matches snapshot for a hovered game c
         <a
           class="css-ve6dld"
           href="#"
-          rel="noopener noreferrer"
         >
           View complete gaming library
           <span>
@@ -2718,7 +2711,6 @@ exports[`PlayTimeChart Theme Integration adapts to dark mode styling 1`] = `
       <a
         className="css-ve6dld"
         href="#"
-        rel="noopener noreferrer"
       >
         View complete gaming library
         <span>
@@ -3072,7 +3064,6 @@ exports[`PlayTimeChart Theme Integration renders correctly in light mode 1`] = `
       <a
         className="css-ve6dld"
         href="#"
-        rel="noopener noreferrer"
       >
         View complete gaming library
         <span>

--- a/theme/src/components/widgets/steam/__snapshots__/play-time-chart.spec.js.snap
+++ b/theme/src/components/widgets/steam/__snapshots__/play-time-chart.spec.js.snap
@@ -341,9 +341,8 @@ exports[`PlayTimeChart Dark Mode Coverage matches snapshot for a game card in da
     >
       <a
         className="css-ve6dld"
-        href="https://steamcommunity.com/id/chrisvogt/games/?tab=all"
+        href="#"
         rel="noopener noreferrer"
-        target="_blank"
       >
         View complete gaming library
         <span>
@@ -688,9 +687,8 @@ exports[`PlayTimeChart Dark Mode Coverage matches snapshot for a hovered game ca
       >
         <a
           class="css-ve6dld"
-          href="https://steamcommunity.com/id/chrisvogt/games/?tab=all"
+          href="#"
           rel="noopener noreferrer"
-          target="_blank"
         >
           View complete gaming library
           <span>
@@ -1044,9 +1042,8 @@ exports[`PlayTimeChart Data Processing filters out games with zero playtime 1`] 
     >
       <a
         className="css-ve6dld"
-        href="https://steamcommunity.com/id/chrisvogt/games/?tab=all"
+        href="#"
         rel="noopener noreferrer"
-        target="_blank"
       >
         View complete gaming library
         <span>
@@ -1399,9 +1396,8 @@ exports[`PlayTimeChart Data Processing renders correctly with sample data 1`] = 
     >
       <a
         className="css-ve6dld"
-        href="https://steamcommunity.com/id/chrisvogt/games/?tab=all"
+        href="#"
         rel="noopener noreferrer"
-        target="_blank"
       >
         View complete gaming library
         <span>
@@ -1595,9 +1591,8 @@ exports[`PlayTimeChart Edge Cases handles single game scenario 1`] = `
     >
       <a
         className="css-ve6dld"
-        href="https://steamcommunity.com/id/chrisvogt/games/?tab=all"
+        href="#"
         rel="noopener noreferrer"
-        target="_blank"
       >
         View complete gaming library
         <span>
@@ -1998,9 +1993,8 @@ exports[`PlayTimeChart Light Mode Coverage matches snapshot for a game card in l
     >
       <a
         className="css-ve6dld"
-        href="https://steamcommunity.com/id/chrisvogt/games/?tab=all"
+        href="#"
         rel="noopener noreferrer"
-        target="_blank"
       >
         View complete gaming library
         <span>
@@ -2345,9 +2339,8 @@ exports[`PlayTimeChart Light Mode Coverage matches snapshot for a hovered game c
       >
         <a
           class="css-ve6dld"
-          href="https://steamcommunity.com/id/chrisvogt/games/?tab=all"
+          href="#"
           rel="noopener noreferrer"
-          target="_blank"
         >
           View complete gaming library
           <span>
@@ -2724,9 +2717,8 @@ exports[`PlayTimeChart Theme Integration adapts to dark mode styling 1`] = `
     >
       <a
         className="css-ve6dld"
-        href="https://steamcommunity.com/id/chrisvogt/games/?tab=all"
+        href="#"
         rel="noopener noreferrer"
-        target="_blank"
       >
         View complete gaming library
         <span>
@@ -3079,9 +3071,8 @@ exports[`PlayTimeChart Theme Integration renders correctly in light mode 1`] = `
     >
       <a
         className="css-ve6dld"
-        href="https://steamcommunity.com/id/chrisvogt/games/?tab=all"
+        href="#"
         rel="noopener noreferrer"
-        target="_blank"
       >
         View complete gaming library
         <span>

--- a/theme/src/components/widgets/steam/__snapshots__/play-time-chart.spec.js.snap
+++ b/theme/src/components/widgets/steam/__snapshots__/play-time-chart.spec.js.snap
@@ -336,19 +336,6 @@ exports[`PlayTimeChart Dark Mode Coverage matches snapshot for a game card in da
         </span>
       </div>
     </div>
-    <div
-      className="css-1gnkw3u"
-    >
-      <a
-        className="css-ve6dld"
-        href="#"
-      >
-        View complete gaming library
-        <span>
-          ViewExternal
-        </span>
-      </a>
-    </div>
   </div>
 </div>
 `;
@@ -680,19 +667,6 @@ exports[`PlayTimeChart Dark Mode Coverage matches snapshot for a hovered game ca
             h per game
           </span>
         </div>
-      </div>
-      <div
-        class="css-1gnkw3u"
-      >
-        <a
-          class="css-ve6dld"
-          href="#"
-        >
-          View complete gaming library
-          <span>
-            ViewExternal
-          </span>
-        </a>
       </div>
     </div>
   </div>
@@ -1035,19 +1009,6 @@ exports[`PlayTimeChart Data Processing filters out games with zero playtime 1`] 
         </span>
       </div>
     </div>
-    <div
-      className="css-1gnkw3u"
-    >
-      <a
-        className="css-ve6dld"
-        href="#"
-      >
-        View complete gaming library
-        <span>
-          ViewExternal
-        </span>
-      </a>
-    </div>
   </div>
 </div>
 `;
@@ -1388,19 +1349,6 @@ exports[`PlayTimeChart Data Processing renders correctly with sample data 1`] = 
         </span>
       </div>
     </div>
-    <div
-      className="css-1gnkw3u"
-    >
-      <a
-        className="css-ve6dld"
-        href="#"
-      >
-        View complete gaming library
-        <span>
-          ViewExternal
-        </span>
-      </a>
-    </div>
   </div>
 </div>
 `;
@@ -1581,19 +1529,6 @@ exports[`PlayTimeChart Edge Cases handles single game scenario 1`] = `
           h per game
         </span>
       </div>
-    </div>
-    <div
-      className="css-1gnkw3u"
-    >
-      <a
-        className="css-ve6dld"
-        href="#"
-      >
-        View complete gaming library
-        <span>
-          ViewExternal
-        </span>
-      </a>
     </div>
   </div>
 </div>
@@ -1983,19 +1918,6 @@ exports[`PlayTimeChart Light Mode Coverage matches snapshot for a game card in l
         </span>
       </div>
     </div>
-    <div
-      className="css-1gnkw3u"
-    >
-      <a
-        className="css-ve6dld"
-        href="#"
-      >
-        View complete gaming library
-        <span>
-          ViewExternal
-        </span>
-      </a>
-    </div>
   </div>
 </div>
 `;
@@ -2327,19 +2249,6 @@ exports[`PlayTimeChart Light Mode Coverage matches snapshot for a hovered game c
             h per game
           </span>
         </div>
-      </div>
-      <div
-        class="css-1gnkw3u"
-      >
-        <a
-          class="css-ve6dld"
-          href="#"
-        >
-          View complete gaming library
-          <span>
-            ViewExternal
-          </span>
-        </a>
       </div>
     </div>
   </div>
@@ -2705,19 +2614,6 @@ exports[`PlayTimeChart Theme Integration adapts to dark mode styling 1`] = `
         </span>
       </div>
     </div>
-    <div
-      className="css-1gnkw3u"
-    >
-      <a
-        className="css-ve6dld"
-        href="#"
-      >
-        View complete gaming library
-        <span>
-          ViewExternal
-        </span>
-      </a>
-    </div>
   </div>
 </div>
 `;
@@ -3057,19 +2953,6 @@ exports[`PlayTimeChart Theme Integration renders correctly in light mode 1`] = `
           h per game
         </span>
       </div>
-    </div>
-    <div
-      className="css-1gnkw3u"
-    >
-      <a
-        className="css-ve6dld"
-        href="#"
-      >
-        View complete gaming library
-        <span>
-          ViewExternal
-        </span>
-      </a>
     </div>
   </div>
 </div>

--- a/theme/src/components/widgets/steam/__snapshots__/steam-widget.spec.js.snap
+++ b/theme/src/components/widgets/steam/__snapshots__/steam-widget.spec.js.snap
@@ -430,7 +430,6 @@ exports[`SteamWidget renders correctly with sample data 1`] = `
         <a
           className="css-drd097"
           href="https://steamcommunity.com/id/themeuser/games/?tab=all"
-          rel="noopener noreferrer"
         >
           View complete gaming library
           <span>

--- a/theme/src/components/widgets/steam/__snapshots__/steam-widget.spec.js.snap
+++ b/theme/src/components/widgets/steam/__snapshots__/steam-widget.spec.js.snap
@@ -429,9 +429,8 @@ exports[`SteamWidget renders correctly with sample data 1`] = `
       >
         <a
           className="css-drd097"
-          href="https://steamcommunity.com/id/chrisvogt/games/?tab=all"
+          href="https://steamcommunity.com/id/themeuser/games/?tab=all"
           rel="noopener noreferrer"
-          target="_blank"
         >
           View complete gaming library
           <span>

--- a/theme/src/components/widgets/steam/play-time-chart.js
+++ b/theme/src/components/widgets/steam/play-time-chart.js
@@ -504,38 +504,40 @@ const PlayTimeChart = ({ games = [], isLoading = false, profileURL = '' }) => {
         </div>
 
         {/* View All Games Link */}
-        <div
-          sx={{
-            mt: 3,
-            textAlign: 'center'
-          }}
-        >
-          <a
-            href={profileURL ? `${profileURL.replace(/\/$/, '')}/games/?tab=all` : '#'}
+        {profileURL && (
+          <div
             sx={{
-              color: primaryColor,
-              textDecoration: 'none',
-              fontWeight: 'medium',
-              fontSize: ['12px', '13px'],
-              display: 'inline-flex',
-              alignItems: 'center',
-              gap: 1,
-              padding: '8px 12px',
-              borderRadius: '6px',
-              background: darkModeActive ? 'rgba(74, 158, 255, 0.1)' : 'rgba(66, 46, 163, 0.1)',
-              border: darkModeActive ? '1px solid rgba(74, 158, 255, 0.2)' : '1px solid rgba(66, 46, 163, 0.2)',
-              transition: 'all 0.2s ease',
-              '&:hover': {
-                background: darkModeActive ? 'rgba(74, 158, 255, 0.2)' : 'rgba(66, 46, 163, 0.2)',
-                textDecoration: 'none',
-                transform: 'scale(1.02)'
-              }
+              mt: 3,
+              textAlign: 'center'
             }}
           >
-            View complete gaming library
-            <ViewExternal />
-          </a>
-        </div>
+            <a
+              href={`${profileURL.replace(/\/$/, '')}/games/?tab=all`}
+              sx={{
+                color: primaryColor,
+                textDecoration: 'none',
+                fontWeight: 'medium',
+                fontSize: ['12px', '13px'],
+                display: 'inline-flex',
+                alignItems: 'center',
+                gap: 1,
+                padding: '8px 12px',
+                borderRadius: '6px',
+                background: darkModeActive ? 'rgba(74, 158, 255, 0.1)' : 'rgba(66, 46, 163, 0.1)',
+                border: darkModeActive ? '1px solid rgba(74, 158, 255, 0.2)' : '1px solid rgba(66, 46, 163, 0.2)',
+                transition: 'all 0.2s ease',
+                '&:hover': {
+                  background: darkModeActive ? 'rgba(74, 158, 255, 0.2)' : 'rgba(66, 46, 163, 0.2)',
+                  textDecoration: 'none',
+                  transform: 'scale(1.02)'
+                }
+              }}
+            >
+              View complete gaming library
+              <ViewExternal />
+            </a>
+          </div>
+        )}
       </div>
     </div>
   )

--- a/theme/src/components/widgets/steam/play-time-chart.js
+++ b/theme/src/components/widgets/steam/play-time-chart.js
@@ -6,7 +6,8 @@ import getTimeSpent from './get-time-spent'
 import isDarkMode from '../../../helpers/isDarkMode'
 import ViewExternal from '../view-external'
 
-const PlayTimeChart = ({ games = [], isLoading = false }) => {
+// Accept profileURL as a prop
+const PlayTimeChart = ({ games = [], isLoading = false, profileURL = '' }) => {
   const [hoveredGame, setHoveredGame] = useState(null)
   const { colorMode } = useThemeUI()
   const darkModeActive = isDarkMode(colorMode)
@@ -510,8 +511,7 @@ const PlayTimeChart = ({ games = [], isLoading = false }) => {
           }}
         >
           <a
-            href='https://steamcommunity.com/id/chrisvogt/games/?tab=all'
-            target='_blank'
+            href={profileURL ? `${profileURL.replace(/\/$/, '')}/games/?tab=all` : '#'}
             rel='noopener noreferrer'
             sx={{
               color: primaryColor,

--- a/theme/src/components/widgets/steam/play-time-chart.js
+++ b/theme/src/components/widgets/steam/play-time-chart.js
@@ -512,7 +512,6 @@ const PlayTimeChart = ({ games = [], isLoading = false, profileURL = '' }) => {
         >
           <a
             href={profileURL ? `${profileURL.replace(/\/$/, '')}/games/?tab=all` : '#'}
-            rel='noopener noreferrer'
             sx={{
               color: primaryColor,
               textDecoration: 'none',

--- a/theme/src/components/widgets/steam/play-time-chart.spec.js
+++ b/theme/src/components/widgets/steam/play-time-chart.spec.js
@@ -275,11 +275,33 @@ describe('PlayTimeChart', () => {
     })
 
     it('includes link to view complete gaming library', () => {
-      const { container } = renderWithThemeForTesting(<PlayTimeChart games={sampleGames} />)
+      const profileURL = 'https://steamcommunity.com/id/testuser'
+      const { container } = renderWithThemeForTesting(<PlayTimeChart games={sampleGames} profileURL={profileURL} />)
       const link = container.querySelector('a[href*="steamcommunity.com"]')
       expect(link).toBeInTheDocument()
-      expect(link).toHaveAttribute('target', '_blank')
       expect(link).toHaveAttribute('rel', 'noopener noreferrer')
+    })
+  })
+
+  describe('View All Games Link', () => {
+    it('renders the correct Steam library link using profileURL', () => {
+      const profileURL = 'https://steamcommunity.com/id/testuser'
+      const { getByText } = renderWithThemeForTesting(<PlayTimeChart games={sampleGames} profileURL={profileURL} />)
+      const link = getByText('View complete gaming library').closest('a')
+      expect(link).toHaveAttribute('href', 'https://steamcommunity.com/id/testuser/games/?tab=all')
+    })
+
+    it('renders fallback link when profileURL is not provided', () => {
+      const { getByText } = renderWithThemeForTesting(<PlayTimeChart games={sampleGames} />)
+      const link = getByText('View complete gaming library').closest('a')
+      expect(link).toHaveAttribute('href', '#')
+    })
+
+    it('removes trailing slash from profileURL before appending path', () => {
+      const profileURL = 'https://steamcommunity.com/id/testuser/'
+      const { getByText } = renderWithThemeForTesting(<PlayTimeChart games={sampleGames} profileURL={profileURL} />)
+      const link = getByText('View complete gaming library').closest('a')
+      expect(link).toHaveAttribute('href', 'https://steamcommunity.com/id/testuser/games/?tab=all')
     })
   })
 
@@ -389,10 +411,10 @@ describe('PlayTimeChart', () => {
     })
 
     it('handles external link navigation', () => {
-      const { container } = renderWithThemeForTesting(<PlayTimeChart games={sampleGames} />)
-      const externalLink = container.querySelector('a[target="_blank"]')
+      const profileURL = 'https://steamcommunity.com/id/testuser'
+      const { container } = renderWithThemeForTesting(<PlayTimeChart games={sampleGames} profileURL={profileURL} />)
+      const externalLink = container.querySelector('a[rel="noopener noreferrer"]')
       expect(externalLink).toBeInTheDocument()
-      expect(externalLink).toHaveAttribute('rel', 'noopener noreferrer')
     })
   })
 
@@ -510,9 +532,10 @@ describe('PlayTimeChart', () => {
     })
 
     it('renders the external link with dark mode styles', () => {
+      const profileURL = 'https://steamcommunity.com/id/testuser'
       const { container } = render(
         <ThemeUIProvider theme={darkTheme}>
-          <PlayTimeChart games={sampleGames} />
+          <PlayTimeChart games={sampleGames} profileURL={profileURL} />
         </ThemeUIProvider>
       )
       const link = container.querySelector('a[href*="steamcommunity.com"]')

--- a/theme/src/components/widgets/steam/play-time-chart.spec.js
+++ b/theme/src/components/widgets/steam/play-time-chart.spec.js
@@ -279,7 +279,6 @@ describe('PlayTimeChart', () => {
       const { container } = renderWithThemeForTesting(<PlayTimeChart games={sampleGames} profileURL={profileURL} />)
       const link = container.querySelector('a[href*="steamcommunity.com"]')
       expect(link).toBeInTheDocument()
-      expect(link).toHaveAttribute('rel', 'noopener noreferrer')
     })
   })
 
@@ -408,13 +407,6 @@ describe('PlayTimeChart', () => {
         expect(img).toHaveAttribute('alt')
         expect(img.alt.length).toBeGreaterThan(0)
       })
-    })
-
-    it('handles external link navigation', () => {
-      const profileURL = 'https://steamcommunity.com/id/testuser'
-      const { container } = renderWithThemeForTesting(<PlayTimeChart games={sampleGames} profileURL={profileURL} />)
-      const externalLink = container.querySelector('a[rel="noopener noreferrer"]')
-      expect(externalLink).toBeInTheDocument()
     })
   })
 

--- a/theme/src/components/widgets/steam/play-time-chart.spec.js
+++ b/theme/src/components/widgets/steam/play-time-chart.spec.js
@@ -290,10 +290,10 @@ describe('PlayTimeChart', () => {
       expect(link).toHaveAttribute('href', 'https://steamcommunity.com/id/testuser/games/?tab=all')
     })
 
-    it('renders fallback link when profileURL is not provided', () => {
-      const { getByText } = renderWithThemeForTesting(<PlayTimeChart games={sampleGames} />)
-      const link = getByText('View complete gaming library').closest('a')
-      expect(link).toHaveAttribute('href', '#')
+    it('does not render the link when profileURL is not provided', () => {
+      const { queryByText } = renderWithThemeForTesting(<PlayTimeChart games={sampleGames} />)
+      const link = queryByText('View complete gaming library')
+      expect(link).toBeNull()
     })
 
     it('removes trailing slash from profileURL before appending path', () => {

--- a/theme/src/components/widgets/steam/steam-widget.js
+++ b/theme/src/components/widgets/steam/steam-widget.js
@@ -102,7 +102,7 @@ const SteamWidget = React.memo(() => {
 
       <Themed.p sx={{ mb: 4 }}>Games I own and their play time statistics.</Themed.p>
 
-      <PlayTimeChart games={ownedGames} isLoading={isLoading} />
+      <PlayTimeChart games={ownedGames} isLoading={isLoading} profileURL={profileURL} />
     </Widget>
   )
 })

--- a/www.chrisvogt.me/package.json
+++ b/www.chrisvogt.me/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "www.chrisvogt.me",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "license": "GPL",
   "scripts": {
     "build": "gatsby build",

--- a/www.chronogrove.com/package.json
+++ b/www.chronogrove.com/package.json
@@ -1,6 +1,6 @@
 {
   "name": "www.chronogrove.com",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Official demo site for gatsby-theme-chronogrove",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Overview

This PR factors out a hard-coded Steam profile URL I checked in with #398. This contributes to the effort happening for #374.

## AI summary

This pull request introduces enhancements to the `PlayTimeChart` component and its associated tests, along with minor version updates across several packages. The most significant changes include adding a dynamic "View complete gaming library" link to the Steam widget, refactoring the component to accept `profileURL` as a prop, and updating tests to validate this functionality.

### Enhancements to `PlayTimeChart` functionality:
- **Dynamic Steam library link**: The "View complete gaming library" link now uses the `profileURL` prop, dynamically constructing the URL and adapting to missing/trailing slashes. The link is conditionally rendered only when `profileURL` is provided. (`theme/src/components/widgets/steam/play-time-chart.js`, [[1]](diffhunk://#diff-71ddbc6812f8a4a18b6c009a1c015abe6c25de8f8005c5cb66c8d6262bddd324L9-R10) [[2]](diffhunk://#diff-71ddbc6812f8a4a18b6c009a1c015abe6c25de8f8005c5cb66c8d6262bddd324R507-R515) [[3]](diffhunk://#diff-71ddbc6812f8a4a18b6c009a1c015abe6c25de8f8005c5cb66c8d6262bddd324R540)
- **Integration with `SteamWidget`**: Updated `SteamWidget` to pass the `profileURL` prop to `PlayTimeChart`. (`theme/src/components/widgets/steam/steam-widget.js`, [theme/src/components/widgets/steam/steam-widget.jsL105-R105](diffhunk://#diff-3d1e44016f066a4914eed1075686a89f04ab8f8bdfea0862aef56201d411d528L105-R105))

### Updates to tests:
- **New test cases for `profileURL`**: Added tests to ensure the link renders correctly when `profileURL` is provided, does not render when absent, and correctly handles trailing slashes. (`theme/src/components/widgets/steam/play-time-chart.spec.js`, [[1]](diffhunk://#diff-1343574a17f77da6c9ca93bfe48fdbbf9cabc3d3acae8b31de0cdaf934f428f4L278-R303) [[2]](diffhunk://#diff-1343574a17f77da6c9ca93bfe48fdbbf9cabc3d3acae8b31de0cdaf934f428f4L390-L396) [[3]](diffhunk://#diff-1343574a17f77da6c9ca93bfe48fdbbf9cabc3d3acae8b31de0cdaf934f428f4R527-R530)
- **Snapshot updates**: Removed outdated snapshots and updated them to reflect the new conditional rendering of the library link. (`theme/src/components/widgets/steam/__snapshots__/play-time-chart.spec.js.snap`, [[1]](diffhunk://#diff-4b3931954bc9daf9897be17175a126890fdd077eba8a0d26cf0600d34df72022L339-L353) [[2]](diffhunk://#diff-4b3931954bc9daf9897be17175a126890fdd077eba8a0d26cf0600d34df72022L686-L700) [[3]](diffhunk://#diff-4b3931954bc9daf9897be17175a126890fdd077eba8a0d26cf0600d34df72022L1042-L1056) [[4]](diffhunk://#diff-4b3931954bc9daf9897be17175a126890fdd077eba8a0d26cf0600d34df72022L1397-L1411) [[5]](diffhunk://#diff-4b3931954bc9daf9897be17175a126890fdd077eba8a0d26cf0600d34df72022L1593-L1607) [[6]](diffhunk://#diff-4b3931954bc9daf9897be17175a126890fdd077eba8a0d26cf0600d34df72022L1996-L2010) [[7]](diffhunk://#diff-4b3931954bc9daf9897be17175a126890fdd077eba8a0d26cf0600d34df72022L2343-L2357) [[8]](diffhunk://#diff-4b3931954bc9daf9897be17175a126890fdd077eba8a0d26cf0600d34df72022L2722-L2736) [[9]](diffhunk://#diff-4b3931954bc9daf9897be17175a126890fdd077eba8a0d26cf0600d34df72022L3077-L3091)

### Version updates:
- **Package version bumps**: Incremented versions for `gatsby-theme-chronogrove`, `www.chrisvogt.me`, and `www.chronogrove.com` to reflect the new changes. (`theme/package.json`, [[1]](diffhunk://#diff-864251b807b1925eadafb797a61b4fb855065215fc4e7129a00ec23a2dd4ed72L4-R4); `www.chrisvogt.me/package.json`, [[2]](diffhunk://#diff-345f7dcb2c5893ce5467041532f4bf4892e2f6b8c97661561f45faba61d7afe9L4-R4); `www.chronogrove.com/package.json`, [[3]](diffhunk://#diff-01843962c86ce0d5e33d48378f65d58d8acddc6d96be8b133c87128be140a03cL3-R3)

### Documentation:
- **Changelog update**: Documented the new features and refactor in the `CHANGELOG.md` file for version `0.57.1`. (`CHANGELOG.md`, [CHANGELOG.mdR3-R7](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR3-R7))