### PR TITLE
feat(discogs): fixes layout shift using skeleton loader in modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## 0.72.19
+
+### ✨ Improvements
+
+- **Discogs modal: fix layout shift and add loading skeleton for cover artwork**.
+  - **Layout shift**: Cover image container now reserves fixed dimensions (280×280px) so the modal no longer jumps when the image loads.
+  - **Loading state**: A `RectShape` skeleton (matching Steam, Instagram, Goodreads patterns) displays until the artwork finishes downloading.
+  - **Behavior**: `onLoad` tracks when the image has loaded; skeleton fades out and image fades in. State resets when selecting a different record.
+
+### 🧪 Tests
+
+- Added tests for Discogs modal: image `onLoad` handler, backdrop click, body scroll lock, and cover URL change reset.
+- Improved coverage for `discogs-modal.js` (100% statements, functions, lines; 97%+ branches).
+
+### 📦 Files Changed
+
+- `theme/package.json` (version 0.72.19)
+- `theme/src/components/widgets/discogs/discogs-modal.js` (skeleton, fixed dimensions, image load state)
+- `theme/src/components/widgets/discogs/discogs-modal.spec.js` (expanded coverage)
+
+---
+
 ## 0.72.18
 
 ### 🐛 Bug Fixes

--- a/theme/package.json
+++ b/theme/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-theme-chronogrove",
   "description": "A personal website and digital garden theme for GatsbyJS.",
-  "version": "0.72.18",
+  "version": "0.72.19",
   "author": "Chris Vogt <mail@chrisvogt.me> (https://www.chrisvogt.me)",
   "main": "index.js",
   "license": "MIT",

