### PR TITLE
fix(discogs): responsive Discogs widget for small screens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.60.3
+
+### 🐛 Bug Fixes
+
+- **Discogs Widget Mobile Layout**: Prevented vinyl items from forcing a minimum width on small screens.
+  - Restored 3-up layout at the smallest breakpoint to match Spotify behavior
+  - Allowed grid items to shrink by adding `minWidth: 0` and `boxSizing: 'border-box'` on cards
+  - Reduced small-screen padding to avoid overflow
+  - Result: Items now grow/contract smoothly on mobile without distorting the page layout
+
 ## 0.60.2
 
 ### 🚀 Performance Improvements

--- a/theme/package.json
+++ b/theme/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-theme-chronogrove",
   "description": "A personal website and digital garden theme for GatsbyJS.",
-  "version": "0.60.2",
+  "version": "0.60.3",
   "author": "Chris Vogt <mail@chrisvogt.me> (https://www.chrisvogt.me)",
   "main": "index.js",
   "license": "MIT",

--- a/theme/src/components/widgets/discogs/__snapshots__/vinyl-collection.spec.js.snap
+++ b/theme/src/components/widgets/discogs/__snapshots__/vinyl-collection.spec.js.snap
@@ -39,7 +39,7 @@ exports[`VinylCollection Edge cases handles releases with empty artist name 1`] 
           className="vinyl-collection_grid null css-4004kc"
         >
           <div
-            className="css-139dwiw"
+            className="css-1f2wh2n"
           >
             <div
               className="vinyl-record css-4gxhk2"
