### PR TITLE
chore(deps): overrides to resove medium+ dependabot security alerts

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
       "@mdx-js/react": "^3.1.1",
       "multer": "^2.1.0",
       "serialize-javascript": ">=7.0.3",
-      "minimatch": ">=3.1.4"
+      "gatsby-plugin-google-analytics>minimatch": "^3.1.4",
+      "gatsby-plugin-sitemap>minimatch": "^3.1.4"
     },
     "publicHoistPattern": [
       "*"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,7 +48,8 @@ overrides:
   '@mdx-js/react': ^3.1.1
   multer: ^2.1.0
   serialize-javascript: '>=7.0.3'
-  minimatch: '>=3.1.4'
+  gatsby-plugin-google-analytics>minimatch: ^3.1.4
+  gatsby-plugin-sitemap>minimatch: ^3.1.4
 
 importers:
 
@@ -3202,6 +3203,9 @@ packages:
 
   brace-expansion@1.1.12:
     resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
+
+  brace-expansion@2.0.2:
+    resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
 
   brace-expansion@5.0.4:
     resolution: {integrity: sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==}
@@ -6643,6 +6647,10 @@ packages:
 
   minimatch@3.1.5:
     resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
+
+  minimatch@9.0.9:
+    resolution: {integrity: sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==}
+    engines: {node: '>=16 || 14 >=14.17'}
 
   minimist-options@4.1.0:
     resolution: {integrity: sha512-Q4r8ghd80yhO/0j1O3B2BjweX3fiHg9cdOwjJd2J76Q135c+NDxGCqdYKQ1SKBuFfgWbAUzBfvYjPUEeNgqN1A==}
@@ -12704,6 +12712,10 @@ snapshots:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
+  brace-expansion@2.0.2:
+    dependencies:
+      balanced-match: 1.0.2
+
   brace-expansion@5.0.4:
     dependencies:
       balanced-match: 4.0.4
@@ -14790,7 +14802,7 @@ snapshots:
     dependencies:
       '@babel/runtime': 7.28.6
       gatsby: 5.16.1(babel-eslint@10.1.0(eslint@10.0.2))(eslint-plugin-jest@29.15.0(eslint@10.0.2)(jest@30.2.0(@types/node@25.3.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(type-fest@4.41.0)(typescript@5.9.3)
-      minimatch: 10.2.4
+      minimatch: 3.1.5
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
       web-vitals: 1.1.2
@@ -14917,7 +14929,7 @@ snapshots:
       '@babel/runtime': 7.28.6
       common-tags: 1.8.2
       gatsby: 5.16.1(babel-eslint@10.1.0(eslint@10.0.2))(eslint-plugin-jest@29.15.0(eslint@10.0.2)(jest@30.2.0(@types/node@25.3.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(type-fest@4.41.0)(typescript@5.9.3)
-      minimatch: 10.2.4
+      minimatch: 3.1.5
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
       sitemap: 7.1.2
@@ -15640,7 +15652,7 @@ snapshots:
     dependencies:
       foreground-child: 3.3.1
       jackspeak: 3.4.3
-      minimatch: 10.2.4
+      minimatch: 9.0.9
       minipass: 7.1.3
       package-json-from-dist: 1.0.1
       path-scurry: 1.11.1
@@ -18018,6 +18030,10 @@ snapshots:
     dependencies:
       brace-expansion: 1.1.12
 
+  minimatch@9.0.9:
+    dependencies:
+      brace-expansion: 2.0.2
+
   minimist-options@4.1.0:
     dependencies:
       arrify: 1.0.1
@@ -20039,7 +20055,7 @@ snapshots:
     dependencies:
       '@istanbuljs/schema': 0.1.3
       glob: 7.2.3
-      minimatch: 10.2.4
+      minimatch: 3.1.5
 
   text-decoder@1.2.7:
     dependencies:


### PR DESCRIPTION
## Overview

Addresses Dependabot security alerts by adding pnpm overrides for vulnerable transitive dependencies that upstream packages have not yet updated:

1. **multer** → `^2.1.0` (DoS – CVE-2026-3304, CVE-2026-2359), pulled in by Gatsby
2. **serialize-javascript** → `>=7.0.3` (XSS/ReDoS – CVE-2020-7660), pulled in by css-minimizer-webpack-plugin and terser-webpack-plugin via Gatsby
3. **minimatch** → `>=3.1.4` (ReDoS), pulled in by gatsby-plugin-google-analytics and gatsby-plugin-sitemap

Also adds `.github/SECURITY-OVERRIDES.md` to track these overrides and where to report upstream. Documents `@parcel/reporter-dev-server` (CVE-2025-56648) as a known issue without override due to Parcel’s tight version coupling.

## AI summary

- Adds four pnpm overrides to `package.json`: multer, serialize-javascript, minimatch (plus existing lodash and @mdx-js/react)
- Creates `.github/SECURITY-OVERRIDES.md` with audit details, upstream repos, and verification commands for each override
- Documents `@parcel/reporter-dev-server` CVE-2025-56648 as intentionally not overridden
- Runs `pnpm install` to refresh lockfile