### PR TITLE
feat: adds support for config-driven canonical URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 0.72.23
+
+### ✨ Improvements
+
+- **Canonical URLs for all main pages**: The theme now outputs a `<link rel="canonical">` tag for the home page, blog index, and about page (blog posts and media pages already had canonicals). The canonical URL is built from site metadata: `baseURL` or `siteUrl` from `gatsby-config` plus the page path. There is no hardcoded domain — every consumer of the theme gets canonicals pointing at their own configured origin. Useful when serving the same site from multiple domains (e.g. alias or redirect) so search engines consolidate on one preferred URL.
+
+### 📦 Files Changed
+
+- `theme/src/templates/home-head.js` (pass `canonicalPath='/'` to `Seo`)
+- `theme/src/pages/blog-head.js` (pass `canonicalPath='/blog/'` to `Seo`)
+- `theme/src/pages/about.js` (pass `canonicalPath='/about/'` to `Seo`)
+
+---
+
 ## 0.72.22
 
 ### ✨ Improvements

--- a/theme/package.json
+++ b/theme/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-theme-chronogrove",
   "description": "A personal website and digital garden theme for GatsbyJS.",
-  "version": "0.72.22",
+  "version": "0.72.23",
   "author": "Chris Vogt <mail@chrisvogt.me> (https://www.chrisvogt.me)",
   "main": "index.js",
   "license": "MIT",

--- a/theme/src/pages/about.js
+++ b/theme/src/pages/about.js
@@ -38,6 +38,6 @@ const AboutPage = () => {
   )
 }
 
-export const Head = () => <Seo title='About' />
+export const Head = () => <Seo canonicalPath='/about/' title='About' />
 
 export default AboutPage

--- a/theme/src/pages/blog-head.js
+++ b/theme/src/pages/blog-head.js
@@ -6,7 +6,7 @@ export default function BlogHead() {
   const { title, description, siteUrl } = useSiteMetadata()
 
   return (
-    <Seo title={`Blog - ${title}`} description={description}>
+    <Seo canonicalPath='/blog/' title={`Blog - ${title}`} description={description}>
       <meta property='og:url' content={`${siteUrl}/blog/`} />
       <meta property='og:type' content='website' />
     </Seo>

--- a/theme/src/templates/home-head.js
+++ b/theme/src/templates/home-head.js
@@ -48,7 +48,7 @@ export default function HomeHead() {
   }
 
   return (
-    <Seo title='Home' description={description}>
+    <Seo canonicalPath='/' title='Home' description={description}>
       {url && <meta property='og:url' content={url} />}
       <meta property='og:type' content='website' />
       <script type='application/ld+json'>{JSON.stringify(structuredData)}</script>

--- a/www.chrisvogt.me/package.json
+++ b/www.chrisvogt.me/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "www.chrisvogt.me",
-  "version": "1.14.0",
+  "version": "1.14.1",
   "license": "GPL",
   "scripts": {
     "build": "gatsby build",

--- a/www.chrisvogt.me/src/gatsby-theme-chronogrove/pages/blog-head.js
+++ b/www.chrisvogt.me/src/gatsby-theme-chronogrove/pages/blog-head.js
@@ -4,6 +4,7 @@ import Seo from '../../../../theme/src/components/seo'
 export default function BlogHead() {
   return (
     <Seo
+      canonicalPath='/blog/'
       title='Blog - Latest Posts'
       description='Read the latest blog posts and insights from the blog. Explore articles on technology, photography, music, and personal growth on chrisvogt.me.'
     >

--- a/www.chrisvogt.me/src/gatsby-theme-chronogrove/templates/home-head.js
+++ b/www.chrisvogt.me/src/gatsby-theme-chronogrove/templates/home-head.js
@@ -44,6 +44,7 @@ export default function HomeHead() {
 
   return (
     <Seo
+      canonicalPath='/'
       title='Home'
       description="Explore Chris Vogt's digital garden. A Software Engineer in San Francisco, Chris shares his interest in photography, piano, and travel."
       keywords='Chris Vogt, Software Engineer in San Francisco, GoDaddy engineer blog, photography blog, piano recordings, travel blog, personal blog, digital garden'

--- a/www.chrisvogt.me/src/pages/about.js
+++ b/www.chrisvogt.me/src/pages/about.js
@@ -49,6 +49,6 @@ const AboutPage = () => {
   )
 }
 
-export const Head = () => <Seo title='About Me' />
+export const Head = () => <Seo canonicalPath='/about/' title='About Me' />
 
 export default AboutPage

--- a/www.chrisvogt.me/src/pages/music.js
+++ b/www.chrisvogt.me/src/pages/music.js
@@ -65,6 +65,7 @@ const MusicPage = ({ data }) => {
 
 export const Head = () => (
   <Seo
+    canonicalPath='/music/'
     title="Chris Vogt's Music - Original and Cover Songs"
     description="Explore Chris Vogt's collection of original songs and covers. Listen to unique tracks and discover the stories behind the music on chrisvogt.me."
   >

--- a/www.chrisvogt.me/src/pages/privacy.js
+++ b/www.chrisvogt.me/src/pages/privacy.js
@@ -63,6 +63,6 @@ const PrivacyPolicy = () => {
   )
 }
 
-export const Head = () => <Seo title='Privacy Policy' />
+export const Head = () => <Seo canonicalPath='/privacy/' title='Privacy Policy' />
 
 export default PrivacyPolicy

--- a/www.chrisvogt.me/src/pages/travel.js
+++ b/www.chrisvogt.me/src/pages/travel.js
@@ -91,6 +91,7 @@ const TravelPage = ({ data }) => {
 
 export const Head = () => (
   <Seo
+    canonicalPath='/travel/'
     title='Travel — Chris Vogt'
     description='Travel posts and photo galleries from trips and destinations. Narrative stories and photos from Belize, Alaska, the Caribbean, and more.'
   >


### PR DESCRIPTION
## Overview

Adds `<link rel="canonical">` to all main theme pages (home, blog index, about) so the site can declare a single preferred URL when served from multiple domains (e.g. www.chrisvogt.com aliasing to www.chrisvogt.me). Blog posts and media pages already had canonicals; this completes coverage. The canonical URL is built from site metadata (`baseURL` or `siteUrl` in `gatsby-config`); there is no hardcoded domain, so every theme consumer gets canonicals for their own origin.

## AI summary

- **Theme:** `Seo` already supported `canonicalPath` and builds the full URL from `metadata.baseURL` or `metadata.siteUrl`. Added `canonicalPath` in:
  - `theme/src/templates/home-head.js` → `'/'`
  - `theme/src/pages/blog-head.js` → `'/blog/'`
  - `theme/src/pages/about.js` → `'/about/'`
- **www.chrisvogt.me:** Set canonicals on shadowed and site-specific pages: home and blog index (shadowed), travel, music, about, and privacy so every page has a canonical in the built HTML.
- **CHANGELOG:** Documented under 0.72.23 with files changed and note that canonicals are config-driven.
- **Verification:** Canonicals appear in production build output (e.g. View Source); theme tests and coverage thresholds (97%+ statements/lines) still pass; no new tests required since `seo.spec.js` already covers canonical rendering.