### PR TITLE
ci: pass CODECOV_TOKEN to codecov-action for reliable PR comments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,7 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: theme/coverage/lcov.info
           flags: unittests
           fail_ci_if_error: true
@@ -74,6 +75,7 @@ jobs:
         if: ${{ !cancelled() }}
         uses: codecov/codecov-action@v5
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           report_type: test_results
           files: theme/junit.xml
 


### PR DESCRIPTION
Codecov wasn't consistently commenting on PRs. The action was relying on the default upload token rather than our org token—adding `token: ${{ secrets.CODECOV_TOKEN }}` to both upload steps so it uses our credentials and should comment more reliably.

Made with [Cursor](https://cursor.com)