### PR TITLE
feat(gatsby-*): exports theme gatsby wrappers for consumers to reuse

### DIFF
--- a/theme/README.md
+++ b/theme/README.md
@@ -379,6 +379,34 @@ pnpm test:coverage
 - Improved error handling in navigation data hooks
 - Better separation of concerns between theme and site-specific configuration
 
+## 🔍 Troubleshooting
+
+### Dark/light mode not updating (workspace or local dependency)
+
+If you use the theme as a **workspace** or **local** dependency (e.g. `"gatsby-theme-chronogrove": "workspace:*"` or `file:../theme`) and the theme toggle or navigation doesn’t update colors correctly, Gatsby may not be applying the theme’s browser/SSR APIs. Re-export them from your site so color-mode sync runs:
+
+**`gatsby-browser.js`** (in your site root):
+
+```javascript
+const themeBrowser = require('gatsby-theme-chronogrove/gatsby-browser')
+exports.wrapRootElement = themeBrowser.wrapRootElement
+exports.onRouteUpdate = themeBrowser.onRouteUpdate
+exports.shouldUpdateScroll = themeBrowser.shouldUpdateScroll
+```
+
+**`gatsby-ssr.js`** (in your site root):
+
+```javascript
+const themeSSR = require('gatsby-theme-chronogrove/gatsby-ssr')
+exports.wrapRootElement = themeSSR.wrapRootElement
+exports.onRenderBody = themeSSR.onRenderBody
+exports.onPreRenderHTML = themeSSR.onPreRenderHTML
+```
+
+If theme switching was working and then breaks after pulling theme changes, try clearing the cache: `gatsby clean` then `gatsby develop`.
+
+---
+
 ## 🤝 Contributing
 
 1. Fork the repository

--- a/www.chronogrove.com/README.md
+++ b/www.chronogrove.com/README.md
@@ -24,6 +24,20 @@ cd www.chronogrove.com
 pnpm develop
 ```
 
+### Theme switching (dark/light mode)
+
+If dark/light mode doesn’t update correctly after changing the theme, clear the cache and restart:
+
+```bash
+cd www.chronogrove.com
+pnpm run clean
+pnpm develop
+# or in one step:
+pnpm run develop:clean
+```
+
+This site re-exports the theme’s `gatsby-browser.js` and `gatsby-ssr.js` so color-mode behavior matches www.chrisvogt.me when the theme is used as a workspace dependency.
+
 ## Content Structure
 
 - `content/blog/` - Blog posts in MDX format

--- a/www.chronogrove.com/gatsby-browser.js
+++ b/www.chronogrove.com/gatsby-browser.js
@@ -1,0 +1,13 @@
+/**
+ * Re-export the theme's browser APIs so color-mode sync and route reconciliation
+ * run on this site. When the theme is used as a workspace dependency, the
+ * theme's gatsby-browser.js may not be applied; this ensures the same
+ * behavior as www.chrisvogt.me (theme toggle and navigation keep dark/light
+ * mode in sync). We re-export wrapRootElement so the theme's root (and thus
+ * RootWrapper + color-mode sync) is guaranteed to run from the site entry point.
+ */
+const themeBrowser = require('gatsby-theme-chronogrove/gatsby-browser')
+
+exports.wrapRootElement = themeBrowser.wrapRootElement
+exports.onRouteUpdate = themeBrowser.onRouteUpdate
+exports.shouldUpdateScroll = themeBrowser.shouldUpdateScroll

--- a/www.chronogrove.com/gatsby-ssr.js
+++ b/www.chronogrove.com/gatsby-ssr.js
@@ -1,0 +1,10 @@
+/**
+ * Re-export the theme's SSR APIs so the color-mode no-flash script and fallback
+ * CSS are injected into the head. When the theme is used as a workspace
+ * dependency, this ensures the same initial theme state as www.chrisvogt.me.
+ */
+const themeSSR = require('gatsby-theme-chronogrove/gatsby-ssr')
+
+exports.wrapRootElement = themeSSR.wrapRootElement
+exports.onRenderBody = themeSSR.onRenderBody
+exports.onPreRenderHTML = themeSSR.onPreRenderHTML

--- a/www.chronogrove.com/package.json
+++ b/www.chronogrove.com/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "scripts": {
     "develop": "gatsby develop",
+    "develop:clean": "gatsby clean && gatsby develop",
     "build": "gatsby build",
     "serve": "gatsby serve",
     "clean": "gatsby clean"


### PR DESCRIPTION
## Summary

Fixes dark/light theme switching on the chronogrove demo site when the theme is used as a workspace dependency, and documents the same approach for other consumers in that setup.

## Problem

- Theme switching works on **www.chrisvogt.me** but was broken on **www.chronogrove.com**: toggling to dark mode did not update the background animation or text; they stayed in the previous color mode.
- When the theme is used as a workspace/local dependency, Gatsby may not apply the theme’s `gatsby-browser.js` and `gatsby-ssr.js`, so color-mode sync and route reconciliation never run.

## Solution

### 1. Chronogrove demo site: re-export theme browser and SSR APIs

- **`www.chronogrove.com/gatsby-browser.js`** – Re-exports the theme’s `wrapRootElement`, `onRouteUpdate`, and `shouldUpdateScroll` so the theme root (with `RootWrapper` and color-mode sync) and route hooks run from the site.
- **`www.chronogrove.com/gatsby-ssr.js`** – Re-exports the theme’s `wrapRootElement`, `onRenderBody`, and `onPreRenderHTML` so the no-flash script and fallback CSS are injected.

This guarantees the same color-mode behavior as www.chrisvogt.me for the demo site.

### 2. Chronogrove: clean + develop and README

- **`www.chronogrove.com/package.json`** – Added `develop:clean` script (`gatsby clean && gatsby develop`).
- **`www.chronogrove.com/README.md`** – Documented theme-switching troubleshooting (run `clean` then `develop`, or `develop:clean`) and noted that this site re-exports the theme’s browser/SSR files.

### 3. Theme README: troubleshooting for workspace/local consumers

- **`theme/README.md`** – New **Troubleshooting** section for consumers who use the theme as a workspace or local dependency:
  - How to add `gatsby-browser.js` and `gatsby-ssr.js` that re-export the theme’s APIs (with copy-paste snippets).
  - Suggestion to run `gatsby clean` then `gatsby develop` if theme switching breaks after pulling theme changes.

## What is unchanged

- **www.chrisvogt.me** – No code or config changes; it already works.
- **Install instructions** – No change for npm/pnpm installs; the theme’s APIs are applied normally. The new docs are only for the workspace/local case.

## Testing

- Run the chronogrove site with a clean cache (`pnpm --filter www.chronogrove.com run develop:clean` or `cd www.chronogrove.com && pnpm run clean && pnpm develop`).
- Toggle dark/light mode and confirm background and text update.
- Navigate between pages and toggle again; color mode should stay in sync.

## Files changed

- `www.chronogrove.com/gatsby-browser.js` (new)
- `www.chronogrove.com/gatsby-ssr.js` (new)
- `www.chronogrove.com/package.json` (add `develop:clean` script)
- `www.chronogrove.com/README.md` (theme-switching + re-export note)
- `theme/README.md` (Troubleshooting: dark/light mode for workspace/local dependency)