### PR TITLE
feat(seo): adds WebSite schema and breadcrumb structured data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,42 @@
 # Changelog
 
+## 0.68.3
+
+### 🔍 SEO Improvements
+
+- **Enhanced Structured Data for Google Sitelinks**: Added comprehensive Schema.org markup to improve search result appearance
+  - **WebSite Schema**: Added `@graph` structure to homepage combining `WebSite` and `Person` schemas with linked `@id` references
+  - **Publisher Relationship**: WebSite schema references Person as publisher for better entity recognition
+  - **Language Declaration**: Added `inLanguage: 'en-US'` to WebSite schema
+  - **Profile Image**: Added ImageObject schema for author avatar
+
+- **Breadcrumb Navigation Schema**: Added BreadcrumbList structured data to blog and media post templates
+  - **Blog Posts**: Home → Category → Post Title breadcrumb trail
+  - **Music Posts**: Home → Category → Post Title breadcrumb trail
+  - **Dynamic Categories**: Breadcrumb category name auto-capitalizes from URL slug
+  - Helps Google understand site hierarchy for potential sitelinks display
+
+### 🧪 Testing
+
+- Added comprehensive test coverage for new structured data
+  - Tests for `@graph` structure with WebSite and Person schemas
+  - Tests for WebSite schema properties (`@id`, `url`, `name`, `publisher`, `inLanguage`)
+  - Tests for Person schema with social profiles (including new BlueSky and Mastodon)
+  - Tests for breadcrumb structured data on post and media templates
+- Updated snapshots to include breadcrumb JSON-LD scripts
+- All 928 tests passing
+
+### 📦 Files Changed
+
+- `www.chrisvogt.me/src/gatsby-theme-chronogrove/templates/home-head.js`
+- `www.chrisvogt.me/src/gatsby-theme-chronogrove/templates/home-head.spec.js`
+- `theme/src/templates/post.js`
+- `theme/src/templates/post.spec.js`
+- `theme/src/templates/media.js`
+- `theme/src/templates/media.spec.js`
+
+---
+
 ## 0.68.2
 
 ### ✨ New Features

--- a/theme/package.json
+++ b/theme/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-theme-chronogrove",
   "description": "A personal website and digital garden theme for GatsbyJS.",
-  "version": "0.68.2",
+  "version": "0.68.3",
   "author": "Chris Vogt <mail@chrisvogt.me> (https://www.chrisvogt.me)",
   "main": "index.js",
   "license": "MIT",

--- a/theme/src/templates/__snapshots__/media.spec.js.snap
+++ b/theme/src/templates/__snapshots__/media.spec.js.snap
@@ -278,6 +278,12 @@ exports[`Media Post renders the Head component with SEO data 1`] = `
 <DocumentFragment>
   <div
     class="seoMock"
-  />
+  >
+    <script
+      type="application/ld+json"
+    >
+      {"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://www.chrisvogt.me"},{"@type":"ListItem","position":2,"name":"Mock Category","item":"https://www.chrisvogt.me/Mock Category"},{"@type":"ListItem","position":3,"name":"A Mock Blog Post"}]}
+    </script>
+  </div>
 </DocumentFragment>
 `;

--- a/theme/src/templates/__snapshots__/post.spec.js.snap
+++ b/theme/src/templates/__snapshots__/post.spec.js.snap
@@ -176,6 +176,12 @@ exports[`Blog Post renders Seo component with the correct props 1`] = `
 <DocumentFragment>
   <div
     class="seoMock"
-  />
+  >
+    <script
+      type="application/ld+json"
+    >
+      {"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://www.chrisvogt.me"},{"@type":"ListItem","position":2,"name":"Mock Category","item":"https://www.chrisvogt.me/Mock Category"},{"@type":"ListItem","position":3,"name":"A Mock Blog Post"}]}
+    </script>
+  </div>
 </DocumentFragment>
 `;

