### PR TITLE
feat(ui): @chronogrove/ui/gatsby — Gatsby SSR/browser helpers (#565)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 0.77.0
+
+### `@chronogrove/ui/gatsby` — Gatsby wiring helpers (Issue #565)
+
+- **New subpath** [`@chronogrove/ui/gatsby`](packages/ui/src/gatsby/): **`buildThemeUiColorModeHeadComponents({ theme })`** (Theme UI no-flash script, HTML background script, fallback CSS from `resolveChronogroveSurfaceColors`), **`onPreRenderHTMLSortThemeUiColorModeFirst`** (Gatsby `onPreRenderHTML` head ordering for `CHRONOGROVE_COLOR_MODE_HEAD_PRIORITY_KEYS`), **`onRouteUpdateThemeUiColorMode`** (browser route reconciliation + `RECONCILE_COLOR_MODE_EVENT`), and re-export of **`RECONCILE_COLOR_MODE_EVENT`**.
+- **Theme integration**: `gatsby-theme-chronogrove` **`gatsby-ssr.js`** / **`gatsby-browser.js`** consume these helpers instead of inlining color-mode wiring; **`onRouteUpdateChronogroveNavigation`** is exported for sites that compose their own `onRouteUpdate` with `@chronogrove/ui/gatsby`.
+
+### Files changed
+
+- `packages/ui/package.json` (export `./gatsby`, version **0.77.0**)
+- `packages/ui/src/gatsby/**`, `packages/ui/src/gatsby/index.spec.js`
+- `theme/package.json` (version **0.77.0**)
+- `theme/gatsby-ssr.js`, `theme/gatsby-browser.js`, `theme/gatsby-browser.spec.js`
+- `packages/ui/jest.config.cjs`
+
+---
+
 ## 0.76.0
 
 ### 📦 `@chronogrove/ui` — shared Theme UI layer

--- a/packages/ui/jest.config.cjs
+++ b/packages/ui/jest.config.cjs
@@ -15,6 +15,7 @@ module.exports = {
     'src/index.js',
     'src/skip-nav/index.js',
     'src/color-mode/index.js',
+    'src/gatsby/index.js',
     'src/theme.js'
   ],
   moduleNameMapper: {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chronogrove/ui",
-  "version": "0.76.0",
+  "version": "0.77.0",
   "description": "Chronogrove Theme UI theme, color mode helpers, and shared UI primitives",
   "license": "MIT",
   "repository": {
@@ -45,6 +45,10 @@
     "./is-dark-mode": {
       "import": "./src/helpers/isDarkMode.js",
       "default": "./src/helpers/isDarkMode.js"
+    },
+    "./gatsby": {
+      "import": "./src/gatsby/index.js",
+      "default": "./src/gatsby/index.js"
     }
   },
   "scripts": {

--- a/packages/ui/src/gatsby/build-theme-ui-color-mode-head-components.js
+++ b/packages/ui/src/gatsby/build-theme-ui-color-mode-head-components.js
@@ -1,0 +1,36 @@
+import React from 'react'
+
+import { resolveChronogroveSurfaceColors } from '../color-mode/resolve-theme-colors.js'
+import {
+  buildThemeUiNoFlashInlineScript,
+  buildHtmlBackgroundInlineScript,
+  buildThemeUiColorModeFallbackCss
+} from '../color-mode/head-inline.js'
+
+/**
+ * React head elements for Theme UI color mode: no-flash script, HTML background script, fallback CSS.
+ * Compose with your own meta tags (e.g. Emotion insertion point) in `onRenderBody`.
+ *
+ * @param {{ theme: object }} options — Theme UI theme object (same as `ThemeUIProvider`)
+ * @returns {import('react').ReactElement[]}
+ */
+export function buildThemeUiColorModeHeadComponents({ theme }) {
+  const surface = resolveChronogroveSurfaceColors(theme)
+  const colorModeScript = buildThemeUiNoFlashInlineScript()
+  const htmlBackgroundScript = buildHtmlBackgroundInlineScript({
+    defaultBackgroundHex: surface.defaultBackgroundHex,
+    darkBackgroundHex: surface.darkBackgroundHex
+  })
+  const colorModeFallbackCSS = buildThemeUiColorModeFallbackCss({
+    defaultTextHex: surface.defaultTextHex,
+    defaultTextMutedHex: surface.defaultTextMutedHex,
+    darkTextHex: surface.darkTextHex,
+    darkTextMutedHex: surface.darkTextMutedHex
+  })
+
+  return [
+    <script key='theme-ui-no-flash' dangerouslySetInnerHTML={{ __html: colorModeScript }} />,
+    <script key='html-bg-color' dangerouslySetInnerHTML={{ __html: htmlBackgroundScript }} />,
+    <style key='theme-ui-color-mode-fallback' dangerouslySetInnerHTML={{ __html: colorModeFallbackCSS }} />
+  ]
+}

--- a/packages/ui/src/gatsby/index.js
+++ b/packages/ui/src/gatsby/index.js
@@ -1,0 +1,4 @@
+export { buildThemeUiColorModeHeadComponents } from './build-theme-ui-color-mode-head-components.js'
+export { onPreRenderHTMLSortThemeUiColorModeFirst } from './on-pre-render-html-sort.js'
+export { onRouteUpdateThemeUiColorMode } from './on-route-update-color-mode.js'
+export { RECONCILE_COLOR_MODE_EVENT } from '../color-mode/constants.js'

--- a/packages/ui/src/gatsby/index.spec.js
+++ b/packages/ui/src/gatsby/index.spec.js
@@ -1,0 +1,131 @@
+import React from 'react'
+import { render } from '@testing-library/react'
+import '@testing-library/jest-dom'
+
+import chronogroveTheme from '../theme.js'
+import * as gatsby from './index.js'
+import { buildThemeUiColorModeHeadComponents } from './build-theme-ui-color-mode-head-components.js'
+import { onPreRenderHTMLSortThemeUiColorModeFirst } from './on-pre-render-html-sort.js'
+import { onRouteUpdateThemeUiColorMode } from './on-route-update-color-mode.js'
+
+describe('@chronogrove/ui/gatsby public API', () => {
+  it('exports reconcile event and helpers from the barrel', () => {
+    expect(gatsby.RECONCILE_COLOR_MODE_EVENT).toBe('theme-ui-reconcile-color-mode')
+    expect(gatsby.buildThemeUiColorModeHeadComponents).toEqual(expect.any(Function))
+    expect(gatsby.onPreRenderHTMLSortThemeUiColorModeFirst).toEqual(expect.any(Function))
+    expect(gatsby.onRouteUpdateThemeUiColorMode).toEqual(expect.any(Function))
+  })
+})
+
+describe('@chronogrove/ui/gatsby', () => {
+  describe('buildThemeUiColorModeHeadComponents', () => {
+    it('returns no-flash script, HTML background script, and fallback style for the theme', () => {
+      const head = buildThemeUiColorModeHeadComponents({ theme: chronogroveTheme })
+      expect(head).toHaveLength(3)
+      expect(head[0].key).toBe('theme-ui-no-flash')
+      expect(head[1].key).toBe('html-bg-color')
+      expect(head[2].key).toBe('theme-ui-color-mode-fallback')
+
+      const { container: colorModeScriptContainer } = render(head[0])
+      const colorModeScriptTag = colorModeScriptContainer.querySelector('script')
+      expect(colorModeScriptTag).toHaveTextContent(/localStorage\.getItem\(['"]theme-ui-color-mode['"]\)/)
+      expect(colorModeScriptTag).toHaveTextContent(/data-theme-ui-color-mode/)
+
+      const { container: htmlBgScriptContainer } = render(head[1])
+      const htmlBgScriptTag = htmlBgScriptContainer.querySelector('script')
+      expect(htmlBgScriptTag).toHaveTextContent(/#14141F/)
+      expect(htmlBgScriptTag).toHaveTextContent(/#fdf8f5/)
+
+      const { container: fallbackStyleContainer } = render(head[2])
+      const fallbackStyle = fallbackStyleContainer.querySelector('style')
+      expect(fallbackStyle).toHaveTextContent(/:root\[data-theme-ui-color-mode="default"\]/)
+      expect(fallbackStyle).toHaveTextContent(/--theme-ui-colors-text: #111 !important/)
+    })
+  })
+
+  describe('onPreRenderHTMLSortThemeUiColorModeFirst', () => {
+    it('puts color-mode scripts and fallback style before other head components', () => {
+      const getHeadComponents = jest.fn(() => [
+        { key: 'emotion-insertion-point', type: 'meta' },
+        { key: 'theme-ui-no-flash', type: 'script' },
+        { key: 'html-bg-color', type: 'script' },
+        { key: 'theme-ui-color-mode-fallback', type: 'style' }
+      ])
+      const replaceHeadComponents = jest.fn()
+
+      onPreRenderHTMLSortThemeUiColorModeFirst({ getHeadComponents, replaceHeadComponents })
+
+      const sorted = replaceHeadComponents.mock.calls[0][0]
+      const colorModeKeys = ['theme-ui-no-flash', 'html-bg-color', 'theme-ui-color-mode-fallback']
+      const firstThree = sorted.slice(0, 3).map(c => c.key)
+      colorModeKeys.forEach(key => expect(firstThree).toContain(key))
+      expect(sorted[3].key).toBe('emotion-insertion-point')
+    })
+
+    it('sorts color-mode keys before arbitrary head components', () => {
+      const getHeadComponents = jest.fn(() => [
+        { key: 'other-meta', type: 'meta' },
+        { key: 'theme-ui-no-flash', type: 'script' },
+        { key: 'another-tag', type: 'link' },
+        { key: 'html-bg-color', type: 'script' },
+        { key: 'theme-ui-color-mode-fallback', type: 'style' }
+      ])
+      const replaceHeadComponents = jest.fn()
+
+      onPreRenderHTMLSortThemeUiColorModeFirst({ getHeadComponents, replaceHeadComponents })
+
+      const sorted = replaceHeadComponents.mock.calls[0][0]
+      const keys = sorted.map(c => c.key)
+      expect(keys.indexOf('theme-ui-no-flash')).toBeLessThan(keys.indexOf('other-meta'))
+      expect(keys.indexOf('html-bg-color')).toBeLessThan(keys.indexOf('another-tag'))
+      expect(keys.indexOf('theme-ui-color-mode-fallback')).toBeLessThan(keys.indexOf('other-meta'))
+    })
+
+    it('preserves relative order among non-priority head components (comparator returns 0)', () => {
+      const getHeadComponents = jest.fn(() => [
+        { key: 'z-last', type: 'meta' },
+        { key: 'a-first', type: 'meta' }
+      ])
+      const replaceHeadComponents = jest.fn()
+      onPreRenderHTMLSortThemeUiColorModeFirst({ getHeadComponents, replaceHeadComponents })
+      expect(replaceHeadComponents.mock.calls[0][0].map(c => c.key)).toEqual(['z-last', 'a-first'])
+    })
+
+    it('preserves relative order among priority keys when both sides are priority (comparator returns 0)', () => {
+      const getHeadComponents = jest.fn(() => [
+        { key: 'html-bg-color', type: 'script' },
+        { key: 'theme-ui-no-flash', type: 'script' }
+      ])
+      const replaceHeadComponents = jest.fn()
+      onPreRenderHTMLSortThemeUiColorModeFirst({ getHeadComponents, replaceHeadComponents })
+      expect(replaceHeadComponents.mock.calls[0][0].map(c => c.key)).toEqual(['html-bg-color', 'theme-ui-no-flash'])
+    })
+  })
+
+  describe('onRouteUpdateThemeUiColorMode', () => {
+    beforeEach(() => {
+      window.localStorage.removeItem('theme-ui-color-mode')
+      document.documentElement.removeAttribute('data-theme-ui-color-mode')
+      document.documentElement.className = ''
+    })
+
+    it('syncs DOM from localStorage and dispatches reconcile event', () => {
+      window.localStorage.setItem('theme-ui-color-mode', 'dark')
+      const listener = jest.fn()
+      window.addEventListener('theme-ui-reconcile-color-mode', listener)
+
+      onRouteUpdateThemeUiColorMode()
+
+      expect(document.documentElement.getAttribute('data-theme-ui-color-mode')).toBe('dark')
+      expect(listener).toHaveBeenCalled()
+    })
+
+    it('does not throw when CustomEvent is unavailable', () => {
+      const original = window.CustomEvent
+      window.CustomEvent = undefined
+      window.localStorage.setItem('theme-ui-color-mode', 'default')
+      expect(() => onRouteUpdateThemeUiColorMode()).not.toThrow()
+      window.CustomEvent = original
+    })
+  })
+})

--- a/packages/ui/src/gatsby/on-pre-render-html-sort.js
+++ b/packages/ui/src/gatsby/on-pre-render-html-sort.js
@@ -1,0 +1,21 @@
+import { CHRONOGROVE_COLOR_MODE_HEAD_PRIORITY_KEYS } from '../color-mode/constants.js'
+
+/**
+ * Gatsby `onPreRenderHTML`: move Theme UI color-mode head entries (`theme-ui-no-flash`, `html-bg-color`,
+ * `theme-ui-color-mode-fallback`) before other head components to minimize flash and ordering issues.
+ *
+ * @param {{ getHeadComponents: () => unknown[], replaceHeadComponents: (c: unknown[]) => void }} api
+ */
+export function onPreRenderHTMLSortThemeUiColorModeFirst({ getHeadComponents, replaceHeadComponents }) {
+  const headComponents = getHeadComponents()
+  const priorityKeys = CHRONOGROVE_COLOR_MODE_HEAD_PRIORITY_KEYS
+  const sorted = [...headComponents].sort((a, b) => {
+    const aKey = a?.key ?? ''
+    const bKey = b?.key ?? ''
+    const aFirst = priorityKeys.includes(aKey) ? -1 : 0
+    const bFirst = priorityKeys.includes(bKey) ? -1 : 0
+    if (aFirst !== bFirst) return aFirst - bFirst
+    return 0
+  })
+  replaceHeadComponents(sorted)
+}

--- a/packages/ui/src/gatsby/on-route-update-color-mode.js
+++ b/packages/ui/src/gatsby/on-route-update-color-mode.js
@@ -1,0 +1,14 @@
+import { RECONCILE_COLOR_MODE_EVENT } from '../color-mode/constants.js'
+import { scheduleThemeUiColorModeSync } from '../color-mode/browser-sync.js'
+
+/**
+ * Call from Gatsby `onRouteUpdate` so Theme UI color mode stays aligned with `localStorage` and the
+ * document after client-side navigations. Dispatches {@link RECONCILE_COLOR_MODE_EVENT} for app code
+ * that listens (e.g. React context reconciliation).
+ */
+export function onRouteUpdateThemeUiColorMode() {
+  scheduleThemeUiColorModeSync()
+  if (typeof window !== 'undefined' && typeof window.CustomEvent === 'function') {
+    window.dispatchEvent(new window.CustomEvent(RECONCILE_COLOR_MODE_EVENT))
+  }
+}

--- a/theme/gatsby-browser.js
+++ b/theme/gatsby-browser.js
@@ -11,7 +11,7 @@ import 'prismjs/themes/prism-solarizedlight.css'
 import 'prismjs/plugins/line-numbers/prism-line-numbers.css'
 
 import WrapRootElement from './wrapRootElement'
-import { scheduleThemeUiColorModeSync, RECONCILE_COLOR_MODE_EVENT } from '@chronogrove/ui/color-mode'
+import { onRouteUpdateThemeUiColorMode } from '@chronogrove/ui/gatsby'
 import { getChronogroveEmotionCache } from '@chronogrove/ui/emotion-cache'
 
 export const wrapRootElement = ({ element }) => (
@@ -31,17 +31,14 @@ export const shouldUpdateScroll = ({ routerProps, prevRouterProps }) => {
   return false
 }
 
-export const onRouteUpdate = ({ location, prevLocation }) => {
-  scheduleThemeUiColorModeSync()
-  if (typeof window !== 'undefined' && typeof window.CustomEvent === 'function') {
-    window.dispatchEvent(new window.CustomEvent(RECONCILE_COLOR_MODE_EVENT))
-  }
-
+/** Scroll-to-top and skip-link focus after pathname changes (used with {@link onRouteUpdateThemeUiColorMode} on consumer sites). */
+export const onRouteUpdateChronogroveNavigation = ({ location, prevLocation }) => {
   if (prevLocation !== null) {
     const currentPath = location?.pathname
     const prevPath = prevLocation?.pathname
     if (currentPath === prevPath) return
     const performScrollToTop = () => {
+      /* istanbul ignore next -- gatsby-browser always runs in a browser */
       if (typeof window === 'undefined') return
       const pathname = window.location?.pathname
       const hash = window.location?.hash
@@ -56,4 +53,9 @@ export const onRouteUpdate = ({ location, prevLocation }) => {
       performScrollToTop()
     }
   }
+}
+
+export const onRouteUpdate = ({ location, prevLocation }) => {
+  onRouteUpdateThemeUiColorMode()
+  onRouteUpdateChronogroveNavigation({ location, prevLocation })
 }

--- a/theme/gatsby-browser.spec.js
+++ b/theme/gatsby-browser.spec.js
@@ -1,7 +1,12 @@
 import React from 'react'
 import { render } from '@testing-library/react'
 import '@testing-library/jest-dom'
-import { shouldUpdateScroll, onRouteUpdate, wrapRootElement } from './gatsby-browser'
+import {
+  shouldUpdateScroll,
+  onRouteUpdate,
+  onRouteUpdateChronogroveNavigation,
+  wrapRootElement
+} from './gatsby-browser'
 
 jest.mock('@gatsbyjs/reach-router', () => ({
   ...jest.requireActual('@gatsbyjs/reach-router'),
@@ -47,6 +52,30 @@ afterEach(() => {
 })
 
 describe('gatsby-browser', () => {
+  describe('onRouteUpdateChronogroveNavigation', () => {
+    it('is a no-op when prevLocation is null', () => {
+      expect(() =>
+        onRouteUpdateChronogroveNavigation({ location: { pathname: '/' }, prevLocation: null })
+      ).not.toThrow()
+    })
+
+    it('does not scroll when window is at / with a hash (home hash routes)', () => {
+      mockGetElementById.mockReturnValue(mockSkipContent)
+      const href = window.location.href
+      window.history.pushState({}, '', '/#posts')
+      try {
+        onRouteUpdateChronogroveNavigation({
+          location: { pathname: '/blog', hash: '' },
+          prevLocation: { pathname: '/' }
+        })
+        expect(mockScrollTo).not.toHaveBeenCalled()
+        expect(mockFocus).not.toHaveBeenCalled()
+      } finally {
+        window.history.pushState({}, '', href)
+      }
+    })
+  })
+
   describe('wrapRootElement', () => {
     it('wraps the root element with Emotion cache provider without crashing', () => {
       const wrapped = wrapRootElement({ element: <div>Root content</div> })

--- a/theme/gatsby-ssr.js
+++ b/theme/gatsby-ssr.js
@@ -1,50 +1,18 @@
 import React from 'react'
 import { version as themeVersion } from './package.json'
 import chronogroveTheme from '@chronogrove/ui/theme'
-import {
-  resolveChronogroveSurfaceColors,
-  buildThemeUiNoFlashInlineScript,
-  buildHtmlBackgroundInlineScript,
-  buildThemeUiColorModeFallbackCss,
-  CHRONOGROVE_COLOR_MODE_HEAD_PRIORITY_KEYS
-} from '@chronogrove/ui/color-mode'
+import { buildThemeUiColorModeHeadComponents, onPreRenderHTMLSortThemeUiColorModeFirst } from '@chronogrove/ui/gatsby'
 
 export { default as wrapRootElement } from './wrapRootElement'
 
 export const onRenderBody = ({ setHtmlAttributes, setHeadComponents }) => {
   setHtmlAttributes({ lang: 'en' })
 
-  const surface = resolveChronogroveSurfaceColors(chronogroveTheme)
-  const colorModeScript = buildThemeUiNoFlashInlineScript()
-  const htmlBackgroundScript = buildHtmlBackgroundInlineScript({
-    defaultBackgroundHex: surface.defaultBackgroundHex,
-    darkBackgroundHex: surface.darkBackgroundHex
-  })
-  const colorModeFallbackCSS = buildThemeUiColorModeFallbackCss({
-    defaultTextHex: surface.defaultTextHex,
-    defaultTextMutedHex: surface.defaultTextMutedHex,
-    darkTextHex: surface.darkTextHex,
-    darkTextMutedHex: surface.darkTextMutedHex
-  })
-
   setHeadComponents([
     <meta key='emotion-insertion-point' name='emotion-insertion-point' content='' />,
     <meta key='gatsby-theme-chronogrove-version' name='gatsby-theme-chronogrove-version' content={themeVersion} />,
-    <script key='theme-ui-no-flash' dangerouslySetInnerHTML={{ __html: colorModeScript }} />,
-    <script key='html-bg-color' dangerouslySetInnerHTML={{ __html: htmlBackgroundScript }} />,
-    <style key='theme-ui-color-mode-fallback' dangerouslySetInnerHTML={{ __html: colorModeFallbackCSS }} />
+    ...buildThemeUiColorModeHeadComponents({ theme: chronogroveTheme })
   ])
 }
 
-export const onPreRenderHTML = ({ getHeadComponents, replaceHeadComponents }) => {
-  const headComponents = getHeadComponents()
-  const sorted = [...headComponents].sort((a, b) => {
-    const aKey = a?.key ?? ''
-    const bKey = b?.key ?? ''
-    const aFirst = CHRONOGROVE_COLOR_MODE_HEAD_PRIORITY_KEYS.includes(aKey) ? -1 : 0
-    const bFirst = CHRONOGROVE_COLOR_MODE_HEAD_PRIORITY_KEYS.includes(bKey) ? -1 : 0
-    if (aFirst !== bFirst) return aFirst - bFirst
-    return 0
-  })
-  replaceHeadComponents(sorted)
-}
+export const onPreRenderHTML = onPreRenderHTMLSortThemeUiColorModeFirst

--- a/theme/package.json
+++ b/theme/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-theme-chronogrove",
   "description": "A personal website and digital garden theme for GatsbyJS.",
-  "version": "0.76.0",
+  "version": "0.77.0",
   "author": "Chris Vogt <mail@chrisvogt.me> (https://www.chrisvogt.me)",
   "main": "index.js",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Closes #565.

Adds an optional `@chronogrove/ui/gatsby` subpath so consumers can reuse the same Theme UI color-mode wiring the theme uses: SSR head fragments (no-flash script, HTML background script, fallback CSS), `onPreRenderHTML` head ordering, and client `onRouteUpdate` sync plus the reconcile custom event.

Refactors `gatsby-theme-chronogrove` to call these helpers from `gatsby-ssr.js` and `gatsby-browser.js`, and exports `onRouteUpdateChronogroveNavigation` for sites that want to compose their own `onRouteUpdate` without duplicating scroll/skip-nav logic.

## What changed

### `@chronogrove/ui`

- New export: `./gatsby`
- `buildThemeUiColorModeHeadComponents({ theme })` — three head elements from existing color-mode + `resolveChronogroveSurfaceColors`
- `onPreRenderHTMLSortThemeUiColorModeFirst` — sorts `CHRONOGROVE_COLOR_MODE_HEAD_PRIORITY_KEYS` ahead of other head components
- `onRouteUpdateThemeUiColorMode` — `scheduleThemeUiColorModeSync` + `RECONCILE_COLOR_MODE_EVENT` dispatch
- Re-export: `RECONCILE_COLOR_MODE_EVENT`
- Tests: `packages/ui/src/gatsby/index.spec.js` (barrel API, sort edge cases, route hook)

### Theme

- `gatsby-ssr.js`: uses UI package helpers; `onPreRenderHTML` assigns the sort helper
- `gatsby-browser.js`: `onRouteUpdateThemeUiColorMode` + extracted `onRouteUpdateChronogroveNavigation`
- `gatsby-browser.spec.js`: navigation export + home/hash scroll behavior; `istanbul ignore` on unreachable SSR guard in `performScrollToTop`

### Release

- **Version:** `0.77.0` for `@chronogrove/ui` and `gatsby-theme-chronogrove` (lockstep)
- **Changelog:** `CHANGELOG.md` (0.77.0 section)

## How to verify

```bash
pnpm exec turbo run test:coverage -- --maxWorkers=2
pnpm run lint
```

## Notes

- **Consumer sites** do not need a direct `@chronogrove/ui` dependency for this behavior; the theme already depends on `@chronogrove/ui` and wires `@chronogrove/ui/gatsby` internally.
- Optional direct use of `@chronogrove/ui/gatsby` is for non-theme Gatsby apps or custom `onRouteUpdate` composition.

## Checklist

- [x] Implements #565 (head builders, `onPreRenderHTML` ordering, route reconcile wrapping `@chronogrove/ui/color-mode`)
- [x] Theme `gatsby-ssr` / `gatsby-browser` consume the new module
- [x] Versions + `CHANGELOG.md` updated (`0.77.0`)
- [x] `pnpm exec turbo run test:coverage` and `pnpm run lint` pass locally
