### PR TITLE
fix(lighthouse): fires a GET and waits before checking score

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -14,6 +14,12 @@ jobs:
         with:
           site_name: 'chrisvogt'
           max_timeout: 600 # Timeout if the deploy preview hasn't posted within 10 minutes
+      - name: Warm up deploy preview
+        run: |
+          echo "Warming up deploy preview at ${{ steps.netlify.outputs.url }}"
+          curl -sS -o /dev/null -w "Response: %{http_code}\n" "${{ steps.netlify.outputs.url }}"
+          echo "Waiting 8 seconds for cache and server to warm..."
+          sleep 8
       - name: Audit URLs using Lighthouse
         uses: treosh/lighthouse-ci-action@v12
         with:


### PR DESCRIPTION
## Hypothesis

Lighthouse scores have been consistently low on PR deploy previews. The theory: the Lighthouse CI action runs immediately when the Netlify preview becomes available—before the server has warmed up and the page is cached. That first cold request is likely skewing performance metrics downward.

## What we're doing

Adding a warm-up step between the Netlify preview wait and the Lighthouse audit:

1. **Fire a 200 GET request** to the deploy preview URL (to warm the server and populate caches)
2. **Wait 8 seconds** to let things settle
3. **Then run** the Lighthouse audit

This should give us a more accurate picture of real-world performance. We'll know right away in this PR if it fixed the issue.