### PR TITLE
fix(ci): correct GitHub Packages name for scoped @chronogrove/ui

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -91,9 +91,13 @@ jobs:
 
             local NPM_NAME
             NPM_NAME=$(node -p "require('./${PKG_JSON}').name")
+            # GitHub Packages uses @OWNER/<single-segment-name>. For npm scoped names
+            # like @chronogrove/ui, "${NPM_NAME#@*/}" wrongly becomes just "ui" — use the
+            # full @scope/pkg string with "/" -> "-" (e.g. chronogrove-ui).
             local BASE_NAME
             if [[ "${NPM_NAME}" == @* ]]; then
-              BASE_NAME="${NPM_NAME#@*/}"
+              local REST="${NPM_NAME#@}"
+              BASE_NAME="${REST//\//-}"
             else
               BASE_NAME="${NPM_NAME}"
             fi


### PR DESCRIPTION
## Summary

The publish workflow computed the GitHub Packages package name for scoped npm packages using `${NPM_NAME#@*/}`, which strips `@scope/` and leaves only the last segment (e.g. `ui`). That produced `@chrisvogt/ui` instead of a name that reflects `@chronogrove/ui`.

## Change

- For scoped names, derive the GitHub segment from the full `scope/pkg` string with `/` replaced by `-` (e.g. `chronogrove-ui` → `@owner/chronogrove-ui`).
- Unscoped packages are unchanged.

## Notes

- npm publishes were already correct; only GitHub Packages naming was wrong.
- Existing versions published under the mistaken name will remain; new publishes will use the corrected name.

Made with [Cursor](https://cursor.com)