### PR TITLE
chore(browserlist): adds browserlist config to reduce polyfills

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,5 +42,10 @@
   "resolutions": {
     "lodash": "^4.17.23"
   },
-  "packageManager": "yarn@4.9.2"
+  "packageManager": "yarn@4.9.2",
+  "browserslist": [
+    ">0.25%",
+    "not dead",
+    "not op_mini all"
+  ]
 }


### PR DESCRIPTION
## Overview

This PR adds a browserlist config in an attempt to reduce the unnecessary polyfills being bundled with my website. Since `vanilla-tilt` ships with pre-transpiled code, it may not be possible to factor out the Babel Transform Classes plugin, but I'm hoping this will get rid of the Array.prototype.sort polyfill.

<img width="976" height="323" alt="Screenshot 2026-01-30 at 7 48 33 PM" src="https://github.com/user-attachments/assets/e5fdae67-8b41-4100-b84d-76970545ba57" />