--- a/theme/src/templates/media.js
+++ b/theme/src/templates/media.js
@@ -101,8 +101,41 @@ export const Head = ({ data: { mdx } }) => {
   const banner = getBanner(mdx)
   const description = getDescription(mdx)
   const title = getTitle(mdx)
+  const category = mdx.fields.category
 
-  return <Seo article={true} description={description} image={banner} title={title} />
+  // Format category for display (capitalize first letter)
+  const categoryDisplay = category ? category.charAt(0).toUpperCase() + category.slice(1) : 'Music'
+
+  // Breadcrumb structured data for SEO
+  const breadcrumbData = {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: [
+      {
+        '@type': 'ListItem',
+        position: 1,
+        name: 'Home',
+        item: 'https://www.chrisvogt.me'
+      },
+      {
+        '@type': 'ListItem',
+        position: 2,
+        name: categoryDisplay,
+        item: `https://www.chrisvogt.me/${category || 'music'}`
+      },
+      {
+        '@type': 'ListItem',
+        position: 3,
+        name: title
+      }
+    ]
+  }
+
+  return (
+    <Seo article={true} description={description} image={banner} title={title}>
+      <script type='application/ld+json'>{JSON.stringify(breadcrumbData)}</script>
+    </Seo>
+  )
 }
 
 export const pageQuery = graphql`

--- a/theme/src/templates/media.spec.js
+++ b/theme/src/templates/media.spec.js
@@ -122,4 +122,28 @@ describe('Media Post', () => {
     const { asFragment } = renderWithTheme(<Head data={data} />)
     expect(asFragment()).toMatchSnapshot()
   })
+
+  it('renders breadcrumb structured data', () => {
+    const { container } = renderWithTheme(<Head data={data} />)
+    const script = container.querySelector('script[type="application/ld+json"]')
+
+    expect(script).toBeInTheDocument()
+    const breadcrumbData = JSON.parse(script.textContent)
+
+    expect(breadcrumbData['@context']).toBe('https://schema.org')
+    expect(breadcrumbData['@type']).toBe('BreadcrumbList')
+    expect(breadcrumbData.itemListElement).toHaveLength(3)
+
+    // Check Home breadcrumb
+    expect(breadcrumbData.itemListElement[0].name).toBe('Home')
+    expect(breadcrumbData.itemListElement[0].position).toBe(1)
+
+    // Check Category breadcrumb
+    expect(breadcrumbData.itemListElement[1].name).toBe('Mock Category')
+    expect(breadcrumbData.itemListElement[1].position).toBe(2)
+
+    // Check Media title breadcrumb
+    expect(breadcrumbData.itemListElement[2].name).toBe('A Mock Blog Post')
+    expect(breadcrumbData.itemListElement[2].position).toBe(3)
+  })
 })

--- a/theme/src/templates/post.js
+++ b/theme/src/templates/post.js
@@ -70,8 +70,41 @@ export const Head = ({ data: { mdx } }) => {
   const banner = mdx.frontmatter.banner
   const description = mdx.frontmatter.description
   const title = mdx.frontmatter.title
+  const category = mdx.fields.category
 
-  return <Seo article={true} description={description} image={banner} title={title} />
+  // Format category for display (capitalize first letter)
+  const categoryDisplay = category ? category.charAt(0).toUpperCase() + category.slice(1) : 'Blog'
+
+  // Breadcrumb structured data for SEO
+  const breadcrumbData = {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: [
+      {
+        '@type': 'ListItem',
+        position: 1,
+        name: 'Home',
+        item: 'https://www.chrisvogt.me'
+      },
+      {
+        '@type': 'ListItem',
+        position: 2,
+        name: categoryDisplay,
+        item: `https://www.chrisvogt.me/${category || 'blog'}`
+      },
+      {
+        '@type': 'ListItem',
+        position: 3,
+        name: title
+      }
+    ]
+  }
+
+  return (
+    <Seo article={true} description={description} image={banner} title={title}>
+      <script type='application/ld+json'>{JSON.stringify(breadcrumbData)}</script>
+    </Seo>
+  )
 }
 
 export const pageQuery = graphql`

--- a/theme/src/templates/post.spec.js
+++ b/theme/src/templates/post.spec.js
@@ -71,4 +71,28 @@ describe('Blog Post', () => {
     const { asFragment } = render(<Head data={data} />)
     expect(asFragment()).toMatchSnapshot()
   })
+
+  it('renders breadcrumb structured data', () => {
+    const { container } = render(<Head data={data} />)
+    const script = container.querySelector('script[type="application/ld+json"]')
+
+    expect(script).toBeInTheDocument()
+    const breadcrumbData = JSON.parse(script.textContent)
+
+    expect(breadcrumbData['@context']).toBe('https://schema.org')
+    expect(breadcrumbData['@type']).toBe('BreadcrumbList')
+    expect(breadcrumbData.itemListElement).toHaveLength(3)
+
+    // Check Home breadcrumb
+    expect(breadcrumbData.itemListElement[0].name).toBe('Home')
+    expect(breadcrumbData.itemListElement[0].position).toBe(1)
+
+    // Check Category breadcrumb
+    expect(breadcrumbData.itemListElement[1].name).toBe('Mock Category')
+    expect(breadcrumbData.itemListElement[1].position).toBe(2)
+
+    // Check Post title breadcrumb
+    expect(breadcrumbData.itemListElement[2].name).toBe('A Mock Blog Post')
+    expect(breadcrumbData.itemListElement[2].position).toBe(3)
+  })
 })

--- a/www.chrisvogt.me/package.json
+++ b/www.chrisvogt.me/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "www.chrisvogt.me",
-  "version": "1.11.2",
+  "version": "1.11.3",
   "license": "GPL",
   "scripts": {
     "build": "gatsby build",

--- a/www.chrisvogt.me/src/gatsby-theme-chronogrove/templates/home-head.js
+++ b/www.chrisvogt.me/src/gatsby-theme-chronogrove/templates/home-head.js
@@ -2,6 +2,48 @@ import React from 'react'
 import Seo from '../../../../theme/src/components/seo'
 
 export default function HomeHead() {
+  const structuredData = {
+    '@context': 'https://schema.org',
+    '@graph': [
+      {
+        '@type': 'WebSite',
+        '@id': 'https://www.chrisvogt.me/#website',
+        url: 'https://www.chrisvogt.me',
+        name: 'Chris Vogt',
+        description: 'Software Engineer in San Francisco blogging about code, photography and piano music.',
+        publisher: {
+          '@id': 'https://www.chrisvogt.me/#person'
+        },
+        inLanguage: 'en-US'
+      },
+      {
+        '@type': 'Person',
+        '@id': 'https://www.chrisvogt.me/#person',
+        name: 'Chris Vogt',
+        url: 'https://www.chrisvogt.me',
+        image: {
+          '@type': 'ImageObject',
+          url: 'https://www.chrisvogt.me/images/avatar-256px.jpg'
+        },
+        sameAs: [
+          'https://linkedin.com/in/cjvogt',
+          'https://github.com/chrisvogt',
+          'https://x.com/c1v0',
+          'https://twitter.com/c1v0',
+          'https://www.instagram.com/c1v0',
+          'https://stackoverflow.com/users/1391826/chris-vogt',
+          'https://bsky.app/profile/chrisvogt.me',
+          'https://hachyderm.io/@chrisvogt'
+        ],
+        jobTitle: 'Principal Software Engineer',
+        worksFor: {
+          '@type': 'Organization',
+          name: 'GoDaddy'
+        }
+      }
+    ]
+  }
+
   return (
     <Seo
       title='Home'
@@ -10,27 +52,7 @@ export default function HomeHead() {
     >
       <meta property='og:url' content='https://www.chrisvogt.me' />
       <meta property='og:type' content='website' />
-      <script type='application/ld+json'>
-        {`{
-          "@context": "https://schema.org",
-          "@type": "Person",
-          "name": "Chris Vogt",
-          "url": "https://www.chrisvogt.me",
-          "sameAs": [
-            "https://linkedin.com/in/cjvogt",
-            "https://github.com/chrisvogt",
-            "https://x.com/c1v0",
-            "https://twitter.com/c1v0",
-            "https://www.instagram.com/c1v0",
-            "https://stackoverflow.com/users/1391826/chris-vogt"
-          ],
-          "jobTitle": "Principal Software Engineer",
-          "worksFor": {
-            "@type": "Organization",
-            "name": "GoDaddy"
-          }
-        }`}
-      </script>
+      <script type='application/ld+json'>{JSON.stringify(structuredData)}</script>
     </Seo>
   )
 }

--- a/www.chrisvogt.me/src/gatsby-theme-chronogrove/templates/home-head.spec.js
+++ b/www.chrisvogt.me/src/gatsby-theme-chronogrove/templates/home-head.spec.js
@@ -41,7 +41,7 @@ describe('HomeHead (chrisvogt.me shadow)', () => {
     expect(typeMeta).toHaveAttribute('content', 'website')
   })
 
-  it('renders structured data with Chris Vogt-specific information', () => {
+  it('renders structured data with @graph containing WebSite and Person schemas', () => {
     const { container } = render(<HomeHead />)
     const script = container.querySelector('script[type="application/ld+json"]')
 
@@ -49,19 +49,45 @@ describe('HomeHead (chrisvogt.me shadow)', () => {
     const structuredData = JSON.parse(script.textContent)
 
     expect(structuredData['@context']).toBe('https://schema.org')
-    expect(structuredData['@type']).toBe('Person')
-    expect(structuredData.name).toBe('Chris Vogt')
-    expect(structuredData.url).toBe('https://www.chrisvogt.me')
-    expect(structuredData.jobTitle).toBe('Principal Software Engineer')
-    expect(structuredData.worksFor.name).toBe('GoDaddy')
-    expect(structuredData.sameAs).toContain('https://github.com/chrisvogt')
-    expect(structuredData.sameAs).toContain('https://linkedin.com/in/cjvogt')
+    expect(structuredData['@graph']).toBeDefined()
+    expect(structuredData['@graph']).toHaveLength(2)
   })
 
-  it('includes social media profiles in structured data', () => {
+  it('includes WebSite schema with correct information', () => {
     const { container } = render(<HomeHead />)
     const script = container.querySelector('script[type="application/ld+json"]')
     const structuredData = JSON.parse(script.textContent)
+
+    const websiteSchema = structuredData['@graph'].find(item => item['@type'] === 'WebSite')
+
+    expect(websiteSchema).toBeDefined()
+    expect(websiteSchema['@id']).toBe('https://www.chrisvogt.me/#website')
+    expect(websiteSchema.url).toBe('https://www.chrisvogt.me')
+    expect(websiteSchema.name).toBe('Chris Vogt')
+    expect(websiteSchema.inLanguage).toBe('en-US')
+    expect(websiteSchema.publisher['@id']).toBe('https://www.chrisvogt.me/#person')
+  })
+
+  it('includes Person schema with Chris Vogt-specific information', () => {
+    const { container } = render(<HomeHead />)
+    const script = container.querySelector('script[type="application/ld+json"]')
+    const structuredData = JSON.parse(script.textContent)
+
+    const personSchema = structuredData['@graph'].find(item => item['@type'] === 'Person')
+
+    expect(personSchema).toBeDefined()
+    expect(personSchema['@id']).toBe('https://www.chrisvogt.me/#person')
+    expect(personSchema.name).toBe('Chris Vogt')
+    expect(personSchema.url).toBe('https://www.chrisvogt.me')
+    expect(personSchema.jobTitle).toBe('Principal Software Engineer')
+    expect(personSchema.worksFor.name).toBe('GoDaddy')
+  })
+
+  it('includes social media profiles in Person schema', () => {
+    const { container } = render(<HomeHead />)
+    const script = container.querySelector('script[type="application/ld+json"]')
+    const structuredData = JSON.parse(script.textContent)
+    const personSchema = structuredData['@graph'].find(item => item['@type'] === 'Person')
 
     const expectedProfiles = [
       'https://linkedin.com/in/cjvogt',
@@ -69,11 +95,13 @@ describe('HomeHead (chrisvogt.me shadow)', () => {
       'https://x.com/c1v0',
       'https://twitter.com/c1v0',
       'https://www.instagram.com/c1v0',
-      'https://stackoverflow.com/users/1391826/chris-vogt'
+      'https://stackoverflow.com/users/1391826/chris-vogt',
+      'https://bsky.app/profile/chrisvogt.me',
+      'https://hachyderm.io/@chrisvogt'
     ]
 
     expectedProfiles.forEach(profile => {
-      expect(structuredData.sameAs).toContain(profile)
+      expect(personSchema.sameAs).toContain(profile)
     })
   })
 })


### PR DESCRIPTION
## 🔍 SEO: Add WebSite Schema and Breadcrumb Structured Data for Google Sitelinks

This PR adds comprehensive Schema.org structured data to improve the site's eligibility for Google Sitelinks in search results.

### What are Sitelinks?

Sitelinks are the additional page links Google sometimes displays below a main search result. They help users navigate directly to important sections of a website. Example:

> **Chris Vogt** - chrisvogt.me  
> └── About  
> └── Blog  
> └── Music

### Changes

#### 1. Homepage: WebSite + Person Schema (`@graph`)

Updated the homepage structured data to use a `@graph` array that includes both schemas with linked `@id` references:

{
  "@context": "https://schema.org",
  "@graph": [
    {
      "@type": "WebSite",
      "@id": "https://www.chrisvogt.me/#website",
      "publisher": { "@id": "https://www.chrisvogt.me/#person" },
      ...
    },
    {
      "@type": "Person",
      "@id": "https://www.chrisvogt.me/#person",
      ...
    }
  ]
}
