### PR TITLE
fix: resolves lightgallery and spotify embed warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## 0.71.3
+
+### 🐛 Bug Fixes
+
+- **Spotify Embed Warning**: Fixed browser warning "Allow attribute will take precedence over 'allowfullscreen'"
+  - **Root Cause**: Spotify's oEmbed API returns iframe HTML with both the deprecated `allowfullscreen` attribute and the modern `allow` attribute
+  - **Solution**: Sanitize the embed HTML to remove the deprecated `allowfullscreen` attribute before rendering
+  - **Impact**: Eliminates console warning when clicking Spotify items on the Home page
+
+- **lightGallery License Key on Blog Pages**: Fixed "license key is not valid for production use" error on blog photo galleries
+  - **Root Cause**: The `PhotoGallery` component in `www.chrisvogt.me/components/` was missing the `licenseKey` prop that home page widgets already use
+  - **Solution**: Added `licenseKey={process.env.GATSBY_LIGHT_GALLERY_LICENSE_KEY}` to the LightGallery component
+  - **Impact**: Blog photography posts no longer show license validation errors in production
+
+### 📦 Files Changed
+
+- `theme/src/shortcodes/spotify.js` (sanitize oEmbed HTML to remove deprecated attribute)
+- `www.chrisvogt.me/components/PhotoGallery.js` (add licenseKey prop)
+
+---
+
 ## 0.71.2
 
 ### 🚀 Performance Improvements

--- a/theme/package.json
+++ b/theme/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-theme-chronogrove",
   "description": "A personal website and digital garden theme for GatsbyJS.",
-  "version": "0.71.2",
+  "version": "0.71.3",
   "author": "Chris Vogt <mail@chrisvogt.me> (https://www.chrisvogt.me)",
   "main": "index.js",
   "license": "MIT",

--- a/theme/src/shortcodes/spotify.js
+++ b/theme/src/shortcodes/spotify.js
@@ -26,7 +26,9 @@ const Spotify = ({ spotifyURL }) => {
         }
 
         const data = await response.json()
-        setEmbedHtml(data.html)
+        // Remove deprecated allowfullscreen attribute that conflicts with allow attribute
+        const sanitizedHtml = data.html?.replace(/\s*allowfullscreen/gi, '')
+        setEmbedHtml(sanitizedHtml)
       } catch (error) {
         console.error('Failed to fetch Spotify embed:', error)
         setError('Failed to load Spotify embed')

--- a/theme/src/shortcodes/spotify.spec.js
+++ b/theme/src/shortcodes/spotify.spec.js
@@ -60,6 +60,46 @@ describe('Spotify', () => {
     })
   })
 
+  it('removes deprecated allowfullscreen attribute from embed HTML', async () => {
+    const mockResponse = {
+      html: '<iframe src="https://open.spotify.com/embed/track/123" allowfullscreen allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture"></iframe>'
+    }
+    fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockResponse
+    })
+
+    const { container } = render(<Spotify spotifyURL='https://open.spotify.com/track/123' />)
+
+    await waitFor(() => {
+      expect(container.innerHTML).toContain('iframe')
+    })
+
+    // Verify allowfullscreen attribute was removed
+    expect(container.innerHTML).not.toContain('allowfullscreen')
+    // Verify the allow attribute is still present
+    expect(container.innerHTML).toContain('allow=')
+  })
+
+  it('handles case-insensitive allowFullScreen attribute removal', async () => {
+    const mockResponse = {
+      html: '<iframe src="https://open.spotify.com/embed/track/123" allowFullScreen allow="fullscreen"></iframe>'
+    }
+    fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockResponse
+    })
+
+    const { container } = render(<Spotify spotifyURL='https://open.spotify.com/track/123' />)
+
+    await waitFor(() => {
+      expect(container.innerHTML).toContain('iframe')
+    })
+
+    // Verify allowFullScreen (camelCase) was also removed
+    expect(container.innerHTML.toLowerCase()).not.toContain('allowfullscreen')
+  })
+
   it('does not render when no spotifyURL is provided', () => {
     const { container } = render(<Spotify />)
     expect(container.firstChild).toBeNull()

--- a/www.chrisvogt.me/components/PhotoGallery.js
+++ b/www.chrisvogt.me/components/PhotoGallery.js
@@ -42,6 +42,7 @@ const LightGalleryComponent = ({ lightGalleryRef, photos }) => {
         }
       }}
       plugins={[lgThumbnail, lgZoom]}
+      licenseKey={process.env.GATSBY_LIGHT_GALLERY_LICENSE_KEY}
       download={false}
       dynamic
       dynamicEl={photos.map(photo => ({


### PR DESCRIPTION
## Summary

Fixes two production console warnings/errors.

## Changes

### 🐛 Bug Fixes

**Spotify Embed Warning**
- Fixed: "Allow attribute will take precedence over 'allowfullscreen'"
- Sanitizes Spotify oEmbed HTML to remove the deprecated `allowfullscreen` attribute before rendering

**lightGallery License Key on Blog Pages**
- Fixed: "license key is not valid for production use" error on `/photography` blog posts
- Added missing `licenseKey` prop to `PhotoGallery` component (home page widgets already had this)

### 🧪 Testing

- Added 2 new tests for `allowfullscreen` attribute sanitization
- Spotify shortcode maintains 100% test coverage
- All 1025 tests passing

## Files Changed

- `theme/src/shortcodes/spotify.js`
- `theme/src/shortcodes/spotify.spec.js`
- `www.chrisvogt.me/components/PhotoGallery.js`
- `theme/package.json` (version bump to 0.71.3)
- `CHANGELOG.md`