### PR TITLE
fix(theme-ui): replaces custom CacheProvider with default Emotion cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 0.72.1
+
+### 🐛 Bug Fixes
+
+- **Header/nav font FOUC in production**: Fixed flash of unstyled content (FOUC) on hard reload where the header, skip link, and home left navigation briefly rendered as plain links before applying theme fonts
+  - **Root cause**: A custom Emotion cache in `wrapRootElement` was used for layout/header/nav styles, while `gatsby-plugin-emotion` extracts critical CSS using the default cache during SSR, so those styles were never inlined in the initial HTML
+  - **Fix**: Removed the custom `CacheProvider`/`createCache` so the app uses Emotion’s default cache; production builds now inline critical CSS for the header and nav correctly
+  - Only reproducible in production (e.g. after excluding `gatsby-theme-style-guide` in prod in 0.72.0); dev was unaffected
+
+### 📦 Files Changed
+
+- `theme/wrapRootElement.js` (removed custom Emotion cache)
+- `theme/wrapRootElement.spec.js` (removed CacheProvider test)
+
+---
+
 ## 0.72.0
 
 ### ✨ Features

--- a/theme/package.json
+++ b/theme/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-theme-chronogrove",
   "description": "A personal website and digital garden theme for GatsbyJS.",
-  "version": "0.72.0",
+  "version": "0.72.1",
   "author": "Chris Vogt <mail@chrisvogt.me> (https://www.chrisvogt.me)",
   "main": "index.js",
   "license": "MIT",

--- a/theme/wrapRootElement.js
+++ b/theme/wrapRootElement.js
@@ -1,6 +1,5 @@
 /** @jsx jsx */
-import { Global, CacheProvider } from '@emotion/react'
-import createCache from '@emotion/cache'
+import { Global } from '@emotion/react'
 import { jsx, useColorMode } from 'theme-ui'
 import { MDXProvider } from '@mdx-js/react'
 import { Provider as ReduxProvider } from 'react-redux'
@@ -13,9 +12,6 @@ import RootWrapper from './src/components/root-wrapper'
 import store from './src/store'
 import theme from './src/gatsby-plugin-theme-ui'
 import YouTube from './src/shortcodes/youtube'
-
-// Create an Emotion cache
-const cache = createCache({ key: 'css', prepend: true })
 
 // Create a TanStack Query client with optimized defaults for Gatsby
 const queryClient = new QueryClient({
@@ -58,16 +54,14 @@ const components = {
 
 const WrapRootElement = ({ element }) => (
   <QueryClientProvider client={queryClient}>
-    <CacheProvider value={cache}>
-      <ReduxProvider store={store}>
-        <ThemeUIProvider theme={theme}>
-          <Global styles={theme.global} />
-          <MDXProvider components={components}>
-            <RootWrapper>{element}</RootWrapper>
-          </MDXProvider>
-        </ThemeUIProvider>
-      </ReduxProvider>
-    </CacheProvider>
+    <ReduxProvider store={store}>
+      <ThemeUIProvider theme={theme}>
+        <Global styles={theme.global} />
+        <MDXProvider components={components}>
+          <RootWrapper>{element}</RootWrapper>
+        </MDXProvider>
+      </ThemeUIProvider>
+    </ReduxProvider>
   </QueryClientProvider>
 )
 

--- a/theme/wrapRootElement.spec.js
+++ b/theme/wrapRootElement.spec.js
@@ -41,11 +41,6 @@ describe('wrapRootElement', () => {
     expect(container).toBeDefined()
   })
 
-  it('renders CacheProvider wrapper', () => {
-    const { container } = render(<WrapRootElement element={<span>Cache Test</span>} />)
-    expect(container).toBeDefined()
-  })
-
   it('renders ReduxProvider wrapper', () => {
     const { container } = render(<WrapRootElement element={<span>Redux Test</span>} />)
     expect(container).toBeDefined()


### PR DESCRIPTION
## Overview

This PR fixes a FOUC I'm noticing in Production for the header and top navigation elements. That issue was being masked by the Style Guide plugin, which was removed in #468.

## Screenshots

A demonstration of the issue.

https://github.com/user-attachments/assets/a4ee045f-8de9-4a5a-b911-6dde3502d2b5

