### PR TITLE
fix(ai-summaries): updates endpoints to fixed versions

### DIFF
--- a/www.chrisvogt.me/gatsby-config.js
+++ b/www.chrisvogt.me/gatsby-config.js
@@ -52,7 +52,7 @@ module.exports = {
       },
       goodreads: {
         username: 'chrisvogt',
-        widgetDataSource: 'https://metrics.chrisvogt.me/api/widgets/goodreads?t=1771095932'
+        widgetDataSource: 'https://metrics.chrisvogt.me/api/widgets/goodreads?t=1771106360'
       },
       instagram: {
         username: 'chrisvogt',
@@ -64,7 +64,7 @@ module.exports = {
       },
       steam: {
         username: 'chrisvogt',
-        widgetDataSource: 'https://metrics.chrisvogt.me/api/widgets/steam'
+        widgetDataSource: 'https://metrics.chrisvogt.me/api/widgets/steam?t=1771106360'
       }
     },
     webmentionUrl: 'https://webmention.io/www.chrisvogt.me/webmention'


### PR DESCRIPTION
Quick, small PR to add a timestamp to Goodreads and Steam widget calls, breaking the cached version and switching to the new version from chrisvogt/metrics#92. This restores the AI summaries on those widgets.