@@ -119,7 +119,7 @@ exports[`VinylCollection Edge cases handles releases with empty artists array 1`
           className="vinyl-collection_grid null css-4004kc"
         >
           <div
-            className="css-139dwiw"
+            className="css-1f2wh2n"
           >
             <div
               className="vinyl-record css-4gxhk2"
@@ -199,7 +199,7 @@ exports[`VinylCollection Edge cases handles releases with empty cdnThumbUrl 1`] 
           className="vinyl-collection_grid null css-4004kc"
         >
           <div
-            className="css-139dwiw"
+            className="css-1f2wh2n"
           >
             <div
               className="vinyl-record css-4gxhk2"
@@ -281,7 +281,7 @@ exports[`VinylCollection Edge cases handles releases with empty resourceUrl 1`] 
           className="vinyl-collection_grid null css-4004kc"
         >
           <div
-            className="css-139dwiw"
+            className="css-1f2wh2n"
           >
             <div
               className="vinyl-record css-4gxhk2"
@@ -371,7 +371,7 @@ exports[`VinylCollection Edge cases handles releases with missing artist name 1`
           className="vinyl-collection_grid null css-4004kc"
         >
           <div
-            className="css-139dwiw"
+            className="css-1f2wh2n"
           >
             <div
               className="vinyl-record css-4gxhk2"
@@ -451,7 +451,7 @@ exports[`VinylCollection Edge cases handles releases with missing basicInformati
           className="vinyl-collection_grid null css-4004kc"
         >
           <div
-            className="css-139dwiw"
+            className="css-1f2wh2n"
           >
             <div
               className="vinyl-record css-4gxhk2"
@@ -529,7 +529,7 @@ exports[`VinylCollection Edge cases handles releases with missing cdnThumbUrl pr
           className="vinyl-collection_grid null css-4004kc"
         >
           <div
-            className="css-139dwiw"
+            className="css-1f2wh2n"
           >
             <div
               className="vinyl-record css-4gxhk2"
@@ -611,7 +611,7 @@ exports[`VinylCollection Edge cases handles releases with missing resourceUrl 1`
           className="vinyl-collection_grid null css-4004kc"
         >
           <div
-            className="css-139dwiw"
+            className="css-1f2wh2n"
           >
             <div
               className="vinyl-record css-4gxhk2"
@@ -701,7 +701,7 @@ exports[`VinylCollection Edge cases handles releases with missing resourceUrl pr
           className="vinyl-collection_grid null css-4004kc"
         >
           <div
-            className="css-139dwiw"
+            className="css-1f2wh2n"
           >
             <div
               className="vinyl-record css-4gxhk2"
@@ -791,7 +791,7 @@ exports[`VinylCollection Edge cases handles releases with missing title 1`] = `
           className="vinyl-collection_grid null css-4004kc"
         >
           <div
-            className="css-139dwiw"
+            className="css-1f2wh2n"
           >
             <div
               className="vinyl-record css-4gxhk2"
@@ -871,7 +871,7 @@ exports[`VinylCollection Edge cases handles releases with missing year 1`] = `
           className="vinyl-collection_grid null css-4004kc"
         >
           <div
-            className="css-139dwiw"
+            className="css-1f2wh2n"
           >
             <div
               className="vinyl-record css-4gxhk2"
@@ -951,7 +951,7 @@ exports[`VinylCollection Edge cases handles releases with null artists 1`] = `
           className="vinyl-collection_grid null css-4004kc"
         >
           <div
-            className="css-139dwiw"
+            className="css-1f2wh2n"
           >
             <div
               className="vinyl-record css-4gxhk2"
@@ -1031,7 +1031,7 @@ exports[`VinylCollection Edge cases handles releases with undefined artist name 
           className="vinyl-collection_grid null css-4004kc"
         >
           <div
-            className="css-139dwiw"
+            className="css-1f2wh2n"
           >
             <div
               className="vinyl-record css-4gxhk2"
@@ -1111,7 +1111,7 @@ exports[`VinylCollection Edge cases handles releases with undefined artists 1`] 
           className="vinyl-collection_grid null css-4004kc"
         >
           <div
-            className="css-139dwiw"
+            className="css-1f2wh2n"
           >
             <div
               className="vinyl-record css-4gxhk2"
@@ -1191,7 +1191,7 @@ exports[`VinylCollection Edge cases handles releases with undefined cdnThumbUrl 
           className="vinyl-collection_grid null css-4004kc"
         >
           <div
-            className="css-139dwiw"
+            className="css-1f2wh2n"
           >
             <div
               className="vinyl-record css-4gxhk2"
@@ -1273,7 +1273,7 @@ exports[`VinylCollection Edge cases handles releases with undefined resourceUrl 
           className="vinyl-collection_grid null css-4004kc"
         >
           <div
-            className="css-139dwiw"
+            className="css-1f2wh2n"
           >
             <div
               className="vinyl-record css-4gxhk2"
@@ -1363,7 +1363,7 @@ exports[`VinylCollection handles releases with missing artist information 1`] = 
           className="vinyl-collection_grid null css-4004kc"
         >
           <div
-            className="css-139dwiw"
+            className="css-1f2wh2n"
           >
             <div
               className="vinyl-record css-4gxhk2"
@@ -1443,7 +1443,7 @@ exports[`VinylCollection handles releases with missing basicInformation 1`] = `
           className="vinyl-collection_grid null css-4004kc"
         >
           <div
-            className="css-139dwiw"
+            className="css-1f2wh2n"
           >
             <div
               className="vinyl-record css-4gxhk2"
@@ -1474,7 +1474,7 @@ exports[`VinylCollection handles releases with missing basicInformation 1`] = `
             </div>
           </div>
           <div
-            className="css-139dwiw"
+            className="css-1f2wh2n"
           >
             <div
               className="vinyl-record css-4gxhk2"
@@ -1556,7 +1556,7 @@ exports[`VinylCollection handles releases with multiple artists 1`] = `
           className="vinyl-collection_grid null css-4004kc"
         >
           <div
-            className="css-139dwiw"
+            className="css-1f2wh2n"
           >
             <div
               className="vinyl-record css-4gxhk2"
@@ -1638,7 +1638,7 @@ exports[`VinylCollection handles releases without CDN thumb URL 1`] = `
           className="vinyl-collection_grid null css-4004kc"
         >
           <div
-            className="css-139dwiw"
+            className="css-1f2wh2n"
           >
             <div
               className="vinyl-record css-4gxhk2"
@@ -1792,7 +1792,7 @@ exports[`VinylCollection renders with many releases for pagination testing 1`] =
           className="vinyl-collection_grid null css-4004kc"
         >
           <div
-            className="css-139dwiw"
+            className="css-1f2wh2n"
           >
             <div
               className="vinyl-record css-4gxhk2"
@@ -1837,7 +1837,7 @@ exports[`VinylCollection renders with many releases for pagination testing 1`] =
             </div>
           </div>
           <div
-            className="css-139dwiw"
+            className="css-1f2wh2n"
           >
             <div
               className="vinyl-record css-4gxhk2"
@@ -1882,7 +1882,7 @@ exports[`VinylCollection renders with many releases for pagination testing 1`] =
             </div>
           </div>
           <div
-            className="css-139dwiw"
+            className="css-1f2wh2n"
           >
             <div
               className="vinyl-record css-4gxhk2"
@@ -1927,7 +1927,7 @@ exports[`VinylCollection renders with many releases for pagination testing 1`] =
             </div>
           </div>
           <div
-            className="css-139dwiw"
+            className="css-1f2wh2n"
           >
             <div
               className="vinyl-record css-4gxhk2"
@@ -1972,7 +1972,7 @@ exports[`VinylCollection renders with many releases for pagination testing 1`] =
             </div>
           </div>
           <div
-            className="css-139dwiw"
+            className="css-1f2wh2n"
           >
             <div
               className="vinyl-record css-4gxhk2"
@@ -2017,7 +2017,7 @@ exports[`VinylCollection renders with many releases for pagination testing 1`] =
             </div>
           </div>
           <div
-            className="css-139dwiw"
+            className="css-1f2wh2n"
           >
             <div
               className="vinyl-record css-4gxhk2"
@@ -2062,7 +2062,7 @@ exports[`VinylCollection renders with many releases for pagination testing 1`] =
             </div>
           </div>
           <div
-            className="css-139dwiw"
+            className="css-1f2wh2n"
           >
             <div
               className="vinyl-record css-4gxhk2"
@@ -2107,7 +2107,7 @@ exports[`VinylCollection renders with many releases for pagination testing 1`] =
             </div>
           </div>
           <div
-            className="css-139dwiw"
+            className="css-1f2wh2n"
           >
             <div
               className="vinyl-record css-4gxhk2"
@@ -2152,7 +2152,7 @@ exports[`VinylCollection renders with many releases for pagination testing 1`] =
             </div>
           </div>
           <div
-            className="css-139dwiw"
+            className="css-1f2wh2n"
           >
             <div
               className="vinyl-record css-4gxhk2"
@@ -2197,7 +2197,7 @@ exports[`VinylCollection renders with many releases for pagination testing 1`] =
             </div>
           </div>
           <div
-            className="css-139dwiw"
+            className="css-1f2wh2n"
           >
             <div
               className="vinyl-record css-4gxhk2"
@@ -2242,7 +2242,7 @@ exports[`VinylCollection renders with many releases for pagination testing 1`] =
             </div>
           </div>
           <div
-            className="css-139dwiw"
+            className="css-1f2wh2n"
           >
             <div
               className="vinyl-record css-4gxhk2"
@@ -2287,7 +2287,7 @@ exports[`VinylCollection renders with many releases for pagination testing 1`] =
             </div>
           </div>
           <div
-            className="css-139dwiw"
+            className="css-1f2wh2n"
           >
             <div
               className="vinyl-record css-4gxhk2"
@@ -2332,7 +2332,7 @@ exports[`VinylCollection renders with many releases for pagination testing 1`] =
             </div>
           </div>
           <div
-            className="css-139dwiw"
+            className="css-1f2wh2n"
           >
             <div
               className="vinyl-record css-4gxhk2"
@@ -2377,7 +2377,7 @@ exports[`VinylCollection renders with many releases for pagination testing 1`] =
             </div>
           </div>
           <div
-            className="css-139dwiw"
+            className="css-1f2wh2n"
           >
             <div
               className="vinyl-record css-4gxhk2"
@@ -2422,7 +2422,7 @@ exports[`VinylCollection renders with many releases for pagination testing 1`] =
             </div>
           </div>
           <div
-            className="css-139dwiw"
+            className="css-1f2wh2n"
           >
             <div
               className="vinyl-record css-4gxhk2"
@@ -2467,7 +2467,7 @@ exports[`VinylCollection renders with many releases for pagination testing 1`] =
             </div>
           </div>
           <div
-            className="css-139dwiw"
+            className="css-1f2wh2n"
           >
             <div
               className="vinyl-record css-4gxhk2"
@@ -2512,7 +2512,7 @@ exports[`VinylCollection renders with many releases for pagination testing 1`] =
             </div>
           </div>
           <div
-            className="css-139dwiw"
+            className="css-1f2wh2n"
           >
             <div
               className="vinyl-record css-4gxhk2"
@@ -2557,7 +2557,7 @@ exports[`VinylCollection renders with many releases for pagination testing 1`] =
             </div>
           </div>
           <div
-            className="css-139dwiw"
+            className="css-1f2wh2n"
           >
             <div
               className="vinyl-record css-4gxhk2"
@@ -2610,7 +2610,7 @@ exports[`VinylCollection renders with many releases for pagination testing 1`] =
           className="vinyl-collection_grid null css-4004kc"
         >
           <div
-            className="css-139dwiw"
+            className="css-1f2wh2n"
           >
             <div
               className="vinyl-record css-4gxhk2"
@@ -2655,7 +2655,7 @@ exports[`VinylCollection renders with many releases for pagination testing 1`] =
             </div>
           </div>
           <div
-            className="css-139dwiw"
+            className="css-1f2wh2n"
           >
             <div
               className="vinyl-record css-4gxhk2"
@@ -2700,7 +2700,7 @@ exports[`VinylCollection renders with many releases for pagination testing 1`] =
             </div>
           </div>
           <div
-            className="css-139dwiw"
+            className="css-1f2wh2n"
           >
             <div
               className="vinyl-record css-4gxhk2"
@@ -2745,7 +2745,7 @@ exports[`VinylCollection renders with many releases for pagination testing 1`] =
             </div>
           </div>
           <div
-            className="css-139dwiw"
+            className="css-1f2wh2n"
           >
             <div
               className="vinyl-record css-4gxhk2"
@@ -2790,7 +2790,7 @@ exports[`VinylCollection renders with many releases for pagination testing 1`] =
             </div>
           </div>
           <div
-            className="css-139dwiw"
+            className="css-1f2wh2n"
           >
             <div
               className="vinyl-record css-4gxhk2"
@@ -2835,7 +2835,7 @@ exports[`VinylCollection renders with many releases for pagination testing 1`] =
             </div>
           </div>
           <div
-            className="css-139dwiw"
+            className="css-1f2wh2n"
           >
             <div
               className="vinyl-record css-4gxhk2"
@@ -2880,7 +2880,7 @@ exports[`VinylCollection renders with many releases for pagination testing 1`] =
             </div>
           </div>
           <div
-            className="css-139dwiw"
+            className="css-1f2wh2n"
           >
             <div
               className="vinyl-record css-4gxhk2"
@@ -3053,7 +3053,7 @@ exports[`VinylCollection renders with vinyl releases 1`] = `
           className="vinyl-collection_grid null css-4004kc"
         >
           <div
-            className="css-139dwiw"
+            className="css-1f2wh2n"
           >
             <div
               className="vinyl-record css-4gxhk2"
@@ -3098,7 +3098,7 @@ exports[`VinylCollection renders with vinyl releases 1`] = `
             </div>
           </div>
           <div
-            className="css-139dwiw"
+            className="css-1f2wh2n"
           >
             <div
               className="vinyl-record css-4gxhk2"

--- a/theme/src/components/widgets/discogs/vinyl-collection.js
+++ b/theme/src/components/widgets/discogs/vinyl-collection.js
@@ -213,6 +213,9 @@ const VinylCollection = ({ isLoading, releases = [] }) => {
                         key={id}
                         variant='actionCard'
                         sx={{
+                          p: [1, 2, 3],
+                          minWidth: 0,
+                          boxSizing: 'border-box',
                           height: '100%',
                           display: 'flex',
                           flexDirection: 'column',


### PR DESCRIPTION
## Overview

This PR fixes an issue on small and mobile screens where the Discogs widget is causing the Home page to horizontally overflow from the page.

## Screenshots

| BEFORE                         | AFTER                        |
| ------------------------------ | ---------------------------- |
| <img width="1661" height="1084" alt="resp-before" src="https://github.com/user-attachments/assets/38728e0f-2617-438e-8a2b-dc0a4822e2c6" /> | <img width="1661" height="1084" alt="resp-after" src="https://github.com/user-attachments/assets/15f03d82-1e79-41d4-b0cf-c4dc3c7b43c3" /> |

## AI summary

This pull request addresses a bug with the Discogs vinyl collection widget's mobile layout, ensuring that vinyl items no longer force a minimum width on small screens and that the layout is consistent with the Spotify widget. It also updates the package version and includes changes to snapshot tests reflecting the updated styling.

**Discogs Widget Mobile Layout Fixes:**
- Fixed the vinyl collection widget so that items no longer force a minimum width on mobile screens, restoring the 3-up layout at the smallest breakpoint and allowing grid items to shrink. This was achieved by adding `minWidth: 0` and `boxSizing: 'border-box'` to cards and reducing small-screen padding, resulting in smoother resizing and preventing layout distortion.

**Versioning:**
- Bumped the package version to `0.60.3` in `package.json` to reflect the bug fix.

**Testing and Snapshots:**
- Updated all relevant Jest snapshot tests for the `VinylCollection` component to reflect the new CSS class (`css-1f2wh2n`), ensuring tests are in sync with the layout and style changes. [[1]](diffhunk://#diff-aac3cf78a007879a1ac2c389b4f49852dc2f56063c314066a9d33e0f154fa9d0L42-R42) [[2]](diffhunk://#diff-aac3cf78a007879a1ac2c389b4f49852dc2f56063c314066a9d33e0f154fa9d0L122-R122) [[3]](diffhunk://#diff-aac3cf78a007879a1ac2c389b4f49852dc2f56063c314066a9d33e0f154fa9d0L202-R202) [[4]](diffhunk://#diff-aac3cf78a007879a1ac2c389b4f49852dc2f56063c314066a9d33e0f154fa9d0L284-R284) [[5]](diffhunk://#diff-aac3cf78a007879a1ac2c389b4f49852dc2f56063c314066a9d33e0f154fa9d0L374-R374) [[6]](diffhunk://#diff-aac3cf78a007879a1ac2c389b4f49852dc2f56063c314066a9d33e0f154fa9d0L454-R454) [[7]](diffhunk://#diff-aac3cf78a007879a1ac2c389b4f49852dc2f56063c314066a9d33e0f154fa9d0L532-R532) [[8]](diffhunk://#diff-aac3cf78a007879a1ac2c389b4f49852dc2f56063c314066a9d33e0f154fa9d0L614-R614) [[9]](diffhunk://#diff-aac3cf78a007879a1ac2c389b4f49852dc2f56063c314066a9d33e0f154fa9d0L704-R704) [[10]](diffhunk://#diff-aac3cf78a007879a1ac2c389b4f49852dc2f56063c314066a9d33e0f154fa9d0L794-R794) [[11]](diffhunk://#diff-aac3cf78a007879a1ac2c389b4f49852dc2f56063c314066a9d33e0f154fa9d0L874-R874) [[12]](diffhunk://#diff-aac3cf78a007879a1ac2c389b4f49852dc2f56063c314066a9d33e0f154fa9d0L954-R954) [[13]](diffhunk://#diff-aac3cf78a007879a1ac2c389b4f49852dc2f56063c314066a9d33e0f154fa9d0L1034-R1034) [[14]](diffhunk://#diff-aac3cf78a007879a1ac2c389b4f49852dc2f56063c314066a9d33e0f154fa9d0L1114-R1114) [[15]](diffhunk://#diff-aac3cf78a007879a1ac2c389b4f49852dc2f56063c314066a9d33e0f154fa9d0L1194-R1194) [[16]](diffhunk://#diff-aac3cf78a007879a1ac2c389b4f49852dc2f56063c314066a9d33e0f154fa9d0L1276-R1276) [[17]](diffhunk://#diff-aac3cf78a007879a1ac2c389b4f49852dc2f56063c314066a9d33e0f154fa9d0L1366-R1366) [[18]](diffhunk://#diff-aac3cf78a007879a1ac2c389b4f49852dc2f56063c314066a9d33e0f154fa9d0L1446-R1446) [[19]](diffhunk://#diff-aac3cf78a007879a1ac2c389b4f49852dc2f56063c314066a9d33e0f154fa9d0L1477-R1477) [[20]](diffhunk://#diff-aac3cf78a007879a1ac2c389b4f49852dc2f56063c314066a9d33e0f154fa9d0L1559-R1559) [[21]](diffhunk://#diff-aac3cf78a007879a1ac2c389b4f49852dc2f56063c314066a9d33e0f154fa9d0L1641-R1641) [[22]](diffhunk://#diff-aac3cf78a007879a1ac2c389b4f49852dc2f56063c314066a9d33e0f154fa9d0L1795-R1795) [[23]](diffhunk://#diff-aac3cf78a007879a1ac2c389b4f49852dc2f56063c314066a9d33e0f154fa9d0L1840-R1840) [[24]](diffhunk://#diff-aac3cf78a007879a1ac2c389b4f49852dc2f56063c314066a9d33e0f154fa9d0L1885-R1885) [[25]](diffhunk://#diff-aac3cf78a007879a1ac2c389b4f49852dc2f56063c314066a9d33e0f154fa9d0L1930-R1930) [[26]](diffhunk://#diff-aac3cf78a007879a1ac2c389b4f49852dc2f56063c314066a9d33e0f154fa9d0L1975-R1975) [[27]](diffhunk://#diff-aac3cf78a007879a1ac2c389b4f49852dc2f56063c314066a9d33e0f154fa9d0L2020-R2020) [[28]](diffhunk://#diff-aac3cf78a007879a1ac2c389b4f49852dc2f56063c314066a9d33e0f154fa9d0L2065-R2065) [[29]](diffhunk://#diff-aac3cf78a007879a1ac2c389b4f49852dc2f56063c314066a9d33e0f154fa9d0L2110-R2110) [[30]](diffhunk://#diff-aac3cf78a007879a1ac2c389b4f49852dc2f56063c314066a9d33e0f154fa9d0L2155-R2155) [[31]](diffhunk://#diff-aac3cf78a007879a1ac2c389b4f49852dc2f56063c314066a9d33e0f154fa9d0L2200-R2200) [[32]](diffhunk://#diff-aac3cf78a007879a1ac2c389b4f49852dc2f56063c314066a9d33e0f154fa9d0L2245-R2245)