### PR TITLE
content(/now): add July 2025 journal entry

### DIFF
--- a/www.chrisvogt.me/content/blog/2025-06-30-june-2025-recap/2025-06-30-june-2025-recap.mdx
+++ b/www.chrisvogt.me/content/blog/2025-06-30-june-2025-recap/2025-06-30-june-2025-recap.mdx
@@ -1,6 +1,7 @@
 ---
-title: 'Now — June 2025 Recap'
-slug: now
+title: 'June 2025 Recap'
+category: personal
+slug: june-2025
 banner: https://res.cloudinary.com/chrisvogt/image/upload/f_auto/v1751343485/chrisvogt-me/thumbnails/now-page.webp
 date: '2025-06-30T14:00:00.000Z'
 description: >

--- a/www.chrisvogt.me/content/blog/2025-06-30-june-2025-recap/2025-06-30-june-2025-recap.mdx
+++ b/www.chrisvogt.me/content/blog/2025-06-30-june-2025-recap/2025-06-30-june-2025-recap.mdx
@@ -2,7 +2,7 @@
 title: 'June 2025 Recap'
 category: personal
 slug: june-2025
-banner: https://res.cloudinary.com/chrisvogt/image/upload/f_auto/v1751343485/chrisvogt-me/thumbnails/now-page.webp
+banner: https://res.cloudinary.com/chrisvogt/image/upload/v1754292181/chrisvogt-me/thumbnails/june-2025-banner.webp
 date: '2025-06-30T14:00:00.000Z'
 description: >
   A personal recap of what I've been working on, exploring, and thinking about in June 2025.

--- a/www.chrisvogt.me/content/blog/2025-07-31-july-2025-recap/2025-07-31-july-2025-recap.mdx
+++ b/www.chrisvogt.me/content/blog/2025-07-31-july-2025-recap/2025-07-31-july-2025-recap.mdx
@@ -1,0 +1,63 @@
+---
+title: 'Now — July 2025 Recap'
+slug: now
+banner: https://res.cloudinary.com/chrisvogt/image/upload/f_auto/v1751343485/chrisvogt-me/thumbnails/now-page.webp
+date: '2025-08-03T20:00:00.000Z'
+description: >
+  A personal recap of what I've been working on, exploring, and thinking about in July 2025.
+excerpt: >
+  A roundup of July 2025. Projects, travel, thoughts, and things in between.
+keywords: [july 2025, personal blog, monthly recap, chris vogt, software projects, music practice, travel highlights]
+---
+
+import { PhotoGallery } from '../../../components/PhotoGallery'
+import { pvrFlight, pvrHotel, pvrZonaRomantica, vinylCollection } from './photos'
+
+This is my second monthly recap, a monthly writing ritual I started June 2025 where I recap the month work in a topic-organized journal entry. When these articles are published, they can be accessed on my [Now](/now) page. When the next recap publishes, I move the previous post into the blog to archive it.
+
+## 🎯 July Overview
+
+July started out with a short trip to Puerto Vallarta, Mexico over the 4th of July weekend. I've also been adding new features to my personal website, practicing new songs on the piano, collecting LPs on vinyl, and practicing new songs. At the end of the month, I worked out of Tempe, Arizona for a week, where I stopped by to visit my parents, who live in Arizona. I'll cover that all and more in this article.
+
+## Updates to My Website
+
+I added a few new features to my personal website this month: a new UI for my Steam game play widget and a Discogs widget, both on the [Home](/) page, and an interactive career visualization on my [About](/about) page.
+
+I've also been working to make the theme for my site reusable, so others can use it for their own sites.
+
+## What I'm Working On At Work
+
+Continuing with the theme of last month, AI is still a big focus at work. Both as a product feature and as a way to improve productivity and the quality of our code.
+
+## 🌴 Puerto Vallarta, Mexico
+
+In 2021 I met Francis while docked in Curaçao on a Celebrity Cruise ship. We've kept in touch over the years and met up last year in NYC. A couple months before July he invited me to join him and a friend for their first visit to Puerto Vallarta.
+
+I already had 2 days off work for the 4th of July holiday, and learned a friend and former coworker was also going to be in town with his partner, and so I took an extra day off work and flew down for a Wednesday-Sunday trip.
+
+My United flight from SFO to PVR was fast—only 3 hours, 45 minutes. I recommend sitting on the left side of the plane for the best views, because you'll face inland and see the mountains.
+
+<PhotoGallery photos={pvrFlight} />
+
+I stayed at an LGBTQ resort in Amapas, a neighborhood (colonia) just south of the Romantic Zone (Zona Romántica) and Playa de los Muertos. It's a 10-minute walk to the beach and slightly uphill, making it a good spot to look out over the bay and stay a close walk to the action while having a quiet, private space to relax.
+
+<PhotoGallery photos={pvrHotel} />
+
+Here are a few of the photos I took around the area while I was there.
+
+<PhotoGallery photos={pvrZonaRomantica} />
+
+## Collecting Vinyls
+
+Vinyl has taken over my friend group — my friends are constantly talking about new records they're litening to, and I've caught the bug too. I've built up a collection of 37 LPs so far and finally bought a record player, an [AT-LP120XBT-USB-BK](https://www.audio-technica.com/en-us/at-lp120xbt-usb).
+
+I've been using [Discogs](https://www.discogs.com/) to track my collection, which is now rendered on a new widget on the Home page. It uses the Discogs API to fetch and render an up-to-date list of my LPs.
+
+<PhotoGallery photos={vinylCollection} />
+
+## What I'm reading
+
+At the beginning of the month I finished _Flowers for Algernon_ by Daniel Keyes. I maintain a list of books that have been recommended by friends when asked for recommendations on what books left a profound impact and stuck with them over the years. My partner recommend this one, and said for them it was a required high school reading assignment.
+
+In Mexico, someone had left a few copies of _Finding My Humanity: I Am Because You Are_ by Ryan Ubuntu Wilson in my hotel room. I took home one of those copies and am now nearly finished reading Ryan's memoir, sharing story as a gay man coming of age in a rural, conservative commmunity in Colorado, and later a private Jesuit institution in Spokane, Washington.
+

