### PR TITLE
chore(deps): updates all deps; pnpm version; banner to esm

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "format": "prettier --write \"**/*.{js,jsx,ts,tsx,json,css,md,mdx}\"",
     "lint": "eslint .",
     "preinstall": "npx only-allow pnpm",
-    "postinstall": "node ./scripts/postinstall-banner.js",
+    "postinstall": "node ./scripts/postinstall-banner.mjs",
     "prepare": "husky",
     "prettier": "prettier --check .",
     "test": "turbo run test",
@@ -55,7 +55,7 @@
       "sharp"
     ]
   },
-  "packageManager": "pnpm@10.30.1+sha512.3590e550d5384caa39bd5c7c739f72270234b2f6059e13018f975c313b1eb9fefcc09714048765d4d9efe961382c312e624572c0420762bdc5d5940cdf9be73a",
+  "packageManager": "pnpm@10.30.3+sha512.c961d1e0a2d8e354ecaa5166b822516668b7f44cb5bd95122d590dd81922f606f5473b6d23ec4a5be05e7fcd18e8488d47d978bbe981872f1145d06e9a740017",
   "lint-staged": {
     "*.{js,jsx,ts,tsx}": "eslint --fix"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -93,7 +93,7 @@ importers:
         version: 9.1.7
       lint-staged:
         specifier: ^16.3.0
-        version: 16.3.0
+        version: 16.3.1
       only-allow:
         specifier: ^1.2.2
         version: 1.2.2
@@ -3407,8 +3407,8 @@ packages:
     resolution: {integrity: sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==}
     engines: {node: '>=18'}
 
-  cli-truncate@5.1.1:
-    resolution: {integrity: sha512-SroPvNHxUnk+vIW/dOSfNqdy1sPEFkrTk6TUtqLCnBlo3N7TNYYkzzN7uSD6+jVjrdO4+p8nH7JzH6cIvUem6A==}
+  cli-truncate@5.2.0:
+    resolution: {integrity: sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw==}
     engines: {node: '>=20'}
 
   cli-width@3.0.0:
@@ -6039,8 +6039,8 @@ packages:
   linkfs@2.1.0:
     resolution: {integrity: sha512-kmsGcmpvjStZ0ATjuHycBujtNnXiZR28BTivEu0gAMDTT7GEyodcK6zSRtu6xsrdorrPZEIN380x7BD7xEYkew==}
 
-  lint-staged@16.3.0:
-    resolution: {integrity: sha512-YVHHy/p6U4/No9Af+35JLh3umJ9dPQnGTvNCbfO/T5fC60us0jFnc+vw33cqveI+kqxIFJQakcMVTO2KM+653A==}
+  lint-staged@16.3.1:
+    resolution: {integrity: sha512-bqvvquXzFBAlSbluugR4KXAe4XnO/QZcKVszpkBtqLWa2KEiVy8n6Xp38OeUbv/gOJOX4Vo9u5pFt/ADvbm42Q==}
     engines: {node: '>=20.17'}
     hasBin: true
 
@@ -6713,10 +6713,6 @@ packages:
 
   mute-stream@0.0.8:
     resolution: {integrity: sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==}
-
-  nano-spawn@2.0.0:
-    resolution: {integrity: sha512-tacvGzUY5o2D8CBh2rrwxyNojUsZNU2zjNTzKQrkgGJQTbGAfArVWXSKMBokBeeg6C7OLRGUEyoFlYbfeWQIqw==}
-    engines: {node: '>=20.17'}
 
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
@@ -8066,6 +8062,10 @@ packages:
   slice-ansi@7.1.2:
     resolution: {integrity: sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==}
     engines: {node: '>=18'}
+
+  slice-ansi@8.0.0:
+    resolution: {integrity: sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==}
+    engines: {node: '>=20'}
 
   slugify@1.6.6:
     resolution: {integrity: sha512-h+z7HKHYXj6wJU+AnS/+IH8Uh9fdcX1Lrhg1/VMdf9PwoBQXFcXiAdsy2tSK0P6gKwJLXp02r90ahUCqHk9rrw==}
@@ -12978,9 +12978,9 @@ snapshots:
     dependencies:
       restore-cursor: 5.1.0
 
-  cli-truncate@5.1.1:
+  cli-truncate@5.2.0:
     dependencies:
-      slice-ansi: 7.1.2
+      slice-ansi: 8.0.0
       string-width: 8.2.0
 
   cli-width@3.0.0: {}
@@ -16970,19 +16970,18 @@ snapshots:
 
   linkfs@2.1.0: {}
 
-  lint-staged@16.3.0:
+  lint-staged@16.3.1:
     dependencies:
       commander: 14.0.3
       listr2: 9.0.5
       micromatch: 4.0.8
-      nano-spawn: 2.0.0
       string-argv: 0.3.2
       tinyexec: 1.0.2
       yaml: 2.8.2
 
   listr2@9.0.5:
     dependencies:
-      cli-truncate: 5.1.1
+      cli-truncate: 5.2.0
       colorette: 2.0.20
       eventemitter3: 5.0.4
       log-update: 6.1.0
@@ -18113,8 +18112,6 @@ snapshots:
       object-assign: 4.1.1
 
   mute-stream@0.0.8: {}
-
-  nano-spawn@2.0.0: {}
 
   nanoid@3.3.11: {}
 
@@ -19632,6 +19629,11 @@ snapshots:
       ansi-styles: 6.2.3
       is-fullwidth-code-point: 5.1.0
 
+  slice-ansi@8.0.0:
+    dependencies:
+      ansi-styles: 6.2.3
+      is-fullwidth-code-point: 5.1.0
+
   slugify@1.6.6: {}
 
   snake-case@3.0.4:
@@ -19791,7 +19793,7 @@ snapshots:
     dependencies:
       eastasianwidth: 0.2.0
       emoji-regex: 9.2.2
-      strip-ansi: 7.1.2
+      strip-ansi: 7.2.0
 
   string-width@7.2.0:
     dependencies:
@@ -20830,7 +20832,7 @@ snapshots:
     dependencies:
       ansi-styles: 6.2.3
       string-width: 5.1.2
-      strip-ansi: 7.1.2
+      strip-ansi: 7.2.0
 
   wrap-ansi@9.0.2:
     dependencies:

--- a/scripts/postinstall-banner.mjs
+++ b/scripts/postinstall-banner.mjs
@@ -1,5 +1,8 @@
-const boxen = require('boxen').default
-const chalk = require('chalk')
+import boxen from 'boxen'
+import chalk from 'chalk'
+import { createRequire } from 'node:module'
+
+const require = createRequire(import.meta.url)
 const packageData = require('../theme/package.json')
 
 const banner = boxen(`${chalk.bold('www.chrisvogt.me')}\nMy Personal Website\nv${packageData.version}`, {


### PR DESCRIPTION
## Overview

Dependency update and postinstall fix: bumps pnpm and refreshed lockfile deps, and migrates the postinstall banner to ESM so it works with chalk v5. Chalk v5 is ESM-only, so `require('chalk')` caused `TypeError: chalk.bold is not a function` during `pnpm install`; the banner is now an `.mjs` module.

**Changes:**
- **Postinstall banner:** Replace `scripts/postinstall-banner.js` (CommonJS) with `scripts/postinstall-banner.mjs` (ESM): `import chalk`, `import boxen`, and `createRequire(import.meta.url)` for `theme/package.json`. Update `package.json` postinstall to `node ./scripts/postinstall-banner.mjs`.
- **packageManager:** Bump `packageManager` in `package.json` from pnpm 10.30.1 to 10.30.3 (updated hash).
- **Lockfile (pnpm update):** `pnpm-lock.yaml` refreshed; notable resolution changes:
  - lint-staged 16.3.0 → 16.3.1 (drops nano-spawn)
  - cli-truncate 5.1.1 → 5.2.0
  - slice-ansi 7.1.2 → 8.0.0 (new entry)
  - strip-ansi 7.1.2 → 7.2.0

## AI summary

- **Problem:** Postinstall failed with `chalk.bold is not a function` after chalk was upgraded to v5 (ESM-only; CommonJS `require()` no longer supported). The branch also includes a broader dependency refresh.
- **Solution:** (1) Convert postinstall banner to ESM (`.mjs`) with `import` for chalk/boxen and `createRequire` for theme package.json; point postinstall at the new script and remove the old `.js`. (2) Bump `packageManager` to pnpm 10.30.3. (3) Run `pnpm update` and commit lockfile changes (lint-staged, cli-truncate, slice-ansi, strip-ansi, removal of nano-spawn, etc.).
