### PR TITLE
release: v0.79.0 — @chronogrove/ui ESM packaging, tooling, Gatsby gatsby-browser fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,15 @@
 - **`gatsby-theme-chronogrove` Jest**: `transformIgnorePatterns` now **transpiles `@chronogrove/ui`** from `node_modules` (including `.pnpm` paths) so ESM in the workspace package stays compatible with Babel-Jest.
 - **Root ESLint**: Scoped React/browser rules to `theme/`, `www.chrisvogt.me/`, `www.chronogrove.com/`, and `packages/`; **Node globals** for `eslint.config.js` and `scripts/**` so root tooling still lints.
 
+### `gatsby-theme-chronogrove` — Gatsby `gatsby-browser` API validation
+
+- **Fixed** Gatsby **#11329** (`API.NODE.VALIDATION`): `gatsby-browser.js` may only export [known lifecycle APIs](https://www.gatsbyjs.com/docs/reference/config-files/gatsby-browser/). The scroll/skip-nav helper **`onRouteUpdateChronogroveNavigation`** is moved to **`theme/src/helpers/on-route-update-chronogrove-navigation.js`**. Sites that implement their own `onRouteUpdate` should import that helper (and `@chronogrove/ui/gatsby`’s `onRouteUpdateThemeUiColorMode`) from those modules — do not export custom names from `gatsby-browser.js`.
+
 ### Files changed
 
 - `packages/ui/package.json` (version **0.79.0**)
 - `packages/ui/README.md`, `packages/ui/jest.config.cjs`, `packages/ui/src/color-toggle.js`, `packages/ui/src/skip-nav/SkipNavLink.js`