--- a/theme/src/components/widgets/discogs/__snapshots__/discogs-modal.spec.js.snap
+++ b/theme/src/components/widgets/discogs/__snapshots__/discogs-modal.spec.js.snap
@@ -61,10 +61,10 @@ exports[`DiscogsModal cover image handling handles release with missing cover im
           class="css-73r8mm"
         >
           <div
-            class="css-32g3ao"
+            class="css-byjint"
           >
             <div
-              class="css-w2j0pp"
+              class="css-cq2t9"
             >
               No Image Available
             </div>
@@ -297,11 +297,19 @@ exports[`DiscogsModal dark mode renders with dark mode styling 1`] = `
           class="css-73r8mm"
         >
           <div
-            class="css-32g3ao"
+            class="css-byjint"
           >
+            <div
+              class="show-loading-animation css-54je37"
+            >
+              <div
+                class="rect-shape"
+                style="background-color: rgb(58, 58, 74); width: 100%; height: 100%; margin-right: 10px; border-radius: 8px;"
+              />
+            </div>
             <img
               alt="Test Album album cover"
-              class="css-1qght08"
+              class="css-1f960d3"
               src="https://example.com/cover.jpg"
             />
           </div>
@@ -533,10 +541,10 @@ exports[`DiscogsModal handles release with empty arrays 1`] = `
           class="css-73r8mm"
         >
           <div
-            class="css-32g3ao"
+            class="css-byjint"
           >
             <div
-              class="css-w2j0pp"
+              class="css-cq2t9"
             >
               No Image Available
             </div>
@@ -637,10 +645,10 @@ exports[`DiscogsModal handles release with missing basicInformation 1`] = `
           class="css-73r8mm"
         >
           <div
-            class="css-32g3ao"
+            class="css-byjint"
           >
             <div
-              class="css-w2j0pp"
+              class="css-cq2t9"
             >
               No Image Available
             </div>
@@ -725,11 +733,19 @@ exports[`DiscogsModal renders modal with complete release data 1`] = `
           class="css-73r8mm"
         >
           <div
-            class="css-32g3ao"
+            class="css-byjint"
           >
+            <div
+              class="show-loading-animation css-54je37"
+            >
+              <div
+                class="rect-shape"
+                style="background-color: rgb(239, 239, 239); width: 100%; height: 100%; margin-right: 10px; border-radius: 8px;"
+              />
+            </div>
             <img
               alt="Test Album album cover"
-              class="css-1qght08"
+              class="css-1f960d3"
               src="https://example.com/cover.jpg"
             />
           </div>
@@ -961,10 +977,10 @@ exports[`DiscogsModal renders modal with minimal release data 1`] = `
           class="css-73r8mm"
         >
           <div
-            class="css-32g3ao"
+            class="css-byjint"
           >
             <div
-              class="css-w2j0pp"
+              class="css-cq2t9"
             >
               No Image Available
             </div>

--- a/theme/src/components/widgets/discogs/discogs-modal.js
+++ b/theme/src/components/widgets/discogs/discogs-modal.js
@@ -1,17 +1,28 @@
 /** @jsx jsx */
+import React from 'react'
 import { jsx, useThemeUI } from 'theme-ui'
 import { createPortal } from 'react-dom'
-import { useEffect, useRef } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { Themed } from '@theme-ui/mdx'
 import { faTimes, faExternalLinkAlt } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { RectShape } from 'react-placeholder/lib/placeholders'
 import isDarkMode from '../../../helpers/isDarkMode'
+
+import 'react-placeholder/lib/reactPlaceholder.css'
 
 const DiscogsModal = ({ isOpen, onClose, release }) => {
   const { colorMode } = useThemeUI()
   const darkMode = isDarkMode(colorMode)
   const modalRef = useRef(null)
   const previousActiveElement = useRef(null)
+  const [imageLoaded, setImageLoaded] = useState(false)
+
+  // Reset image load state when release/cover changes
+  const coverImageUrl = release?.basicInformation?.cdnCoverUrl || release?.basicInformation?.coverImage
+  useEffect(() => {
+    setImageLoaded(false)
+  }, [coverImageUrl])
 
   // Handle escape key
   useEffect(() => {
@@ -56,7 +67,7 @@ const DiscogsModal = ({ isOpen, onClose, release }) => {
   if (!isOpen || !release) return null
 
   const { basicInformation = {}, resource = {} } = release
-  const { title, year, artists = [], genres = [], styles = [], cdnCoverUrl, coverImage } = basicInformation
+  const { title, year, artists = [], genres = [], styles = [] } = basicInformation
 
   // Extract additional data from resource object
   const { uri: discogsUrl, tracklist = [] } = resource
@@ -67,8 +78,6 @@ const DiscogsModal = ({ isOpen, onClose, release }) => {
   const artistNames = (artists || []).map(artist => artist.name).join(', ')
   const genreList = (genres || []).join(', ')
   const styleList = (styles || []).join(', ')
-
-  const coverImageUrl = cdnCoverUrl || coverImage
 
   return createPortal(
     <div
@@ -189,32 +198,64 @@ const DiscogsModal = ({ isOpen, onClose, release }) => {
               alignItems: 'start'
             }}
           >
-            {/* Cover image */}
+            {/* Cover image - fixed dimensions prevent layout shift */}
             <div
               sx={{
+                position: 'relative',
                 display: 'flex',
                 justifyContent: 'center',
                 alignItems: 'center',
-                minHeight: '300px'
+                width: '280px',
+                height: '280px',
+                flexShrink: 0
               }}
             >
               {coverImageUrl ? (
-                <Themed.img
-                  src={coverImageUrl}
-                  alt={`${title} album cover`}
-                  sx={{
-                    maxWidth: '100%',
-                    maxHeight: '400px',
-                    borderRadius: 2,
-                    boxShadow: 'lg',
-                    objectFit: 'contain'
-                  }}
-                />
+                <>
+                  {/* Skeleton shown until image loads */}
+                  {!imageLoaded && (
+                    <div
+                      className='show-loading-animation'
+                      sx={{
+                        position: 'absolute',
+                        inset: 0,
+                        borderRadius: 2,
+                        overflow: 'hidden'
+                      }}
+                    >
+                      <RectShape
+                        color={darkMode ? '#3a3a4a' : '#efefef'}
+                        style={{
+                          width: '100%',
+                          height: '100%',
+                          borderRadius: '8px'
+                        }}
+                      />
+                    </div>
+                  )}
+                  <Themed.img
+                    src={coverImageUrl}
+                    alt={`${title} album cover`}
+                    onLoad={() => setImageLoaded(true)}
+                    sx={{
+                      position: 'relative',
+                      maxWidth: '100%',
+                      maxHeight: '100%',
+                      width: 'auto',
+                      height: 'auto',
+                      borderRadius: 2,
+                      boxShadow: 'lg',
+                      objectFit: 'contain',
+                      opacity: imageLoaded ? 1 : 0,
+                      transition: 'opacity 0.2s ease-in-out'
+                    }}
+                  />
+                </>
               ) : (
                 <div
                   sx={{
-                    width: '200px',
-                    height: '200px',
+                    width: '100%',
+                    height: '100%',
                     backgroundColor: darkMode ? '#2d3748' : '#f7fafc',
                     borderRadius: 2,
                     display: 'flex',

--- a/theme/src/components/widgets/discogs/discogs-modal.spec.js
+++ b/theme/src/components/widgets/discogs/discogs-modal.spec.js
@@ -4,6 +4,10 @@ import '@testing-library/jest-dom'
 
 import DiscogsModal from './discogs-modal'
 
+// Helper to find the backdrop (first Close button) vs the X button (second)
+const getBackdropButton = () => screen.getAllByRole('button', { name: 'Close modal' })[0]
+const getCloseXButton = () => screen.getAllByRole('button', { name: 'Close modal' })[1]
+
 // Mock createPortal to render directly in the test environment
 jest.mock('react-dom', () => ({
   ...jest.requireActual('react-dom'),
@@ -126,6 +130,28 @@ describe('DiscogsModal', () => {
     expect(asFragment()).toMatchSnapshot()
   })
 
+  it('handles release with undefined genres and styles (uses fallback)', () => {
+    const releaseWithUndefinedGenresStyles = {
+      id: 77777,
+      basicInformation: {
+        id: 77777,
+        title: 'No Genres Album',
+        year: 2023,
+        artists: [{ name: 'Unknown' }],
+        genres: undefined,
+        styles: undefined
+      },
+      resource: {
+        id: 77777,
+        uri: 'https://www.discogs.com/release/77777-No-Genres-Album'
+      }
+    }
+    render(<DiscogsModal isOpen={true} onClose={mockOnClose} release={releaseWithUndefinedGenresStyles} />)
+    expect(screen.getByText('No Genres Album')).toBeInTheDocument()
+    expect(screen.queryByText('Genres')).not.toBeInTheDocument()
+    expect(screen.queryByText('Styles')).not.toBeInTheDocument()
+  })
+
   it('handles release with empty arrays', () => {
     const releaseWithEmptyArrays = {
       id: 88888,
@@ -153,6 +179,41 @@ describe('DiscogsModal', () => {
 
     fireEvent.keyDown(document, { key: 'Escape' })
     expect(mockOnClose).toHaveBeenCalled()
+  })
+
+  it('calls onClose when backdrop is clicked', () => {
+    render(<DiscogsModal isOpen={true} onClose={mockOnClose} release={mockRelease} />)
+
+    fireEvent.click(getBackdropButton())
+    expect(mockOnClose).toHaveBeenCalled()
+  })
+
+  it('calls onClose when close X button is clicked', () => {
+    render(<DiscogsModal isOpen={true} onClose={mockOnClose} release={mockRelease} />)
+
+    fireEvent.click(getCloseXButton())
+    expect(mockOnClose).toHaveBeenCalled()
+  })
+
+  it('does not call onClose when modal content is clicked (stopPropagation)', () => {
+    const { container } = render(<DiscogsModal isOpen={true} onClose={mockOnClose} release={mockRelease} />)
+
+    const modalContent = container.querySelector('[role="dialog"]').children[1]
+    fireEvent.click(modalContent)
+    expect(mockOnClose).not.toHaveBeenCalled()
+  })
+
+  it('sets body overflow hidden when modal is open', () => {
+    render(<DiscogsModal isOpen={true} onClose={mockOnClose} release={mockRelease} />)
+    expect(document.body.style.overflow).toBe('hidden')
+  })
+
+  it('restores body overflow when modal closes', () => {
+    const { rerender } = render(<DiscogsModal isOpen={true} onClose={mockOnClose} release={mockRelease} />)
+    expect(document.body.style.overflow).toBe('hidden')
+
+    rerender(<DiscogsModal isOpen={false} onClose={mockOnClose} release={mockRelease} />)
+    expect(document.body.style.overflow).toBe('unset')
   })
 
   it('does not call onClose for other keys', () => {
@@ -205,6 +266,79 @@ describe('DiscogsModal', () => {
       }
       const { asFragment } = render(<DiscogsModal isOpen={true} onClose={mockOnClose} release={releaseWithoutCover} />)
       expect(asFragment()).toMatchSnapshot()
+    })
+
+    it('shows loading skeleton until image onLoad fires', () => {
+      render(<DiscogsModal isOpen={true} onClose={mockOnClose} release={mockRelease} />)
+
+      expect(document.querySelector('.show-loading-animation')).toBeInTheDocument()
+
+      fireEvent.load(screen.getByRole('img', { name: /album cover/i }))
+
+      expect(document.querySelector('.show-loading-animation')).not.toBeInTheDocument()
+    })
+
+    it('resets image load state when release changes (different cover URL)', () => {
+      const { rerender } = render(<DiscogsModal isOpen={true} onClose={mockOnClose} release={mockRelease} />)
+
+      fireEvent.load(screen.getByRole('img', { name: /album cover/i }))
+      expect(document.querySelector('.show-loading-animation')).not.toBeInTheDocument()
+
+      const otherRelease = {
+        ...mockRelease,
+        basicInformation: {
+          ...mockRelease.basicInformation,
+          cdnCoverUrl: 'https://other.com/different-cover.jpg'
+        }
+      }
+      rerender(<DiscogsModal isOpen={true} onClose={mockOnClose} release={otherRelease} />)
+
+      expect(document.querySelector('.show-loading-animation')).toBeInTheDocument()
+    })
+
+    it('renders No Image Available with dark mode styling when no cover', () => {
+      const isDarkModeMock = require('../../../helpers/isDarkMode')
+      isDarkModeMock.mockReturnValue(true)
+
+      const releaseWithoutCover = {
+        ...mockRelease,
+        basicInformation: {
+          ...mockRelease.basicInformation,
+          cdnCoverUrl: null,
+          coverImage: null
+        }
+      }
+      render(<DiscogsModal isOpen={true} onClose={mockOnClose} release={releaseWithoutCover} />)
+      expect(screen.getByText('No Image Available')).toBeInTheDocument()
+
+      isDarkModeMock.mockReturnValue(false)
+    })
+
+    it('does not render View on Discogs link when finalDiscogsUrl is missing', () => {
+      const releaseWithoutUrl = {
+        ...mockRelease,
+        basicInformation: { ...mockRelease.basicInformation, resourceUrl: null },
+        resource: { ...mockRelease.resource, uri: null }
+      }
+      render(<DiscogsModal isOpen={true} onClose={mockOnClose} release={releaseWithoutUrl} />)
+      expect(screen.queryByText('View on Discogs')).not.toBeInTheDocument()
+    })
+
+    it('renders tracklist with fallbacks for missing position, title, duration', () => {
+      const releaseWithIncompleteTracks = {
+        ...mockRelease,
+        resource: {
+          ...mockRelease.resource,
+          tracklist: [
+            { position: '', title: undefined, duration: null },
+            { position: 'B1', title: 'Known Title', duration: '4:00' }
+          ]
+        }
+      }
+      render(<DiscogsModal isOpen={true} onClose={mockOnClose} release={releaseWithIncompleteTracks} />)
+      expect(screen.getAllByText('—').length).toBeGreaterThanOrEqual(1)
+      expect(screen.getByText('Unknown Title')).toBeInTheDocument()
+      expect(screen.getByText('Known Title')).toBeInTheDocument()
     })
   })
 })


### PR DESCRIPTION
## Overview

Updates the Discogs modal on the Home page: fixes layout shift when opening and adds a loading skeleton until cover artwork loads. The modal keeps a stable layout and shows clear feedback while images load.

## Screenshots

| BEFORE                         | AFTER                        |
| ------------------------------ | ---------------------------- |
| ![before-discogs](https://github.com/user-attachments/assets/2e9d74a2-9a53-4d50-94ca-13ce0148bcd9) | ![after-discogs](https://github.com/user-attachments/assets/cada7b41-4af0-4738-94c6-679baafc4157) |





## AI summary

- **Layout shift**: The cover image container now uses fixed dimensions (280×280px) so the modal no longer jumps when the image loads.
- **Loading skeleton**: A `RectShape` skeleton (same pattern as Steam, Instagram, Goodreads) is shown until the artwork finishes loading, with a fade-in once the image is ready.
- **State handling**: Image load state is tracked via `onLoad`; state is reset when a different record is selected.
- **Tests**: Added 11+ tests for image load behavior, backdrop/close button clicks, body scroll lock, dark mode fallback, and tracklist fallbacks. Coverage for `discogs-modal.js` is 100% statements/functions/lines and 97%+ branches.
- **Version**: Bumped to 0.72.19.