### PR TITLE
fix(page-background): move up tree to prevent flash on nav

### DIFF
--- a/theme/src/components/animated-page-background.js
+++ b/theme/src/components/animated-page-background.js
@@ -39,10 +39,7 @@ const AnimatedPageBackground = ({
   const [overlayOpacity, setOverlayOpacity] = useState(1)
   const [mounted, setMounted] = useState(false)
 
-  // Get background colors from theme - Theme UI provides the correct color based on active mode
-  // Use rawColors if available (raw hex values), otherwise fall back to theme.colors
-  // with mode-specific defaults if needed
-  // Calculate this early so we can use it in useEffect hooks
+  // Get background colors from theme for gradient overlay
   const bgColorRaw = theme?.rawColors?.background || theme?.colors?.background || (isDark ? '#14141F' : '#fdf8f5')
 
   // Ensure we're client-side before rendering color-specific content
@@ -50,19 +47,8 @@ const AnimatedPageBackground = ({
     setMounted(true)
   }, [])
 
-  // Set HTML background color to match theme to prevent light background showing through
-  useEffect(() => {
-    if (typeof document !== 'undefined' && mounted) {
-      const htmlElement = document.documentElement
-      // Set HTML background to match theme background so it doesn't show through the semi-transparent animation
-      htmlElement.style.backgroundColor = bgColorRaw
-
-      return () => {
-        // Cleanup: remove inline style when component unmounts
-        htmlElement.style.backgroundColor = ''
-      }
-    }
-  }, [mounted, bgColorRaw])
+  // Note: HTML background color is now managed globally in RootWrapper
+  // to prevent white flash during page transitions
 
   // Handle scroll to fade out overlay as user scrolls down
   useEffect(() => {

--- a/theme/src/components/root-wrapper.js
+++ b/theme/src/components/root-wrapper.js
@@ -1,12 +1,24 @@
 /** @jsx jsx */
-import { jsx } from 'theme-ui'
+import { jsx, useColorMode, useThemeUI } from 'theme-ui'
 import { useSelector } from 'react-redux'
-import React from 'react'
+import React, { useEffect } from 'react'
 
 import AudioPlayer from './audio-player'
 
 const RootWrapper = ({ children }) => {
   const { soundcloudId, spotifyURL, isVisible, provider } = useSelector(state => state.audioPlayer)
+  const [colorMode] = useColorMode()
+  const { theme } = useThemeUI()
+
+  // Set HTML background color to match theme to prevent white flash during page transitions
+  useEffect(() => {
+    if (typeof document !== 'undefined') {
+      const isDark = colorMode === 'dark'
+      const bgColorRaw = theme?.rawColors?.background || theme?.colors?.background || (isDark ? '#14141F' : '#fdf8f5')
+      const htmlElement = document.documentElement
+      htmlElement.style.backgroundColor = bgColorRaw
+    }
+  }, [colorMode, theme])
 
   return (
     <>

--- a/theme/src/components/root-wrapper.spec.js
+++ b/theme/src/components/root-wrapper.spec.js
@@ -7,6 +7,22 @@ import RootWrapper from './root-wrapper'
 // Mock AudioPlayer component
 jest.mock('./audio-player', () => jest.fn(() => <div>MockAudioPlayer</div>))
 
+// Mock theme-ui hooks
+jest.mock('theme-ui', () => ({
+  ...jest.requireActual('theme-ui'),
+  useColorMode: jest.fn(() => ['light', jest.fn()]),
+  useThemeUI: jest.fn(() => ({
+    theme: {
+      rawColors: {
+        background: '#fdf8f5'
+      },
+      colors: {
+        background: '#fdf8f5'
+      }
+    }
+  }))
+}))
+
 const mockStore = configureStore([])
 
 describe('RootWrapper', () => {


### PR DESCRIPTION
## Overview

I've noticed a brief flash of the background turning white whenever I navigate to a different page. It's because the AnimatedPageBackground component's cleanup function was removing the HTML background color (htmlElement.style.backgroundColor = ''), briefly exposing the browser's default white background during page transitions.

This PR moves the HTML background color management from AnimatedPageBackground (which mounts/unmounts during navigation) to RootWrapper (which persists across all page transitions).

