### PR TITLE
feat(plugins): factors out Theme UI style guide in production

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 0.71.2
+
+### 🚀 Performance Improvements
+
+- **Conditional Style Guide Plugin**: `gatsby-theme-style-guide` is now only included in development builds
+  - **Root Cause**: The style guide plugin was loading Google Fonts (Roboto) in production, triggering Lighthouse warnings about `font-display` not being set to `swap`
+  - **Solution**: Added conditional plugin inclusion based on `NODE_ENV` - plugin only loads when `NODE_ENV !== 'production'`
+  - **Impact**: Production builds no longer load unnecessary Google Fonts, improving Lighthouse performance scores and reducing network requests
+  - **Development**: Style guide remains available at `/___style-guide` during local development
+
+### 📦 Files Changed
+
+- `theme/gatsby-config.js` (added `isDevelopment` check, conditional plugin spread)
+
+---
+
 ## 0.71.1
 
 ### 🐛 Bug Fixes

--- a/theme/gatsby-config.js
+++ b/theme/gatsby-config.js
@@ -39,6 +39,9 @@ const path = require('path')
 // This handles merging default theme options with user-provided options
 const { mergeConfig } = require('./src/data/theme-config')
 
+// Only include development-only plugins when not in production
+const isDevelopment = process.env.NODE_ENV !== 'production'
+
 /**
  * Main theme configuration function
  *
@@ -220,15 +223,18 @@ module.exports = (themeOptions = {}) => {
       'gatsby-plugin-emotion',
 
       /**
-       * Style Guide Plugin
+       * Style Guide Plugin (Development Only)
        *
        * Provides a development style guide page for Theme UI.
        * This is useful during development to see all available
        * theme components and design tokens.
        *
        * Accessible at /___style-guide during development.
+       *
+       * Note: Only included in development to avoid loading Google Fonts
+       * (Roboto) in production, which improves Lighthouse performance scores.
        */
-      'gatsby-theme-style-guide',
+      ...(isDevelopment ? ['gatsby-theme-style-guide'] : []),
 
       /**
        * JSON Transformer

--- a/theme/package.json
+++ b/theme/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-theme-chronogrove",
   "description": "A personal website and digital garden theme for GatsbyJS.",
-  "version": "0.71.1",
+  "version": "0.71.2",
   "author": "Chris Vogt <mail@chrisvogt.me> (https://www.chrisvogt.me)",
   "main": "index.js",
   "license": "MIT",


### PR DESCRIPTION
## Overview

### Summary

Makes gatsby-theme-style-guide load only in development, fixing a Lighthouse performance warning about Google Fonts.

### Problem

Lighthouse flagged that Roboto font from Google Fonts CDN was missing font-display: swap, impacting First Contentful Paint (FCP) scores. The font was being loaded by gatsby-theme-style-guide which is only needed during development.

### Solution

- Added conditional plugin inclusion based on NODE_ENV:
- Development: Style guide loads normally, accessible at /___style-guide
- Production: Plugin is excluded, no Google Fonts loaded