--- a/www.chrisvogt.me/content/blog/2025-07-31-july-2025-recap/2025-07-31-july-2025-recap.mdx
+++ b/www.chrisvogt.me/content/blog/2025-07-31-july-2025-recap/2025-07-31-july-2025-recap.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Now — July 2025 Recap'
 slug: now
-banner: https://res.cloudinary.com/chrisvogt/image/upload/f_auto/v1751343485/chrisvogt-me/thumbnails/now-page.webp
+banner: https://res.cloudinary.com/chrisvogt/image/upload/v1754293496/chrisvogt-me/thumbnails/june-2025-banner.webp
 date: '2025-08-03T20:00:00.000Z'
 description: >
   A personal recap of what I've been working on, exploring, and thinking about in July 2025.

--- a/www.chrisvogt.me/content/blog/2025-07-31-july-2025-recap/2025-07-31-july-2025-recap.mdx
+++ b/www.chrisvogt.me/content/blog/2025-07-31-july-2025-recap/2025-07-31-july-2025-recap.mdx
@@ -19,13 +19,13 @@ This is my second monthly recap, a monthly writing ritual I started June 2025 wh
 
 July started out with a short trip to Puerto Vallarta, Mexico over the 4th of July weekend. I've also been adding new features to my personal website, practicing new songs on the piano, collecting LPs on vinyl, and practicing new songs. At the end of the month, I worked out of Tempe, Arizona for a week, where I stopped by to visit my parents, who live in Arizona. I'll cover that all and more in this article.
 
-## Updates to My Website
+## ✨ Updates to My Website
 
 I added a few new features to my personal website this month: a new UI for my Steam game play widget and a Discogs widget, both on the [Home](/) page, and an interactive career visualization on my [About](/about) page.
 
 I've also been working to make the theme for my site reusable, so others can use it for their own sites.
 
-## What I'm Working On At Work
+## 💼 What I'm Working On at Work
 
 Continuing with the theme of last month, AI is still a big focus at work. Both as a product feature and as a way to improve productivity and the quality of our code.
 
@@ -47,7 +47,7 @@ Here are a few of the photos I took around the area while I was there.
 
 <PhotoGallery photos={pvrZonaRomantica} />
 
-## Collecting Vinyls
+## 🎵 Collecting Vinyl
 
 Vinyl has taken over my friend group — my friends are constantly talking about new records they're litening to, and I've caught the bug too. I've built up a collection of 37 LPs so far and finally bought a record player, an [AT-LP120XBT-USB-BK](https://www.audio-technica.com/en-us/at-lp120xbt-usb).
 
@@ -55,9 +55,8 @@ I've been using [Discogs](https://www.discogs.com/) to track my collection, whic
 
 <PhotoGallery photos={vinylCollection} />
 
