### PR TITLE
refactor(theme): modernize error boundary to functional component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## 0.62.1
+
+### 🔧 Modernization
+
+- **Modernized Error Boundary**: Converted the only class component to a functional component using `react-error-boundary`
+  - Replaced legacy `PlaylistsErrorBoundary` class component with modern functional component using the `react-error-boundary` library
+  - Eliminated the last class component from the theme codebase
+  - Maintained identical error handling behavior while adopting modern React patterns
+  - Improved code maintainability and consistency with the rest of the theme
+
+### 📦 Dependencies
+
+- Added `react-error-boundary` (v4.1.2) as a dependency for improved error boundary management
+
+### 🧪 Testing
+
+- All existing error boundary tests continue to pass with new implementation
+- No test changes required - functionality is fully backward compatible
+- All 37 Spotify widget tests passing
+
 ## 0.62.0
 
 ### ✨ Features

--- a/theme/package.json
+++ b/theme/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-theme-chronogrove",
   "description": "A personal website and digital garden theme for GatsbyJS.",
-  "version": "0.62.0",
+  "version": "0.62.1",
   "author": "Chris Vogt <mail@chrisvogt.me> (https://www.chrisvogt.me)",
   "main": "index.js",
   "license": "MIT",
@@ -102,6 +102,7 @@
     "prismjs": "^1.30.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-error-boundary": "^4.0.13",
     "react-photo-gallery": "^8.0.0",
     "react-placeholder": "^4.1.0",
     "react-redux": "^9.2.0",

--- a/theme/src/components/widgets/spotify/playlist-error-boundary.spec.js
+++ b/theme/src/components/widgets/spotify/playlist-error-boundary.spec.js
@@ -36,7 +36,7 @@ describe('PlaylistsErrorBoundary', () => {
         <ErrorChild />
       </PlaylistsErrorBoundary>
     )
-    // When an error is caught, the boundary renders null,
+    // When an error is caught, the boundary renders null via FallbackComponent,
     // so container.firstChild should be null.
     expect(container.firstChild).toBeNull()
   })

--- a/theme/src/components/widgets/spotify/playlists-error-boundary.js
+++ b/theme/src/components/widgets/spotify/playlists-error-boundary.js
@@ -1,31 +1,25 @@
-import { Component } from 'react'
+import React from 'react'
+import { ErrorBoundary } from 'react-error-boundary'
 
 // This component is a temporary solution for an issue I've been observing the last month or two
 // where the Spotify Widget response data is missing images for the playlists. This causes a fatal
 // error in the component which takes down the entire Home page.
-class PlaylistsErrorBoundary extends Component {
-  constructor(props) {
-    super(props)
-    this.state = { hasError: false }
-  }
+const PlaylistsErrorBoundaryFallback = () => {
+  // Don't render anything if there's an error. Most visitors, if not all, won't realize
+  // this is missing.
+  return null
+}
 
-  static getDerivedStateFromError() {
-    return { hasError: true }
-  }
-
-  componentDidCatch(error, errorInfo) {
+const PlaylistsErrorBoundary = ({ children }) => {
+  const handleError = (error, errorInfo) => {
     console.error('Error in Playlists component:', error, errorInfo)
   }
 
-  render() {
-    if (this.state.hasError) {
-      // Don't render anything if there's an error. Most visitors, if not all, won't realize
-      // this is missing.
-      return null
-    }
-
-    return this.props.children
-  }
+  return (
+    <ErrorBoundary onError={handleError} FallbackComponent={PlaylistsErrorBoundaryFallback}>
+      {children}
+    </ErrorBoundary>
+  )
 }
 
 export default PlaylistsErrorBoundary

--- a/yarn.lock
+++ b/yarn.lock
@@ -12596,6 +12596,7 @@ __metadata:
     prismjs: "npm:^1.30.0"
     react: "npm:^18.3.1"
     react-dom: "npm:^18.3.1"
+    react-error-boundary: "npm:^4.0.13"
     react-photo-gallery: "npm:^8.0.0"
     react-placeholder: "npm:^4.1.0"
     react-redux: "npm:^9.2.0"
@@ -19874,6 +19875,17 @@ __metadata:
   peerDependencies:
     react: ">=16.13.1"
   checksum: 10c0/f977ca61823e43de2381d53dd7aa8b4d79ff6a984c9afdc88dc44f9973b99de7fd382d2f0f91f2688e24bb987c0185bf45d0b004f22afaaab0f990a830253bfb
+  languageName: node
+  linkType: hard
+
+"react-error-boundary@npm:^4.0.13":
+  version: 4.1.2
+  resolution: "react-error-boundary@npm:4.1.2"
+  dependencies:
+    "@babel/runtime": "npm:^7.12.5"
+  peerDependencies:
+    react: ">=16.13.1"
+  checksum: 10c0/0737e5259bed40ce14eb0823b3c7b152171921f2179e604f48f3913490cdc594d6c22d43d7abb4ffb1512c832850228db07aa69d3b941db324953a5e393cb399
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Overview

Converts the last class component to a functional component using `react-error-boundary`.

## Why

Class-based error boundaries limit React patterns:
- Blocks hooks (useEffect/useState)
- Requires lifecycle methods (getDerivedStateFromError, componentDidCatch)
- More boilerplate than functional equivalents

Using `react-error-boundary` lets us:
- Follow a single component pattern across the theme
- Compose with hooks when needed
- Rely on maintained libraries
- Improve integration with DevTools

## Changes

- Replace `PlaylistsErrorBoundary` class with a functional component using `react-error-boundary`
- Add `react-error-boundary` v4.1.2
- Bump version to 0.62.1
- Update CHANGELOG

## Testing

- All 37 Spotify widget tests passing
- Both error boundary tests passing
- No functional changes

## Files Changed

5 files: +49, -22
- `playlists-error-boundary.js` - Converted to functional component
- `playlist-error-boundary.spec.js` - Updated comment
- `package.json` - Added dependency, bumped version
- `CHANGELOG.md` - Added entry
- `yarn.lock` - Updated