-- `theme/package.json` (version **0.79.0**), `theme/jest.config.js`
+- `theme/package.json` (version **0.79.0**), `theme/jest.config.js`, `theme/gatsby-browser.js`, `theme/gatsby-browser.spec.js`, `theme/src/helpers/on-route-update-chronogrove-navigation.js` (new)
 - `eslint.config.js`
 
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## 0.79.0
+
+### `@chronogrove/ui` — ESM metadata, packaging, and imports
+
+- **`"type": "module"`** and npm **`files`** (`src`, `README.md`) so published `.js` matches ESM and the tarball omits tests and tooling.
+- **Imports**: `color-toggle.js` and `skip-nav/SkipNavLink.js` use **relative** imports for `isDarkMode` instead of the package self-path; **Jest** `moduleNameMapper` for `@chronogrove/ui/is-dark-mode` removed as redundant.
+- **Docs**: README note to bump **pnpm catalog** entries for shared Theme UI / Emotion deps in the **same PR** for `packages/ui` and `theme`.
+
+### Tooling
+
+- **`gatsby-theme-chronogrove` Jest**: `transformIgnorePatterns` now **transpiles `@chronogrove/ui`** from `node_modules` (including `.pnpm` paths) so ESM in the workspace package stays compatible with Babel-Jest.
+- **Root ESLint**: Scoped React/browser rules to `theme/`, `www.chrisvogt.me/`, `www.chronogrove.com/`, and `packages/`; **Node globals** for `eslint.config.js` and `scripts/**` so root tooling still lints.
+
+### Files changed
+
+- `packages/ui/package.json` (version **0.79.0**)
+- `packages/ui/README.md`, `packages/ui/jest.config.cjs`, `packages/ui/src/color-toggle.js`, `packages/ui/src/skip-nav/SkipNavLink.js`
+- `theme/package.json` (version **0.79.0**), `theme/jest.config.js`
+- `eslint.config.js`
+
+---
+
 ## 0.78.0
 
 ### `@chronogrove/ui` — presentational components (Issue #566)

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -18,9 +18,27 @@ module.exports = [
     ]
   },
   {
-    files: ['theme/**/*.js', 'www.chrisvogt.me/**/*.js']
+    files: ['eslint.config.js'],
+    languageOptions: {
+      ecmaVersion: 'latest',
+      sourceType: 'commonjs',
+      globals: {
+        ...globals.node
+      }
+    }
   },
   {
+    files: ['scripts/**/*.js', 'scripts/**/*.mjs'],
+    languageOptions: {
+      ecmaVersion: 'latest',
+      sourceType: 'module',
+      globals: {
+        ...globals.node
+      }
+    }
+  },
+  {
+    files: ['theme/**/*.js', 'www.chrisvogt.me/**/*.js', 'www.chronogrove.com/**/*.js', 'packages/**/*.js'],
     languageOptions: {
       ecmaVersion: 2022,
       sourceType: 'module',
@@ -44,6 +62,7 @@ module.exports = [
   },
   js.configs.recommended,
   {
+    files: ['theme/**/*.js', 'www.chrisvogt.me/**/*.js', 'www.chronogrove.com/**/*.js', 'packages/**/*.js'],
     plugins: {
       react,
       'jsx-a11y': jsxA11Y,

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -12,6 +12,8 @@ pnpm add @chronogrove/ui
 
 Use **`pnpm publish`** for releases so `workspace:` dependencies in dependents are rewritten; see [pnpm workspaces — publishing](https://pnpm.io/workspaces#publishing-workspace-packages).
 
+**Shared dependencies with `gatsby-theme-chronogrove`:** both packages depend on Theme UI, Emotion, and related libraries, with versions driven by the root [pnpm catalog](../../pnpm-workspace.yaml). When you bump those catalog entries, update **`packages/ui`** and **`theme`** in the **same change** so the theme and `@chronogrove/ui` stay aligned and you avoid duplicate or mismatched installs.
+
 ## Subpath exports
 
 Prefer deep imports so bundles stay lean:

--- a/packages/ui/jest.config.cjs
+++ b/packages/ui/jest.config.cjs
@@ -19,7 +19,6 @@ module.exports = {
     'src/theme.js'
   ],
   moduleNameMapper: {
-    '^@chronogrove/ui/is-dark-mode$': '<rootDir>/src/helpers/isDarkMode.js',
     '^@theme-toggles/react$': '<rootDir>/test-utils/mock-theme-toggles-react.js'
   },
   coverageThreshold: {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,8 +1,13 @@
 {
   "name": "@chronogrove/ui",
-  "version": "0.78.0",
+  "version": "0.79.0",
   "description": "Chronogrove Theme UI theme, color mode helpers, and shared UI primitives",
   "license": "MIT",
+  "type": "module",
+  "files": [
+    "src",
+    "README.md"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/chrisvogt/gatsby-theme-chronogrove.git",

--- a/packages/ui/src/color-toggle.js
+++ b/packages/ui/src/color-toggle.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { useColorMode } from 'theme-ui'
 import { Expand } from '@theme-toggles/react'
-import isDarkMode from '@chronogrove/ui/is-dark-mode'
+import isDarkMode from './helpers/isDarkMode.js'
 
 export default function ColorToggle() {
   const [colorMode, setColorMode] = useColorMode()

--- a/packages/ui/src/skip-nav/SkipNavLink.js
+++ b/packages/ui/src/skip-nav/SkipNavLink.js
@@ -1,7 +1,7 @@
 /** @jsx jsx */
 import { jsx, useThemeUI } from 'theme-ui'
 import { forwardRef } from 'react'
-import isDarkMode from '@chronogrove/ui/is-dark-mode'
+import isDarkMode from '../helpers/isDarkMode.js'
 
 const SkipNavLink = forwardRef(function SkipNavLink(
   { as: Comp = 'a', children = 'Skip to content', contentId = 'skip-nav-content', ...props },

--- a/theme/gatsby-browser.js
+++ b/theme/gatsby-browser.js
@@ -13,6 +13,7 @@ import 'prismjs/plugins/line-numbers/prism-line-numbers.css'
 import WrapRootElement from './wrapRootElement'
 import { onRouteUpdateThemeUiColorMode } from '@chronogrove/ui/gatsby'
 import { getChronogroveEmotionCache } from '@chronogrove/ui/emotion-cache'
+import { onRouteUpdateChronogroveNavigation } from './src/helpers/on-route-update-chronogrove-navigation'
 
 export const wrapRootElement = ({ element }) => (
   <CacheProvider value={getChronogroveEmotionCache()}>
@@ -29,30 +30,6 @@ export const shouldUpdateScroll = ({ routerProps, prevRouterProps }) => {
   }
 
   return false
-}
-
-/** Scroll-to-top and skip-link focus after pathname changes (used with {@link onRouteUpdateThemeUiColorMode} on consumer sites). */
-export const onRouteUpdateChronogroveNavigation = ({ location, prevLocation }) => {
-  if (prevLocation !== null) {
-    const currentPath = location?.pathname
-    const prevPath = prevLocation?.pathname
-    if (currentPath === prevPath) return
-    const performScrollToTop = () => {
-      /* istanbul ignore next -- gatsby-browser always runs in a browser */
-      if (typeof window === 'undefined') return
-      const pathname = window.location?.pathname
-      const hash = window.location?.hash
-      if (pathname === '/' && hash) return
-      window.scrollTo(0, 0)
-      const skipContent = document.getElementById('skip-nav-content')
-      if (skipContent) skipContent.focus({ preventScroll: true })
-    }
-    if (typeof window !== 'undefined' && typeof window.requestAnimationFrame === 'function') {
-      window.requestAnimationFrame(performScrollToTop)
-    } else {
-      performScrollToTop()
-    }
-  }
 }
 
 export const onRouteUpdate = ({ location, prevLocation }) => {

--- a/theme/gatsby-browser.spec.js
+++ b/theme/gatsby-browser.spec.js
@@ -1,12 +1,8 @@
 import React from 'react'
 import { render } from '@testing-library/react'
 import '@testing-library/jest-dom'
-import {
-  shouldUpdateScroll,
-  onRouteUpdate,
-  onRouteUpdateChronogroveNavigation,
-  wrapRootElement
-} from './gatsby-browser'
+import { shouldUpdateScroll, onRouteUpdate, wrapRootElement } from './gatsby-browser'
+import { onRouteUpdateChronogroveNavigation } from './src/helpers/on-route-update-chronogrove-navigation'
 
 jest.mock('@gatsbyjs/reach-router', () => ({
   ...jest.requireActual('@gatsbyjs/reach-router'),

--- a/theme/jest.config.js
+++ b/theme/jest.config.js
@@ -90,8 +90,8 @@ module.exports = {
 
   // Allow specific ESM packages in node_modules to be transformed (pnpm uses .pnpm store)
   transformIgnorePatterns: [
-    'node_modules/(?!(gatsby|@mdx-js|react-error-boundary|\\.pnpm)(/|$))',
-    '\\.pnpm/[^/]+/node_modules/(?!(gatsby|@mdx-js|react-error-boundary)/)'
+    'node_modules/(?!(gatsby|@mdx-js|react-error-boundary|@chronogrove/ui|\\.pnpm)(/|$))',
+    '\\.pnpm/[^/]+/node_modules/(?!(gatsby|@mdx-js|react-error-boundary|@chronogrove/ui)/)'
   ],
 
   // Indicates whether each individual test should be reported during the run

--- a/theme/package.json
+++ b/theme/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-theme-chronogrove",
   "description": "A personal website and digital garden theme for GatsbyJS.",
-  "version": "0.78.0",
+  "version": "0.79.0",
   "author": "Chris Vogt <mail@chrisvogt.me> (https://www.chrisvogt.me)",
   "main": "index.js",
   "license": "MIT",

--- a/theme/src/helpers/on-route-update-chronogrove-navigation.js
+++ b/theme/src/helpers/on-route-update-chronogrove-navigation.js
@@ -1,0 +1,32 @@
+/**
+ * Scroll-to-top and skip-link focus after pathname changes.
+ * Used by the theme's `onRouteUpdate` in `gatsby-browser.js`.
+ *
+ * Sites that define their own `onRouteUpdate` can import this helper and call it
+ * alongside `@chronogrove/ui/gatsby`'s `onRouteUpdateThemeUiColorMode` — do not
+ * re-export it from `gatsby-browser.js` (Gatsby only allows known API names there).
+ *
+ * @param {{ location?: { pathname?: string, hash?: string }, prevLocation?: { pathname?: string, hash?: string } | null }}} args
+ */
+export function onRouteUpdateChronogroveNavigation({ location, prevLocation }) {
+  if (prevLocation !== null) {
+    const currentPath = location?.pathname
+    const prevPath = prevLocation?.pathname
+    if (currentPath === prevPath) return
+    const performScrollToTop = () => {
+      /* istanbul ignore next -- gatsby-browser always runs in a browser */
+      if (typeof window === 'undefined') return
+      const pathname = window.location?.pathname
+      const hash = window.location?.hash
+      if (pathname === '/' && hash) return
+      window.scrollTo(0, 0)
+      const skipContent = document.getElementById('skip-nav-content')
+      if (skipContent) skipContent.focus({ preventScroll: true })
+    }
+    if (typeof window !== 'undefined' && typeof window.requestAnimationFrame === 'function') {
+      window.requestAnimationFrame(performScrollToTop)
+    } else {
+      performScrollToTop()
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Ships **`@chronogrove/ui` and `gatsby-theme-chronogrove` at v0.79.0** with clearer ESM packaging, safer Jest/ESLint setup for the monorepo, and a **Gatsby build fix** for invalid `gatsby-browser.js` exports.

---

## Why

### Shared UI package (`@chronogrove/ui`)

- The package already authored **ESM** (`import` / `export`). Declaring **`"type": "module"`** aligns Node and consumers with that reality and avoids ambiguous interpretation of `.js` files.
- Publishing **`files`: `src` + `README.md`** keeps npm tarballs small and predictable (no tests or Jest config in the published artifact).
- **Relative imports** for the `isDarkMode` helper inside the package avoid self-resolution through the package name and keep the module graph obvious for bundlers and tooling.
- **Theme Jest** previously did not whitelist **`@chronogrove/ui`** for Babel transforms. With the UI package explicitly ESM, transpiling it from `node_modules` prevents flaky **“Unexpected token `export`”** failures under Jest as resolution or pnpm layout changes.

### Root ESLint

- React/Prettier rules should apply to **app and package source**, not blindly to every file. Scoping fixes that and adds explicit **Node globals** for **`eslint.config.js`** and **`scripts/**`** so `pnpm lint` stays honest.

### Gatsby `#11329` (`API.NODE.VALIDATION`)

- Gatsby only allows **known lifecycle exports** from `gatsby-browser.js`. Exporting a custom name (**`onRouteUpdateChronogroveNavigation`**) triggered repeated validation errors during **`gatsby build`** (e.g. `www.chrisvogt.me`). The behavior is unchanged; the helper now lives in a **normal module** under `theme/src/helpers/` and is only **imported** by the theme’s real `onRouteUpdate` export.

---

## What changed

| Area | Change |
|------|--------|
| **`@chronogrove/ui`** | `"type": "module"`, npm `files`, relative `isDarkMode` imports, README note on **pnpm catalog** bumps for shared Theme UI / Emotion deps with `theme` |
| **Theme Jest** | `transformIgnorePatterns` includes **`@chronogrove/ui`** (including `.pnpm` paths) |
| **Root ESLint** | Scoped `files` for React stack; Node globals for config and scripts |
| **Theme browser** | New **`on-route-update-chronogrove-navigation.js`**; `gatsby-browser.js` exports only valid Gatsby APIs |

`CHANGELOG.md` is updated for **0.79.0**.

---

## How to verify

- `pnpm lint`
- `pnpm exec turbo run test:coverage`
- `pnpm build` (or site-specific Gatsby build) — **no Gatsby #11329 spam** for `onRouteUpdateChronogroveNavigation`

---

## Notes for consumers

- Sites that only re-export **`onRouteUpdate`** / **`shouldUpdateScroll`** from the theme (e.g. demo site pattern) need **no code changes**.
- Sites that implement a **custom** `onRouteUpdate` should import **`onRouteUpdateChronogroveNavigation`** from `gatsby-theme-chronogrove/src/helpers/on-route-update-chronogrove-navigation` (and Theme UI color-mode from `@chronogrove/ui/gatsby` as before). Do **not** export custom hook names from `gatsby-browser.js`.