-## What I'm reading
+## 📚 What I'm Reading
 
 At the beginning of the month I finished _Flowers for Algernon_ by Daniel Keyes. I maintain a list of books that have been recommended by friends when asked for recommendations on what books left a profound impact and stuck with them over the years. My partner recommend this one, and said for them it was a required high school reading assignment.
 
 In Mexico, someone had left a few copies of _Finding My Humanity: I Am Because You Are_ by Ryan Ubuntu Wilson in my hotel room. I took home one of those copies and am now nearly finished reading Ryan's memoir, sharing story as a gay man coming of age in a rural, conservative commmunity in Colorado, and later a private Jesuit institution in Spokane, Washington.
-

--- a/www.chrisvogt.me/content/blog/2025-07-31-july-2025-recap/2025-07-31-july-2025-recap.mdx
+++ b/www.chrisvogt.me/content/blog/2025-07-31-july-2025-recap/2025-07-31-july-2025-recap.mdx
@@ -15,10 +15,6 @@ import { pvrFlight, pvrHotel, pvrZonaRomantica, vinylCollection } from './photos
 
 This is my second monthly recap, a monthly writing ritual I started June 2025 where I recap the month work in a topic-organized journal entry. When these articles are published, they can be accessed on my [Now](/now) page. When the next recap publishes, I move the previous post into the blog to archive it.
 
-## 🎯 July Overview
-
-July started out with a short trip to Puerto Vallarta, Mexico over the 4th of July weekend. I've also been adding new features to my personal website, practicing new songs on the piano, collecting LPs on vinyl, and practicing new songs. At the end of the month, I worked out of Tempe, Arizona for a week, where I stopped by to visit my parents, who live in Arizona. I'll cover that all and more in this article.
-
 ## ✨ Updates to My Website
 
 I added a few new features to my personal website this month: a new UI for my Steam game play widget and a Discogs widget, both on the [Home](/) page, and an interactive career visualization on my [About](/about) page.

