### PR TITLE
chore: bump version (missed with last commit)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## 0.63.3
+
+### 🐛 Bug Fixes
+
+- **Navigation Scroll Position**: Fixed inconsistent scroll-to-top behavior when navigating from Recent Posts widget
+  - Removed manual `onClick` scroll handler from PostCard that conflicted with Gatsby's navigation timing
+  - Updated `shouldUpdateScroll` in gatsby-browser to explicitly return `[0, 0]` coordinates instead of `true`
+  - Added `preventScroll: true` to skip-nav focus to prevent scroll interference
+  - Changed global CSS `scroll-behavior` from `smooth` to `auto` to eliminate awkward animation after navigation
+  - Navigation now consistently scrolls to top instantly across all pages (home, blog index, etc.)
+
+### 🎯 User Experience
+
+- **Instant Navigation**: Page transitions are now snappy and immediate with no visible scroll animation
+- **Consistent Behavior**: Recent Posts widget cards now behave identically to Blog index cards
+- **Better Performance**: Eliminated timing conflicts between manual scroll handlers and Gatsby's built-in navigation
+
+### 🧪 Testing & Coverage
+
+- **100% Test Coverage**: All modified files maintain complete test coverage
+- **Updated Tests**: Modified 8 existing tests to verify new scroll behavior
+  - Updated `shouldUpdateScroll` tests to expect `[0, 0]` scroll coordinates
+  - Updated `onRouteUpdate` tests to verify `preventScroll: true` parameter
+  - Removed obsolete manual scroll test from PostCard
+- **879 Tests Passing**: Full test suite passes with no regressions
+
 ## 0.63.2
 
 ### 🐛 Bug Fixes

--- a/theme/package.json
+++ b/theme/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-theme-chronogrove",
   "description": "A personal website and digital garden theme for GatsbyJS.",
-  "version": "0.63.2",
+  "version": "0.63.3",
   "author": "Chris Vogt <mail@chrisvogt.me> (https://www.chrisvogt.me)",
   "main": "index.js",
   "license": "MIT",


### PR DESCRIPTION
This PR bumps the changelog and package version, which I missed with #432.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Bumps theme to 0.63.3 and updates changelog with navigation scroll bugfixes and testing notes.
> 
> - **Release**
>   - Bump version in `theme/package.json` to `0.63.3`.
> - **Docs**
>   - Add `CHANGELOG.md` entry for `0.63.3` covering navigation scroll behavior fixes and updated tests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2fec7d8d40459311dcf338706e1656ba7553d1d7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->