### PR TITLE
fix(publish): add repository metadata for npm provenance

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -3,6 +3,11 @@
   "version": "0.76.0",
   "description": "Chronogrove Theme UI theme, color mode helpers, and shared UI primitives",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/chrisvogt/gatsby-theme-chronogrove.git",
+    "directory": "packages/ui"
+  },
   "sideEffects": false,
   "exports": {
     ".": {

--- a/theme/package.json
+++ b/theme/package.json
@@ -6,6 +6,11 @@
   "main": "index.js",
   "license": "MIT",
   "bugs": "https://github.com/chrisvogt/gatsby-theme-chronogrove/issues",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/chrisvogt/gatsby-theme-chronogrove.git",
+    "directory": "theme"
+  },
   "keywords": [
     "personal-website",
     "gatsby-website",


### PR DESCRIPTION
## Summary

Adds `repository` (git URL + monorepo `directory`) to `gatsby-theme-chronogrove` and `@chronogrove/ui` so **npm provenance** (OIDC / `--provenance`) validation succeeds. npm was returning **422** because `repository.url` was empty while the Sigstore attestation expected the GitHub repo URL.

## Changes

- `theme/package.json` — `directory: "theme"`
- `packages/ui/package.json` — `directory: "packages/ui"`

Made with [Cursor](https://cursor.com)