--- a/www.chrisvogt.me/content/blog/2025-07-31-july-2025-recap/photos.js
+++ b/www.chrisvogt.me/content/blog/2025-07-31-july-2025-recap/photos.js
@@ -1,0 +1,173 @@
+export const pvrFlight = [
+  {
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1754281174/chrisvogt-me/galleries/now-july-2025/IMG_4966.jpg',
+    title: 'N17233 — United 737-800 — at SFO',
+    width: 3,
+    height: 4
+  },
+  {
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1754281174/chrisvogt-me/galleries/now-july-2025/IMG_4969.jpg',
+    title: 'Flight Screenshot—SFO to PVR',
+    width: 23,
+    height: 50
+  },
+  {
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1754281175/chrisvogt-me/galleries/now-july-2025/IMG_4974.jpg',
+    title: 'Nick looking out the window as we fly over mountains in Mexico',
+    width: 3,
+    height: 4
+  },
+  {
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1754281176/chrisvogt-me/galleries/now-july-2025/IMG_4990.jpg',
+    title: 'Talpa de Allende, a Pueblo Mágico en Mexico',
+    width: 3,
+    height: 4
+  },
+  {
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1754281175/chrisvogt-me/galleries/now-july-2025/IMG_4982.jpg',
+    title: 'Flying over Talpa de Allende, Jalisco, Mexico',
+    width: 3,
+    height: 4
+  }
+]
+
+export const pvrHotel = [
+  {
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1754281177/chrisvogt-me/galleries/now-july-2025/IMG_4998.jpg',
+    title: 'Our 1bd/2ba hotel room was bigger than my last apartment in SF',
+    width: 4,
+    height: 3
+  },
+  {
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1754281177/chrisvogt-me/galleries/now-july-2025/IMG_5004.jpg',
+    title: 'The hotel bedroom with views of the ocean',
+    width: 4,
+    height: 3
+  },
+  {
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1754281178/chrisvogt-me/galleries/now-july-2025/IMG_5003.jpg',
+    title: "The most unique shower I've ever seen for a hotel room",
+    width: 3,
+    height: 4
+  },
+  {
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1754281178/chrisvogt-me/galleries/now-july-2025/IMG_5013.jpg',
+    title: 'The hotel room had a wraparound balcony overlooking the ocean',
+    width: 4,
+    height: 3
+  },
+  {
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1754281174/chrisvogt-me/galleries/now-july-2025/IMG_5006.jpg',
+    title: 'The private balcony at our hotel room had a hot tub and a view of the ocean',
+    width: 4,
+    height: 3
+  },
+  {
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1754281180/chrisvogt-me/galleries/now-july-2025/IMG_5017.jpg',
+    title: "Bahía de Banderas—the bay from the hotel room's balcony",
+    width: 4,
+    height: 3
+  },
+  {
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1754281187/chrisvogt-me/galleries/now-july-2025/IMG_5090.jpg',
+    title: 'Looking out at Bahía de Banderas from the hotel',
+    width: 3,
+    height: 4
+  },
+  {
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1754281188/chrisvogt-me/galleries/now-july-2025/IMG_5094.jpg',
+    title: 'The balcony view at sunset, with a boat in the distance',
+    width: 3,
+    height: 4
+  },
+  {
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1754281189/chrisvogt-me/galleries/now-july-2025/IMG_5100.jpg',
+    title: 'Another view of the bay at sunset',
+    width: 4,
+    height: 3
+  }
+]
+
+export const pvrZonaRomantica = [
+  {
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1754281182/chrisvogt-me/galleries/now-july-2025/IMG_5045.jpg',
+    title: 'Calle Rodolfo Gómez, just off Olas Altas',
+    width: 3,
+    height: 4
+  },
+  {
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1754281181/chrisvogt-me/galleries/now-july-2025/IMG_5035.jpg',
+    title: 'Nick sweating in the humidity at Anonymo Bar',
+    width: 3,
+    height: 4
+  },
+  {
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1754281183/chrisvogt-me/galleries/now-july-2025/IMG_5055.jpg',
+    title: 'Anonymo Bar, my favorite bar in PV',
+    width: 3,
+    height: 4
+  },
+  {
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1754281239/chrisvogt-me/galleries/now-july-2025/IMG_5118.jpg',
+    title: 'Al pastor at Taquería Taco Jarocho in Puerto Vallarta',
+    width: 3,
+    height: 4
+  },
+  {
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1754281184/chrisvogt-me/galleries/now-july-2025/IMG_5068.jpg',
+    title: 'Old and new friends at The Corner Bar in Puerto Vallarta',
+    width: 4,
+    height: 3
+  },
+  {
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1754281187/chrisvogt-me/galleries/now-july-2025/IMG_5080.jpg',
+    title: 'Nick and I at Industry Bar in Puerto Vallarta',
+    width: 4,
+    height: 3
+  },
+  {
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1754281190/chrisvogt-me/galleries/now-july-2025/IMG_5139.jpg',
+    title: 'Tom, Mark and Nick outside of Mr. Flamingo PV',
+    width: 3,
+    height: 4
+  }
+]
+
+export const vinylCollection = [
+  {
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1754287262/chrisvogt-me/galleries/now-july-2025/IMG_5228.jpg',
+    title: 'This is what started it all—Roc and his vinyl collection',
+    width: 4,
+    height: 3
+  },
+  {
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1754287262/chrisvogt-me/galleries/now-july-2025/IMG_5243.jpg',
+    title: 'Mutemath — Play Dead, one of my favorite albums',
+    width: 3,
+    height: 4
+  },
+  {
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1754287263/chrisvogt-me/galleries/now-july-2025/IMG_5333.jpg',
+    title: 'Rise and Fall of a Midwest Princess by Chappell Roan',
+    width: 3,
+    height: 4
+  },
+  {
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1754287267/chrisvogt-me/galleries/now-july-2025/IMG_5252.jpg',
+    title: 'Purple Disco Machine — Exotica',
+    width: 3,
+    height: 4
+  },
+  {
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1754287265/chrisvogt-me/galleries/now-july-2025/IMG_5313.jpg',
+    title: 'Brat — Charlie XCX',
+    width: 3,
+    height: 4
+  },
+  {
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1754287266/chrisvogt-me/galleries/now-july-2025/IMG_5257.jpg',
+    title: 'Roc in dad mode, having just adjusted the counterbalance on the record player',
+    width: 3,
+    height: 4
+  }
+]


### PR DESCRIPTION
## Overview

This PR replaces the Now page with the July 2025 recap.

## AI summary

This pull request introduces updates to two blog posts and adds a new photo gallery module for the July 2025 recap. The changes include content updates for the June 2025 recap, the addition of a detailed July 2025 recap with multiple sections, and the creation of reusable photo gallery components for enhanced visual storytelling.

### Blog Content Updates:

* **June 2025 Recap (`2025-06-30-june-2025-recap.mdx`)**:
  - Updated metadata: changed the title, slug, and banner to better align with the content and improved categorization by adding a `category` field.

* **July 2025 Recap (`2025-07-31-july-2025-recap.mdx`)**:
  - Added a new blog post structured with multiple sections, including updates on website features, work projects, travel experiences, hobbies, and reading.

### Photo Gallery Enhancements:

* **Photo Gallery Module (`photos.js`)**:
  - Introduced reusable photo gallery components (`pvrFlight`, `pvrHotel`, `pvrZonaRomantica`, `vinylCollection`) to display curated images for the July 2025 recap. These galleries enhance storytelling with detailed captions and metadata for each photo.
