### PR TITLE
feat(animated-bg): adds parallax effect to background animation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Changelog
 
+## 0.68.2
+
+### ✨ New Features
+
+- **Parallax Background Effect**: Added a subtle parallax effect to the animated page background
+  - Background moves slightly opposite to scroll direction, creating depth
+  - Effect scales dynamically based on page height — works smoothly on pages of any length
+  - Canvas extends beyond viewport only by the parallax offset amount (150px by default) for efficiency
+  - Uses GPU-accelerated `transform: translateY()` for smooth performance
+  - New configurable prop: `maxParallaxOffset` (default: 150px) controls total parallax movement
+
+### 🔧 Technical Improvements
+
+- **Dynamic Page Height Detection**: Background now tracks document height on mount and resize
+- **Scroll Progress Calculation**: Parallax offset is percentage-based, spreading evenly across any page length
+- **Performance Optimizations**: Added `willChange: 'transform'` hint for GPU compositing
+
+### 🧪 Testing
+
+- Added comprehensive test coverage for parallax functionality
+- Tests for resize event handling, scroll progress calculation, and edge cases
+- Tests for dynamic page height changes and maxParallaxOffset prop
+
+### 📦 Files Changed
+
+- `theme/src/components/animated-page-background.js`
+- `theme/src/components/animated-page-background.spec.js`
+
+---
+
 ## 0.68.1
 
 ### ♿ Accessibility

--- a/theme/package.json
+++ b/theme/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-theme-chronogrove",
   "description": "A personal website and digital garden theme for GatsbyJS.",
-  "version": "0.68.1",
+  "version": "0.68.2",
   "author": "Chris Vogt <mail@chrisvogt.me> (https://www.chrisvogt.me)",
   "main": "index.js",
   "license": "MIT",


### PR DESCRIPTION
## Overview

This PR adds a parallax scrolling effect to the background animation that renders for dark mode. Giving the feel of depth and dimension, the cosmic ColorBends animation now moves subtly in the opposite direction as you scroll — creating the illusion that the content floats above a distant background layer.

- As you scroll down, the background shifts up slightly (and vice versa)
- The parallax movement is spread evenly across the entire page height, so it works smoothly whether the page is 2,000px or 50,000px tall
- The canvas extends just 150px beyond the viewport (configurable via **maxParallaxOffset**) — no wasteful over-rendering
- Uses GPU-accelerated transform: `translateY()` for smooth performance

## Screenshots

| BEFORE                         | AFTER                        |
| ------------------------------ | ---------------------------- |
| ![before-p](https://github.com/user-attachments/assets/d700aa41-2bd6-4b15-ab2e-f58eec56b444) | ![after-p](https://github.com/user-attachments/assets/15bb8e91-fce3-4557-9562-54846afc405e) |
