### PR TITLE
chore(deps): Next 16, catalog bumps, ESLint consolidation

### DIFF
--- a/examples/chronogrove-next/package.json
+++ b/examples/chronogrove-next/package.json
@@ -5,21 +5,18 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "eslint ."
   },
   "dependencies": {
     "@fortawesome/free-brands-svg-icons": "^7.2.0",
     "@chronogrove/ui": "workspace:*",
     "@emotion/cache": "catalog:",
     "@emotion/react": "catalog:",
+    "@theme-ui/components": "catalog:",
     "next": "catalog:",
     "react": "catalog:",
     "react-dom": "catalog:",
     "react-placeholder": "^4.1.0",
     "theme-ui": "catalog:"
-  },
-  "devDependencies": {
-    "eslint": "^10.2.0",
-    "eslint-config-next": "catalog:"
   }
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -148,7 +148,7 @@
     "test:coverage": "jest --config jest.config.cjs --coverage --colors"
   },
   "peerDependencies": {
-    "next": "^14.0.0 || ^15.0.0",
+    "next": "^14.0.0 || ^15.0.0 || ^16.0.0",
     "react": "^18.0.0 || ^19.0.0",
     "react-dom": "^18.0.0 || ^19.0.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,9 +24,6 @@ catalogs:
     boxen:
       specifier: ^8.0.1
       version: 8.0.1
-    eslint-config-next:
-      specifier: ^15.1.0
-      version: 15.5.15
     gatsby:
       specifier: ^5.16.1
       version: 5.16.1
@@ -43,8 +40,8 @@ catalogs:
       specifier: ^2.9.0
       version: 2.9.0
     next:
-      specifier: ^15.1.0
-      version: 15.5.15
+      specifier: ^16.2.3
+      version: 16.2.3
     prettier:
       specifier: ^3.8.2
       version: 3.8.2
@@ -105,7 +102,7 @@ importers:
         version: 10.1.8(eslint@10.2.0)
       eslint-plugin-jest:
         specifier: ^29.15.2
-        version: 29.15.2(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3)
+        version: 29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3)
       eslint-plugin-json:
         specifier: ^4.0.1
         version: 4.0.1
@@ -154,9 +151,12 @@ importers:
       '@fortawesome/free-brands-svg-icons':
         specifier: ^7.2.0
         version: 7.2.0
+      '@theme-ui/components':
+        specifier: 'catalog:'
+        version: 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@theme-ui/theme-provider@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(react@19.2.5))(react@19.2.5)
       next:
         specifier: 'catalog:'
-        version: 15.5.15(@babel/core@7.29.0)(babel-plugin-macros@3.1.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+        version: 16.2.3(@babel/core@7.29.0)(babel-plugin-macros@3.1.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       react:
         specifier: 'catalog:'
         version: 19.2.5
@@ -168,14 +168,7 @@ importers:
         version: 4.1.0(react@19.2.5)
       theme-ui:
         specifier: 'catalog:'
-        version: 0.17.4(@emotion/react@11.14.0(react@19.2.5))(react@19.2.5)
-    devDependencies:
-      eslint:
-        specifier: ^10.2.0
-        version: 10.2.0
-      eslint-config-next:
-        specifier: 'catalog:'
-        version: 15.5.15(eslint@10.2.0)(typescript@5.9.3)
+        version: 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(react@19.2.5)
 
   packages/ui:
     dependencies:
@@ -196,7 +189,7 @@ importers:
         version: 4.1.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@theme-ui/components':
         specifier: 'catalog:'
-        version: 0.17.4(@emotion/react@11.14.0(react@19.2.5))(@theme-ui/theme-provider@0.17.4(@emotion/react@11.14.0(react@19.2.5))(react@19.2.5))(react@19.2.5)
+        version: 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@theme-ui/theme-provider@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(react@19.2.5))(react@19.2.5)
       '@theme-ui/presets':
         specifier: ^0.17.4
         version: 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5)))
@@ -205,7 +198,7 @@ importers:
         version: 10.0.3(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       theme-ui:
         specifier: 'catalog:'
-        version: 0.17.4(@emotion/react@11.14.0(react@19.2.5))(react@19.2.5)
+        version: 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(react@19.2.5)
       three:
         specifier: 'catalog:'
         version: 0.183.2
@@ -236,7 +229,7 @@ importers:
         version: 30.3.0
       next:
         specifier: 'catalog:'
-        version: 15.5.15(@babel/core@7.29.0)(babel-plugin-macros@3.1.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+        version: 16.2.3(@babel/core@7.29.0)(babel-plugin-macros@3.1.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       react:
         specifier: 'catalog:'
         version: 19.2.5
@@ -292,8 +285,8 @@ importers:
         specifier: ^3.1.1
         version: 3.1.1(@types/react@19.2.14)(react@19.2.5)
       '@tanstack/react-query':
-        specifier: ^5.97.0
-        version: 5.97.0(react@19.2.5)
+        specifier: ^5.99.0
+        version: 5.99.0(react@19.2.5)
       '@theme-toggles/react':
         specifier: ^4.1.0
         version: 4.1.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -302,10 +295,10 @@ importers:
         version: 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))
       '@theme-ui/components':
         specifier: 'catalog:'
-        version: 0.17.4(@emotion/react@11.14.0(react@19.2.5))(@theme-ui/theme-provider@0.17.4(@emotion/react@11.14.0(react@19.2.5))(react@19.2.5))(react@19.2.5)
+        version: 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@theme-ui/theme-provider@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(react@19.2.5))(react@19.2.5)
       '@theme-ui/css':
         specifier: ^0.17.4
-        version: 0.17.4(@emotion/react@11.14.0(react@19.2.5))
+        version: 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))
       '@theme-ui/mdx':
         specifier: 'catalog:'
         version: 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@types/mdx@2.0.13)(react@19.2.5)
@@ -323,52 +316,52 @@ importers:
         version: 2.5.1
       gatsby-plugin-emotion:
         specifier: ^8.16.0
-        version: 8.16.0(@babel/core@7.29.0)(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3))
+        version: 8.16.0(@babel/core@7.29.0)(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3))
       gatsby-plugin-feed:
         specifier: ^5.16.0
-        version: 5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3))(graphql@16.13.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+        version: 5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3))(graphql@16.13.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       gatsby-plugin-manifest:
         specifier: ^5.16.0
-        version: 5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3))(graphql@16.13.2)
+        version: 5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3))(graphql@16.13.2)
       gatsby-plugin-mdx:
         specifier: ^5.16.0
-        version: 5.16.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(gatsby-source-filesystem@5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3)))(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3))(graphql@16.13.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+        version: 5.16.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(gatsby-source-filesystem@5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3)))(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3))(graphql@16.13.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       gatsby-plugin-sharp:
         specifier: ^5.16.0
-        version: 5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3))(graphql@16.13.2)
+        version: 5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3))(graphql@16.13.2)
       gatsby-plugin-theme-ui:
         specifier: ^0.17.4
-        version: 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5)))(@theme-ui/mdx@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@types/mdx@2.0.13)(react@19.2.5))(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3))(react@19.2.5)(theme-ui@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(react@19.2.5))
+        version: 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5)))(@theme-ui/mdx@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@types/mdx@2.0.13)(react@19.2.5))(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3))(react@19.2.5)(theme-ui@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(react@19.2.5))
       gatsby-remark-autolink-headers:
         specifier: ^6.16.0
-        version: 6.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+        version: 6.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       gatsby-remark-copy-linked-files:
         specifier: ^6.16.0
-        version: 6.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3))
+        version: 6.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3))
       gatsby-remark-embed-video:
         specifier: ^3.2.1
         version: 3.2.1
       gatsby-remark-images:
         specifier: ^7.16.0
-        version: 7.16.0(gatsby-plugin-sharp@5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3))(graphql@16.13.2))(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3))
+        version: 7.16.0(gatsby-plugin-sharp@5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3))(graphql@16.13.2))(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3))
       gatsby-remark-prismjs:
         specifier: ^7.16.0
-        version: 7.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3))(prismjs@1.30.0)
+        version: 7.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3))(prismjs@1.30.0)
       gatsby-source-filesystem:
         specifier: ^5.16.0
-        version: 5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3))
+        version: 5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3))
       gatsby-theme-style-guide:
         specifier: ^0.17.4
-        version: 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5)))(@types/mdx@2.0.13)(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+        version: 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5)))(@types/mdx@2.0.13)(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       gatsby-transformer-json:
         specifier: ^5.16.0
-        version: 5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3))
+        version: 5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3))
       gatsby-transformer-remark:
         specifier: ^6.16.0
-        version: 6.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3))
+        version: 6.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3))
       gatsby-transformer-sharp:
         specifier: ^5.16.0
-        version: 5.16.0(gatsby-plugin-sharp@5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3))(graphql@16.13.2))(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3))(graphql@16.13.2)
+        version: 5.16.0(gatsby-plugin-sharp@5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3))(graphql@16.13.2))(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3))(graphql@16.13.2)
       html-react-parser:
         specifier: ^5.2.17
         version: 5.2.17(@types/react@19.2.14)(react@19.2.5)
@@ -413,7 +406,7 @@ importers:
         version: 3.1.1
       theme-ui:
         specifier: 'catalog:'
-        version: 0.17.4(@emotion/react@11.14.0(react@19.2.5))(react@19.2.5)
+        version: 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(react@19.2.5)
       three:
         specifier: ^0.183.2
         version: 0.183.2
@@ -438,7 +431,7 @@ importers:
         version: 3.16.0(@babel/core@7.29.0)(core-js@3.49.0)
       gatsby:
         specifier: 'catalog:'
-        version: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3)
+        version: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3)
       husky:
         specifier: ^9.1.7
         version: 9.1.7
@@ -468,7 +461,7 @@ importers:
         version: 3.1.1(@types/react@19.2.14)(react@19.2.5)
       '@theme-ui/components':
         specifier: 'catalog:'
-        version: 0.17.4(@emotion/react@11.14.0(react@19.2.5))(@theme-ui/theme-provider@0.17.4(@emotion/react@11.14.0(react@19.2.5))(react@19.2.5))(react@19.2.5)
+        version: 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@theme-ui/theme-provider@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(react@19.2.5))(react@19.2.5)
       '@theme-ui/mdx':
         specifier: 'catalog:'
         version: 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@types/mdx@2.0.13)(react@19.2.5)
@@ -480,16 +473,16 @@ importers:
         version: 7.9.0
       gatsby:
         specifier: 'catalog:'
-        version: 5.16.1(babel-eslint@10.1.0(eslint@10.2.0))(eslint-plugin-jest@29.15.2(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3)
+        version: 5.16.1(babel-eslint@10.1.0(eslint@10.2.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3)
       gatsby-plugin-google-gtag:
         specifier: 'catalog:'
-        version: 5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@10.2.0))(eslint-plugin-jest@29.15.2(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+        version: 5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@10.2.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       gatsby-plugin-robots-txt:
         specifier: 'catalog:'
-        version: 1.8.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@10.2.0))(eslint-plugin-jest@29.15.2(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3))
+        version: 1.8.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@10.2.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3))
       gatsby-plugin-sitemap:
         specifier: 'catalog:'
-        version: 6.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@10.2.0))(eslint-plugin-jest@29.15.2(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+        version: 6.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@10.2.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       gatsby-theme-chronogrove:
         specifier: workspace:*
         version: link:../theme
@@ -513,7 +506,7 @@ importers:
         version: 8.0.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       theme-ui:
         specifier: 'catalog:'
-        version: 0.17.4(@emotion/react@11.14.0(react@19.2.5))(react@19.2.5)
+        version: 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(react@19.2.5)
 
   www.chronogrove.com:
     dependencies:
@@ -525,13 +518,13 @@ importers:
         version: 3.1.1(@types/react@19.2.14)(react@19.2.5)
       '@theme-ui/components':
         specifier: 'catalog:'
-        version: 0.17.4(@emotion/react@11.14.0(react@19.2.5))(@theme-ui/theme-provider@0.17.4(@emotion/react@11.14.0(react@19.2.5))(react@19.2.5))(react@19.2.5)
+        version: 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@theme-ui/theme-provider@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(react@19.2.5))(react@19.2.5)
       '@theme-ui/mdx':
         specifier: 'catalog:'
         version: 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@types/mdx@2.0.13)(react@19.2.5)
       gatsby:
         specifier: 'catalog:'
-        version: 5.16.1(babel-eslint@10.1.0(eslint@10.2.0))(eslint-plugin-jest@29.15.2(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3)
+        version: 5.16.1(babel-eslint@10.1.0(eslint@10.2.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3)
       gatsby-theme-chronogrove:
         specifier: workspace:*
         version: link:../theme
@@ -543,7 +536,7 @@ importers:
         version: 19.2.5(react@19.2.5)
       theme-ui:
         specifier: 'catalog:'
-        version: 0.17.4(@emotion/react@11.14.0(react@19.2.5))(react@19.2.5)
+        version: 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(react@19.2.5)
 
 packages:
 
@@ -1994,60 +1987,57 @@ packages:
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
 
-  '@next/env@15.5.15':
-    resolution: {integrity: sha512-vcmyu5/MyFzN7CdqRHO3uHO44p/QPCZkuTUXroeUmhNP8bL5PHFEhik22JUazt+CDDoD6EpBYRCaS2pISL+/hg==}
+  '@next/env@16.2.3':
+    resolution: {integrity: sha512-ZWXyj4uNu4GCWQw9cjRxWlbD+33mcDszIo9iQxFnBX3Wmgq9ulaSJcl6VhuWx5pCWqqD+9W6Wfz7N0lM5lYPMA==}
 
-  '@next/eslint-plugin-next@15.5.15':
-    resolution: {integrity: sha512-ExQoBfyKMjAUQ2nuF39ryQsG26H374ZfH13dlOZqf6TaE9ycRbIm+qUbUFCliU4BtQhiqtS7cnGA1yWfPMQ+jA==}
-
-  '@next/swc-darwin-arm64@15.5.15':
-    resolution: {integrity: sha512-6PvFO2Tzt10GFK2Ro9tAVEtacMqRmTarYMFKAnV2vYMdwWc73xzmDQyAV7SwEdMhzmiRoo7+m88DuiXlJlGeaw==}
+  '@next/swc-darwin-arm64@16.2.3':
+    resolution: {integrity: sha512-u37KDKTKQ+OQLvY+z7SNXixwo4Q2/IAJFDzU1fYe66IbCE51aDSAzkNDkWmLN0yjTUh4BKBd+hb69jYn6qqqSg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
 
-  '@next/swc-darwin-x64@15.5.15':
-    resolution: {integrity: sha512-G+YNV+z6FDZTp/+IdGyIMFqalBTaQSnvAA+X/hrt+eaTRFSznRMz9K7rTmzvM6tDmKegNtyzgufZW0HwVzEqaQ==}
+  '@next/swc-darwin-x64@16.2.3':
+    resolution: {integrity: sha512-gHjL/qy6Q6CG3176FWbAKyKh9IfntKZTB3RY/YOJdDFpHGsUDXVH38U4mMNpHVGXmeYW4wj22dMp1lTfmu/bTQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
 
-  '@next/swc-linux-arm64-gnu@15.5.15':
-    resolution: {integrity: sha512-eVkrMcVIBqGfXB+QUC7jjZ94Z6uX/dNStbQFabewAnk13Uy18Igd1YZ/GtPRzdhtm7QwC0e6o7zOQecul4iC1w==}
+  '@next/swc-linux-arm64-gnu@16.2.3':
+    resolution: {integrity: sha512-U6vtblPtU/P14Y/b/n9ZY0GOxbbIhTFuaFR7F4/uMBidCi2nSdaOFhA0Go81L61Zd6527+yvuX44T4ksnf8T+Q==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@next/swc-linux-arm64-musl@15.5.15':
-    resolution: {integrity: sha512-RwSHKMQ7InLy5GfkY2/n5PcFycKA08qI1VST78n09nN36nUPqCvGSMiLXlfUmzmpQpF6XeBYP2KRWHi0UW3uNg==}
+  '@next/swc-linux-arm64-musl@16.2.3':
+    resolution: {integrity: sha512-/YV0LgjHUmfhQpn9bVoGc4x4nan64pkhWR5wyEV8yCOfwwrH630KpvRg86olQHTwHIn1z59uh6JwKvHq1h4QEw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@next/swc-linux-x64-gnu@15.5.15':
-    resolution: {integrity: sha512-nplqvY86LakS+eeiuWsNWvfmK8pFcOEW7ZtVRt4QH70lL+0x6LG/m1OpJ/tvrbwjmR8HH9/fH2jzW1GlL03TIg==}
+  '@next/swc-linux-x64-gnu@16.2.3':
+    resolution: {integrity: sha512-/HiWEcp+WMZ7VajuiMEFGZ6cg0+aYZPqCJD3YJEfpVWQsKYSjXQG06vJP6F1rdA03COD9Fef4aODs3YxKx+RDQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@next/swc-linux-x64-musl@15.5.15':
-    resolution: {integrity: sha512-eAgl9NKQ84/sww0v81DQINl/vL2IBxD7sMybd0cWRw6wqgouVI53brVRBrggqBRP/NWeIAE1dm5cbKYoiMlqDQ==}
+  '@next/swc-linux-x64-musl@16.2.3':
+    resolution: {integrity: sha512-Kt44hGJfZSefebhk/7nIdivoDr3Ugp5+oNz9VvF3GUtfxutucUIHfIO0ZYO8QlOPDQloUVQn4NVC/9JvHRk9hw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@next/swc-win32-arm64-msvc@15.5.15':
-    resolution: {integrity: sha512-GJVZC86lzSquh0MtvZT+L7G8+jMnJcldloOjA8Kf3wXvBrvb6OGe2MzPuALxFshSm/IpwUtD2mIoof39ymf52A==}
+  '@next/swc-win32-arm64-msvc@16.2.3':
+    resolution: {integrity: sha512-O2NZ9ie3Tq6xj5Z5CSwBT3+aWAMW2PIZ4egUi9MaWLkwaehgtB7YZjPm+UpcNpKOme0IQuqDcor7BsW6QBiQBw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
 
-  '@next/swc-win32-x64-msvc@15.5.15':
-    resolution: {integrity: sha512-nFucjVdwlFqxh/JG3hWSJ4p8+YJV7Ii8aPDuBQULB6DzUF4UNZETXLfEUk+oI2zEznWWULPt7MeuTE6xtK1HSA==}
+  '@next/swc-win32-x64-msvc@16.2.3':
+    resolution: {integrity: sha512-Ibm29/GgB/ab5n7XKqlStkm54qqZE8v2FnijUPBgrd67FWrac45o/RsNlaOWjme/B5UqeWt/8KM4aWBwA1D2Kw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -2066,10 +2056,6 @@ packages:
   '@nodelib/fs.walk@1.2.8':
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
-
-  '@nolyfill/is-core-module@1.0.39':
-    resolution: {integrity: sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==}
-    engines: {node: '>=12.4.0'}
 
   '@parcel/bundler-default@2.8.3':
     resolution: {integrity: sha512-yJvRsNWWu5fVydsWk3O2L4yIy3UZiKWO2cPDukGOIWMgp/Vbpp+2Ct5IygVRtE22bnseW/E/oe0PV3d2IkEJGg==}
@@ -2333,9 +2319,6 @@ packages:
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
 
-  '@rushstack/eslint-patch@1.16.1':
-    resolution: {integrity: sha512-TvZbIpeKqGQQ7X0zSCvPH9riMSFQFSggnfBjFZ1mEoILW+UuXCKwOoPcgjMwiUtRqFZ8jWhPJc4um14vC6I4ag==}
-
   '@sideway/address@4.1.5':
     resolution: {integrity: sha512-IqO/DUQHUkPeixNQ8n0JA6102hT9CmaljNTPmQ1u8MEhBo/R4Q8eKLN/vGZxuebwOroDB4cbpjheD4+/sKFK4Q==}
 
@@ -2370,8 +2353,8 @@ packages:
   '@sinonjs/commons@3.0.1':
     resolution: {integrity: sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==}
 
-  '@sinonjs/fake-timers@15.3.1':
-    resolution: {integrity: sha512-oDDGPn/4jD3viZLphixgu1jwT0bqIqP25FNXC5OkWrUqHZOF4wATtSyVzluOt4DqcMqSoKMClyhUllKSxpQCng==}
+  '@sinonjs/fake-timers@15.3.2':
+    resolution: {integrity: sha512-mrn35Jl2pCpns+mE3HaZa1yPN5EYCRgiMI+135COjr2hr8Cls9DXqIZ57vZe2cz7y2XVSq92tcs6kGQcT1J8Rw==}
 
   '@socket.io/component-emitter@3.1.2':
     resolution: {integrity: sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==}
@@ -2435,11 +2418,11 @@ packages:
     resolution: {integrity: sha512-+PmQX0PiAYPMeVYe237LJAYvOMYW1j2rH5YROyS3b4CTVJum34HfRvKvAzozHAQG0TnHNdUfY9nCeUyRAs//cw==}
     engines: {node: '>=14.16'}
 
-  '@tanstack/query-core@5.97.0':
-    resolution: {integrity: sha512-QdpLP5VzVMgo4VtaPppRA2W04UFjIqX+bxke/ZJhE5cfd5UPkRzqIAJQt9uXkQJjqE8LBOMbKv7f8HCsZltXlg==}
+  '@tanstack/query-core@5.99.0':
+    resolution: {integrity: sha512-3Jv3WQG0BCcH7G+7lf/bP8QyBfJOXeY+T08Rin3GZ1bshvwlbPt7NrDHMEzGdKIOmOzvIQmxjk28YEQX60k7pQ==}
 
-  '@tanstack/react-query@5.97.0':
-    resolution: {integrity: sha512-y4So4eGcQoK2WVMAcDNZE9ofB/p5v1OlKvtc1F3uqHwrtifobT7q+ZnXk2mRkc8E84HKYSlAE9z6HXl2V0+ySQ==}
+  '@tanstack/react-query@5.99.0':
+    resolution: {integrity: sha512-OY2bCqPemT1LlqJ8Y2CUau4KELnIhhG9Ol3ZndPbdnB095pRbPo1cHuXTndg8iIwtoHTgwZjyaDnQ0xD0mYwAw==}
     peerDependencies:
       react: ^18 || ^19
 
@@ -2813,6 +2796,14 @@ packages:
       typescript:
         optional: true
 
+  '@typescript-eslint/eslint-plugin@8.58.1':
+    resolution: {integrity: sha512-eSkwoemjo76bdXl2MYqtxg51HNwUSkWfODUOQ3PaTLZGh9uIWWFZIjyjaJnex7wXDu+TRx+ATsnSxdN9YWfRTQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      '@typescript-eslint/parser': ^8.58.1
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
   '@typescript-eslint/parser@5.62.0':
     resolution: {integrity: sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -2822,6 +2813,13 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  '@typescript-eslint/parser@8.58.1':
+    resolution: {integrity: sha512-gGkiNMPqerb2cJSVcruigx9eHBlLG14fSdPdqMoOcBfh+vvn4iCq2C8MzUB89PrxOXk0y3GZ1yIWb9aOzL93bw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
 
   '@typescript-eslint/project-service@8.58.1':
     resolution: {integrity: sha512-gfQ8fk6cxhtptek+/8ZIqw8YrRW5048Gug8Ts5IYcMLCw18iUgrZAEY/D7s4hkI0FxEfGakKuPK/XUMPzPxi5g==}
@@ -2852,6 +2850,13 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  '@typescript-eslint/type-utils@8.58.1':
+    resolution: {integrity: sha512-HUFxvTJVroT+0rXVJC7eD5zol6ID+Sn5npVPWoFuHGg9Ncq5Q4EYstqR+UOqaNRFXi5TYkpXXkLhoCHe3G0+7w==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
 
   '@typescript-eslint/types@5.62.0':
     resolution: {integrity: sha512-87NVngcbVXUahrRTqIK27gD2t5Cu1yuCXxbLcFtCzZGlfyVWWh8mLHkoxzjsB6DDNnvdL+fW8MiwPEJyGJQDgQ==}
@@ -3484,8 +3489,8 @@ packages:
     resolution: {integrity: sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==}
     engines: {node: ^4.5.0 || >= 5.9}
 
-  baseline-browser-mapping@2.10.17:
-    resolution: {integrity: sha512-HdrkN8eVG2CXxeifv/VdJ4A4RSra1DTW8dc/hdxzhGHN8QePs6gKaWM9pHPcpCoxYZJuOZ8drHmbdpLHjCYjLA==}
+  baseline-browser-mapping@2.10.18:
+    resolution: {integrity: sha512-VSnGQAOLtP5mib/DPyg2/t+Tlv65NTBz83BJBJvmLVHHuKJVaDOBvJJykiT5TR++em5nfAySPccDZDa4oSrn8A==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -3528,11 +3533,11 @@ packages:
     resolution: {integrity: sha512-F3PH5k5juxom4xktynS7MoFY+NUWH5LC4CnH11YB8NPew+HLpmBLCybSAEyb2F+4pRXhuhWqFesoQd6DAyc2hw==}
     engines: {node: '>=18'}
 
-  brace-expansion@1.1.13:
-    resolution: {integrity: sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==}
+  brace-expansion@1.1.14:
+    resolution: {integrity: sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==}
 
-  brace-expansion@2.0.3:
-    resolution: {integrity: sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==}
+  brace-expansion@2.1.0:
+    resolution: {integrity: sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==}
 
   brace-expansion@5.0.5:
     resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
@@ -4546,15 +4551,6 @@ packages:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
 
-  eslint-config-next@15.5.15:
-    resolution: {integrity: sha512-mI5KIONOIosjF3jK2z9a8fY2LePNeW5C4lRJ+XZoJHAKkwx2MQjMPQ2/kL7tsMRPcQPZc/UBtCfqxElluL1CBg==}
-    peerDependencies:
-      eslint: ^7.23.0 || ^8.0.0 || ^9.0.0
-      typescript: '>=3.3.1'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-
   eslint-config-prettier@10.1.8:
     resolution: {integrity: sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==}
     hasBin: true
@@ -4587,19 +4583,6 @@ packages:
 
   eslint-import-resolver-node@0.3.10:
     resolution: {integrity: sha512-tRrKqFyCaKict5hOd244sL6EQFNycnMQnBe+j8uqGNXYzsImGbGUU4ibtoaBmv5FLwJwcFJNeg1GeVjQfbMrDQ==}
-
-  eslint-import-resolver-typescript@3.10.1:
-    resolution: {integrity: sha512-A1rHYb06zjMGAxdLSkN2fXPBwuSaQ0iO5M/hdyS0Ajj1VBaRp0sPD3dn1FhME3c/JluGFbwSxyCfqdSbtQLAHQ==}
-    engines: {node: ^14.18.0 || >=16.0.0}
-    peerDependencies:
-      eslint: '*'
-      eslint-plugin-import: '*'
-      eslint-plugin-import-x: '*'
-    peerDependenciesMeta:
-      eslint-plugin-import:
-        optional: true
-      eslint-plugin-import-x:
-        optional: true
 
   eslint-module-utils@2.12.1:
     resolution: {integrity: sha512-L8jSWTze7K2mTg0vos/RuLRS5soomksDPoJLXIslC7c8Wmut3bx7CPpJijDcBZtxQ5lrbUdM+s0OlNbz0DCDNw==}
@@ -4683,12 +4666,6 @@ packages:
     engines: {node: '>=10'}
     peerDependencies:
       eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0
-
-  eslint-plugin-react-hooks@5.2.0:
-    resolution: {integrity: sha512-+f15FfK64YQwZdJNELETdn5ibXEUQmW1DZL6KXhNnc2heoy/sg9VJJeT7n8TlMWouzWqSWavFkIhHyIbIAEapg==}
-    engines: {node: '>=10'}
-    peerDependencies:
-      eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0
 
   eslint-plugin-react-hooks@7.0.1:
     resolution: {integrity: sha512-O0d0m04evaNzEPoSW+59Mezf8Qt0InfgGIBJnpC0h3NH/WjUAR7BIKUfysC6todmtiZ/A0oUVS8Gce0WhBrHsA==}
@@ -4900,10 +4877,6 @@ packages:
 
   fast-fifo@1.3.2:
     resolution: {integrity: sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==}
-
-  fast-glob@3.3.1:
-    resolution: {integrity: sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==}
-    engines: {node: '>=8.6.0'}
 
   fast-glob@3.3.3:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
@@ -5376,9 +5349,6 @@ packages:
   get-symbol-description@1.1.0:
     resolution: {integrity: sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==}
     engines: {node: '>= 0.4'}
-
-  get-tsconfig@4.13.7:
-    resolution: {integrity: sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==}
 
   get-video-id@3.7.0:
     resolution: {integrity: sha512-hU5pnODTo87slfs9MUFO3vpJr23AESJHmF20T3ivqQJZ/Wz0W5TxjSrGoyB6X538Shyi6tCCpQSeBoV88F9NYA==}
@@ -5855,9 +5825,6 @@ packages:
   is-buffer@2.0.5:
     resolution: {integrity: sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==}
     engines: {node: '>=4'}
-
-  is-bun-module@2.0.0:
-    resolution: {integrity: sha512-gNCGbnnnnFAUGKeZ9PdbyeGYJqewpmc2aKHUEMO5nQPWU9lOmv7jcmQIv+qHD8fXW6W7qfuCwX4rY9LNRjXrkQ==}
 
   is-callable@1.2.7:
     resolution: {integrity: sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==}
@@ -7099,9 +7066,9 @@ packages:
   next-tick@1.1.0:
     resolution: {integrity: sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==}
 
-  next@15.5.15:
-    resolution: {integrity: sha512-VSqCrJwtLVGwAVE0Sb/yikrQfkwkZW9p+lL/J4+xe+G3ZA+QnWPqgcfH1tDUEuk9y+pthzzVFp4L/U8JerMfMQ==}
-    engines: {node: ^18.18.0 || ^19.8.0 || >= 20.0.0}
+  next@16.2.3:
+    resolution: {integrity: sha512-9V3zV4oZFza3PVev5/poB9g0dEafVcgNyQ8eTRop8GvxZjV2G15FC5ARuG1eFD42QgeYkzJBJzHghNP8Ad9xtA==}
+    engines: {node: '>=20.9.0'}
     hasBin: true
     peerDependencies:
       '@opentelemetry/api': ^1.1.0
@@ -8133,11 +8100,8 @@ packages:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
     engines: {node: '>=8'}
 
-  resolve-pkg-maps@1.0.0:
-    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
-
-  resolve@1.22.11:
-    resolution: {integrity: sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==}
+  resolve@1.22.12:
+    resolution: {integrity: sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==}
     engines: {node: '>= 0.4'}
     hasBin: true
 
@@ -8477,9 +8441,6 @@ packages:
 
   sprintf-js@1.1.3:
     resolution: {integrity: sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==}
-
-  stable-hash@0.0.5:
-    resolution: {integrity: sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==}
 
   stable@0.1.8:
     resolution: {integrity: sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==}
@@ -9652,7 +9613,7 @@ snapshots:
       '@babel/helper-plugin-utils': 7.28.6
       debug: 4.4.3
       lodash.debounce: 4.0.8
-      resolve: 1.22.11
+      resolve: 1.22.12
     transitivePeerDependencies:
       - supports-color
 
@@ -11087,7 +11048,7 @@ snapshots:
   '@jest/fake-timers@30.3.0':
     dependencies:
       '@jest/types': 30.3.0
-      '@sinonjs/fake-timers': 15.3.1
+      '@sinonjs/fake-timers': 15.3.2
       '@types/node': 25.6.0
       jest-message-util: 30.3.0
       jest-mock: 30.3.0
@@ -11368,34 +11329,30 @@ snapshots:
       '@tybys/wasm-util': 0.10.1
     optional: true
 
-  '@next/env@15.5.15': {}
+  '@next/env@16.2.3': {}
 
-  '@next/eslint-plugin-next@15.5.15':
-    dependencies:
-      fast-glob: 3.3.1
-
-  '@next/swc-darwin-arm64@15.5.15':
+  '@next/swc-darwin-arm64@16.2.3':
     optional: true
 
-  '@next/swc-darwin-x64@15.5.15':
+  '@next/swc-darwin-x64@16.2.3':
     optional: true
 
-  '@next/swc-linux-arm64-gnu@15.5.15':
+  '@next/swc-linux-arm64-gnu@16.2.3':
     optional: true
 
-  '@next/swc-linux-arm64-musl@15.5.15':
+  '@next/swc-linux-arm64-musl@16.2.3':
     optional: true
 
-  '@next/swc-linux-x64-gnu@15.5.15':
+  '@next/swc-linux-x64-gnu@16.2.3':
     optional: true
 
-  '@next/swc-linux-x64-musl@15.5.15':
+  '@next/swc-linux-x64-musl@16.2.3':
     optional: true
 
-  '@next/swc-win32-arm64-msvc@15.5.15':
+  '@next/swc-win32-arm64-msvc@16.2.3':
     optional: true
 
-  '@next/swc-win32-x64-msvc@15.5.15':
+  '@next/swc-win32-x64-msvc@16.2.3':
     optional: true
 
   '@nicolo-ribaudo/eslint-scope-5-internals@5.1.1-v1':
@@ -11413,8 +11370,6 @@ snapshots:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
-
-  '@nolyfill/is-core-module@1.0.39': {}
 
   '@parcel/bundler-default@2.8.3(@parcel/core@2.8.3)':
     dependencies:
@@ -11744,8 +11699,6 @@ snapshots:
 
   '@rtsao/scc@1.1.0': {}
 
-  '@rushstack/eslint-patch@1.16.1': {}
-
   '@sideway/address@4.1.5':
     dependencies:
       '@hapi/hoek': 9.3.0
@@ -11784,7 +11737,7 @@ snapshots:
     dependencies:
       type-detect: 4.0.8
 
-  '@sinonjs/fake-timers@15.3.1':
+  '@sinonjs/fake-timers@15.3.2':
     dependencies:
       '@sinonjs/commons': 3.0.1
 
@@ -11868,11 +11821,11 @@ snapshots:
     dependencies:
       defer-to-connect: 2.0.1
 
-  '@tanstack/query-core@5.97.0': {}
+  '@tanstack/query-core@5.99.0': {}
 
-  '@tanstack/react-query@5.97.0(react@19.2.5)':
+  '@tanstack/react-query@5.99.0(react@19.2.5)':
     dependencies:
-      '@tanstack/query-core': 5.97.0
+      '@tanstack/query-core': 5.99.0
       react: 19.2.5
 
   '@testing-library/dom@10.4.1':
@@ -11909,122 +11862,122 @@ snapshots:
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
 
-  '@theme-ui/color-modes@0.17.4(@emotion/react@11.14.0(react@19.2.5))(react@19.2.5)':
+  '@theme-ui/color-modes@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(react@19.2.5)':
     dependencies:
       '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.5)
-      '@theme-ui/core': 0.17.4(@emotion/react@11.14.0(react@19.2.5))(react@19.2.5)
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.5))
+      '@theme-ui/core': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(react@19.2.5)
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))
       deepmerge: 4.3.1
       react: 19.2.5
 
   '@theme-ui/color@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))':
     dependencies:
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.5))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))
       polished: 4.3.1
     transitivePeerDependencies:
       - '@emotion/react'
 
-  '@theme-ui/components@0.17.4(@emotion/react@11.14.0(react@19.2.5))(@theme-ui/theme-provider@0.17.4(@emotion/react@11.14.0(react@19.2.5))(react@19.2.5))(react@19.2.5)':
+  '@theme-ui/components@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@theme-ui/theme-provider@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(react@19.2.5))(react@19.2.5)':
     dependencies:
       '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.5)
       '@styled-system/color': 5.1.2
       '@styled-system/should-forward-prop': 5.1.5
       '@styled-system/space': 5.1.2
-      '@theme-ui/core': 0.17.4(@emotion/react@11.14.0(react@19.2.5))(react@19.2.5)
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.5))
-      '@theme-ui/theme-provider': 0.17.4(@emotion/react@11.14.0(react@19.2.5))(react@19.2.5)
+      '@theme-ui/core': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(react@19.2.5)
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))
+      '@theme-ui/theme-provider': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(react@19.2.5)
       '@types/styled-system': 5.1.25
       react: 19.2.5
 
-  '@theme-ui/core@0.17.4(@emotion/react@11.14.0(react@19.2.5))(react@19.2.5)':
+  '@theme-ui/core@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(react@19.2.5)':
     dependencies:
       '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.5)
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.5))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))
       deepmerge: 4.3.1
       react: 19.2.5
 
-  '@theme-ui/css@0.17.4(@emotion/react@11.14.0(react@19.2.5))':
+  '@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))':
     dependencies:
       '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.5)
       csstype: 3.2.3
 
-  '@theme-ui/global@0.17.4(@emotion/react@11.14.0(react@19.2.5))(react@19.2.5)':
+  '@theme-ui/global@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(react@19.2.5)':
     dependencies:
       '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.5)
-      '@theme-ui/core': 0.17.4(@emotion/react@11.14.0(react@19.2.5))(react@19.2.5)
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.5))
+      '@theme-ui/core': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(react@19.2.5)
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))
       react: 19.2.5
 
   '@theme-ui/mdx@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@types/mdx@2.0.13)(react@19.2.5)':
     dependencies:
       '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.5)
-      '@theme-ui/core': 0.17.4(@emotion/react@11.14.0(react@19.2.5))(react@19.2.5)
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.5))
+      '@theme-ui/core': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(react@19.2.5)
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))
       '@types/mdx': 2.0.13
       react: 19.2.5
 
   '@theme-ui/preset-base@0.17.4(@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5)))':
     dependencies:
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.5))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))
 
   '@theme-ui/preset-bootstrap@0.17.4(@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5)))':
     dependencies:
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.5))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))
 
   '@theme-ui/preset-bulma@0.17.4(@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5)))':
     dependencies:
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.5))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))
       '@theme-ui/preset-base': 0.17.4(@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5)))
 
   '@theme-ui/preset-dark@0.17.4(@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5)))':
     dependencies:
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.5))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))
 
   '@theme-ui/preset-deep@0.17.4(@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5)))':
     dependencies:
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.5))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))
 
   '@theme-ui/preset-funk@0.17.4(@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5)))':
     dependencies:
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.5))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))
       '@theme-ui/preset-base': 0.17.4(@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5)))
 
   '@theme-ui/preset-future@0.17.4(@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5)))':
     dependencies:
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.5))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))
       '@theme-ui/preset-base': 0.17.4(@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5)))
 
   '@theme-ui/preset-polaris@0.17.4(@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5)))':
     dependencies:
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.5))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))
       '@theme-ui/preset-base': 0.17.4(@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5)))
 
   '@theme-ui/preset-roboto@0.17.4(@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5)))':
     dependencies:
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.5))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))
       '@theme-ui/preset-base': 0.17.4(@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5)))
 
   '@theme-ui/preset-sketchy@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))':
     dependencies:
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.5))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))
     transitivePeerDependencies:
       - '@emotion/react'
 
   '@theme-ui/preset-swiss@0.17.4(@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5)))':
     dependencies:
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.5))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))
 
   '@theme-ui/preset-system@0.17.4(@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5)))':
     dependencies:
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.5))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))
 
   '@theme-ui/preset-tailwind@0.17.4(@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5)))':
     dependencies:
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.5))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))
 
   '@theme-ui/preset-tosh@0.17.4(@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5)))':
     dependencies:
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.5))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))
 
   '@theme-ui/presets@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5)))':
     dependencies:
@@ -12048,10 +12001,10 @@ snapshots:
 
   '@theme-ui/prism@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@theme-ui/mdx@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@types/mdx@2.0.13)(react@19.2.5))(react@19.2.5)(theme-ui@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(react@19.2.5))':
     dependencies:
-      '@theme-ui/core': 0.17.4(@emotion/react@11.14.0(react@19.2.5))(react@19.2.5)
+      '@theme-ui/core': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(react@19.2.5)
       '@theme-ui/mdx': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@types/mdx@2.0.13)(react@19.2.5)
       prism-react-renderer: 1.3.5(react@19.2.5)
-      theme-ui: 0.17.4(@emotion/react@11.14.0(react@19.2.5))(react@19.2.5)
+      theme-ui: 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(react@19.2.5)
     transitivePeerDependencies:
       - '@emotion/react'
       - react
@@ -12059,23 +12012,23 @@ snapshots:
   '@theme-ui/style-guide@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5)))(react@19.2.5)(theme-ui@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(react@19.2.5))':
     dependencies:
       '@theme-ui/color': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))
-      '@theme-ui/core': 0.17.4(@emotion/react@11.14.0(react@19.2.5))(react@19.2.5)
+      '@theme-ui/core': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(react@19.2.5)
       '@theme-ui/presets': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5)))
       '@types/color': 3.0.7
       color: 3.2.1
       lodash.get: 4.4.2
       react: 19.2.5
-      theme-ui: 0.17.4(@emotion/react@11.14.0(react@19.2.5))(react@19.2.5)
+      theme-ui: 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(react@19.2.5)
     transitivePeerDependencies:
       - '@emotion/react'
       - '@theme-ui/css'
 
-  '@theme-ui/theme-provider@0.17.4(@emotion/react@11.14.0(react@19.2.5))(react@19.2.5)':
+  '@theme-ui/theme-provider@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(react@19.2.5)':
     dependencies:
       '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.5)
-      '@theme-ui/color-modes': 0.17.4(@emotion/react@11.14.0(react@19.2.5))(react@19.2.5)
-      '@theme-ui/core': 0.17.4(@emotion/react@11.14.0(react@19.2.5))(react@19.2.5)
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.5))
+      '@theme-ui/color-modes': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(react@19.2.5)
+      '@theme-ui/core': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(react@19.2.5)
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))
       react: 19.2.5
 
   '@tokenizer/token@0.3.0': {}
@@ -12260,7 +12213,7 @@ snapshots:
 
   '@types/sax@1.2.7':
     dependencies:
-      '@types/node': 25.6.0
+      '@types/node': 17.0.45
 
   '@types/semver@7.7.1': {}
 
@@ -12288,25 +12241,6 @@ snapshots:
 
   '@types/yoga-layout@1.9.2': {}
 
-  '@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(typescript@5.9.3)':
-    dependencies:
-      '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 5.62.0(eslint@10.2.0)(typescript@5.9.3)
-      '@typescript-eslint/scope-manager': 5.62.0
-      '@typescript-eslint/type-utils': 5.62.0(eslint@10.2.0)(typescript@5.9.3)
-      '@typescript-eslint/utils': 5.62.0(eslint@10.2.0)(typescript@5.9.3)
-      debug: 4.4.3
-      eslint: 10.2.0
-      graphemer: 1.4.0
-      ignore: 5.3.2
-      natural-compare-lite: 1.4.0
-      semver: 7.7.4
-      tsutils: 3.21.0(typescript@5.9.3)
-    optionalDependencies:
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - supports-color
-
   '@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.9.3))(eslint@7.32.0)(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
@@ -12326,17 +12260,22 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@5.62.0(eslint@10.2.0)(typescript@5.9.3)':
+  '@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/scope-manager': 5.62.0
-      '@typescript-eslint/types': 5.62.0
-      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.9.3)
-      debug: 4.4.3
+      '@eslint-community/regexpp': 4.12.2
+      '@typescript-eslint/parser': 8.58.1(eslint@10.2.0)(typescript@5.9.3)
+      '@typescript-eslint/scope-manager': 8.58.1
+      '@typescript-eslint/type-utils': 8.58.1(eslint@10.2.0)(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.58.1(eslint@10.2.0)(typescript@5.9.3)
+      '@typescript-eslint/visitor-keys': 8.58.1
       eslint: 10.2.0
-    optionalDependencies:
+      ignore: 7.0.5
+      natural-compare: 1.4.0
+      ts-api-utils: 2.5.0(typescript@5.9.3)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
   '@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.9.3)':
     dependencies:
@@ -12349,6 +12288,19 @@ snapshots:
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
+
+  '@typescript-eslint/parser@8.58.1(eslint@10.2.0)(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/scope-manager': 8.58.1
+      '@typescript-eslint/types': 8.58.1
+      '@typescript-eslint/typescript-estree': 8.58.1(typescript@5.9.3)
+      '@typescript-eslint/visitor-keys': 8.58.1
+      debug: 4.4.3
+      eslint: 10.2.0
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
 
   '@typescript-eslint/project-service@8.58.1(typescript@5.9.3)':
     dependencies:
@@ -12373,18 +12325,6 @@ snapshots:
     dependencies:
       typescript: 5.9.3
 
-  '@typescript-eslint/type-utils@5.62.0(eslint@10.2.0)(typescript@5.9.3)':
-    dependencies:
-      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.9.3)
-      '@typescript-eslint/utils': 5.62.0(eslint@10.2.0)(typescript@5.9.3)
-      debug: 4.4.3
-      eslint: 10.2.0
-      tsutils: 3.21.0(typescript@5.9.3)
-    optionalDependencies:
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - supports-color
-
   '@typescript-eslint/type-utils@5.62.0(eslint@7.32.0)(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.9.3)
@@ -12396,6 +12336,19 @@ snapshots:
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
+
+  '@typescript-eslint/type-utils@8.58.1(eslint@10.2.0)(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/types': 8.58.1
+      '@typescript-eslint/typescript-estree': 8.58.1(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.58.1(eslint@10.2.0)(typescript@5.9.3)
+      debug: 4.4.3
+      eslint: 10.2.0
+      ts-api-utils: 2.5.0(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
 
   '@typescript-eslint/types@5.62.0': {}
 
@@ -12429,21 +12382,6 @@ snapshots:
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
-
-  '@typescript-eslint/utils@5.62.0(eslint@10.2.0)(typescript@5.9.3)':
-    dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.2.0)
-      '@types/json-schema': 7.0.15
-      '@types/semver': 7.7.1
-      '@typescript-eslint/scope-manager': 5.62.0
-      '@typescript-eslint/types': 5.62.0
-      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.9.3)
-      eslint: 10.2.0
-      eslint-scope: 5.1.1
-      semver: 7.7.4
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
 
   '@typescript-eslint/utils@5.62.0(eslint@7.32.0)(typescript@5.9.3)':
     dependencies:
@@ -12544,7 +12482,7 @@ snapshots:
 
   '@vercel/webpack-asset-relocator-loader@1.7.3':
     dependencies:
-      resolve: 1.22.11
+      resolve: 1.22.12
 
   '@webassemblyjs/ast@1.14.1':
     dependencies:
@@ -12881,7 +12819,7 @@ snapshots:
       '@babel/types': 7.29.0
       eslint: 10.2.0
       eslint-visitor-keys: 1.3.0
-      resolve: 1.22.11
+      resolve: 1.22.12
     transitivePeerDependencies:
       - supports-color
 
@@ -12893,7 +12831,7 @@ snapshots:
       '@babel/types': 7.29.0
       eslint: 7.32.0
       eslint-visitor-keys: 1.3.0
-      resolve: 1.22.11
+      resolve: 1.22.12
     transitivePeerDependencies:
       - supports-color
 
@@ -12945,7 +12883,7 @@ snapshots:
     dependencies:
       '@babel/runtime': 7.29.2
       cosmiconfig: 7.1.0
-      resolve: 1.22.11
+      resolve: 1.22.12
 
   babel-plugin-polyfill-corejs2@0.4.17(@babel/core@7.29.0):
     dependencies:
@@ -12979,20 +12917,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  babel-plugin-remove-graphql-queries@5.16.0(@babel/core@7.29.0)(gatsby@5.16.1(babel-eslint@10.1.0(eslint@10.2.0))(eslint-plugin-jest@29.15.2(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3)):
+  babel-plugin-remove-graphql-queries@5.16.0(@babel/core@7.29.0)(gatsby@5.16.1(babel-eslint@10.1.0(eslint@10.2.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3)):
     dependencies:
       '@babel/core': 7.29.0
       '@babel/runtime': 7.29.2
       '@babel/types': 7.29.0
-      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@10.2.0))(eslint-plugin-jest@29.15.2(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3)
+      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@10.2.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3)
       gatsby-core-utils: 4.16.0
 
-  babel-plugin-remove-graphql-queries@5.16.0(@babel/core@7.29.0)(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3)):
+  babel-plugin-remove-graphql-queries@5.16.0(@babel/core@7.29.0)(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3)):
     dependencies:
       '@babel/core': 7.29.0
       '@babel/runtime': 7.29.2
       '@babel/types': 7.29.0
-      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3)
+      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3)
       gatsby-core-utils: 4.16.0
 
   babel-plugin-syntax-trailing-function-commas@7.0.0-beta.0: {}
@@ -13127,7 +13065,7 @@ snapshots:
 
   base64id@2.0.0: {}
 
-  baseline-browser-mapping@2.10.17: {}
+  baseline-browser-mapping@2.10.18: {}
 
   bcp-47-match@2.0.3: {}
 
@@ -13202,12 +13140,12 @@ snapshots:
       widest-line: 5.0.0
       wrap-ansi: 9.0.2
 
-  brace-expansion@1.1.13:
+  brace-expansion@1.1.14:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@2.0.3:
+  brace-expansion@2.1.0:
     dependencies:
       balanced-match: 1.0.2
 
@@ -13221,7 +13159,7 @@ snapshots:
 
   browserslist@4.28.2:
     dependencies:
-      baseline-browser-mapping: 2.10.17
+      baseline-browser-mapping: 2.10.18
       caniuse-lite: 1.0.30001787
       electron-to-chromium: 1.5.335
       node-releases: 2.0.37
@@ -14397,31 +14335,11 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
-  eslint-config-next@15.5.15(eslint@10.2.0)(typescript@5.9.3):
-    dependencies:
-      '@next/eslint-plugin-next': 15.5.15
-      '@rushstack/eslint-patch': 1.16.1
-      '@typescript-eslint/eslint-plugin': 5.62.0(@typescript-eslint/parser@5.62.0(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(typescript@5.9.3)
-      '@typescript-eslint/parser': 5.62.0(eslint@10.2.0)(typescript@5.9.3)
-      eslint: 10.2.0
-      eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@5.62.0(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0))(eslint@10.2.0)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@5.62.0(eslint@10.2.0)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@10.2.0)
-      eslint-plugin-jsx-a11y: 6.10.2(eslint@10.2.0)
-      eslint-plugin-react: 7.37.5(eslint@10.2.0)
-      eslint-plugin-react-hooks: 5.2.0(eslint@10.2.0)
-    optionalDependencies:
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - eslint-import-resolver-webpack
-      - eslint-plugin-import-x
-      - supports-color
-
   eslint-config-prettier@10.1.8(eslint@10.2.0):
     dependencies:
       eslint: 10.2.0
 
-  eslint-config-react-app@6.0.0(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.9.3))(eslint@7.32.0)(typescript@5.9.3))(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.9.3))(babel-eslint@10.1.0(eslint@10.2.0))(eslint-plugin-flowtype@5.10.0(eslint@7.32.0))(eslint-plugin-import@2.32.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.9.3))(eslint@7.32.0))(eslint-plugin-jest@29.15.2(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(eslint-plugin-jsx-a11y@6.10.2(eslint@10.2.0))(eslint-plugin-react-hooks@4.6.2(eslint@7.32.0))(eslint-plugin-react@7.37.5(eslint@10.2.0))(eslint@7.32.0)(typescript@5.9.3):
+  eslint-config-react-app@6.0.0(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.9.3))(eslint@7.32.0)(typescript@5.9.3))(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.9.3))(babel-eslint@10.1.0(eslint@10.2.0))(eslint-plugin-flowtype@5.10.0(eslint@7.32.0))(eslint-plugin-import@2.32.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.9.3))(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(eslint-plugin-jsx-a11y@6.10.2(eslint@10.2.0))(eslint-plugin-react-hooks@4.6.2(eslint@7.32.0))(eslint-plugin-react@7.37.5(eslint@10.2.0))(eslint@7.32.0)(typescript@5.9.3):
     dependencies:
       '@typescript-eslint/eslint-plugin': 5.62.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.9.3))(eslint@7.32.0)(typescript@5.9.3)
       '@typescript-eslint/parser': 5.62.0(eslint@7.32.0)(typescript@5.9.3)
@@ -14434,10 +14352,10 @@ snapshots:
       eslint-plugin-react: 7.37.5(eslint@10.2.0)
       eslint-plugin-react-hooks: 4.6.2(eslint@7.32.0)
     optionalDependencies:
-      eslint-plugin-jest: 29.15.2(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3)
+      eslint-plugin-jest: 29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3)
       typescript: 5.9.3
 
-  eslint-config-react-app@6.0.0(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.9.3))(eslint@7.32.0)(typescript@5.9.3))(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.9.3))(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-flowtype@5.10.0(eslint@7.32.0))(eslint-plugin-import@2.32.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.9.3))(eslint@7.32.0))(eslint-plugin-jest@29.15.2(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(eslint-plugin-jsx-a11y@6.10.2(eslint@7.32.0))(eslint-plugin-react-hooks@4.6.2(eslint@7.32.0))(eslint-plugin-react@7.37.5(eslint@7.32.0))(eslint@7.32.0)(typescript@5.9.3):
+  eslint-config-react-app@6.0.0(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.9.3))(eslint@7.32.0)(typescript@5.9.3))(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.9.3))(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-flowtype@5.10.0(eslint@7.32.0))(eslint-plugin-import@2.32.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.9.3))(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(eslint-plugin-jsx-a11y@6.10.2(eslint@7.32.0))(eslint-plugin-react-hooks@4.6.2(eslint@7.32.0))(eslint-plugin-react@7.37.5(eslint@7.32.0))(eslint@7.32.0)(typescript@5.9.3):
     dependencies:
       '@typescript-eslint/eslint-plugin': 5.62.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.9.3))(eslint@7.32.0)(typescript@5.9.3)
       '@typescript-eslint/parser': 5.62.0(eslint@7.32.0)(typescript@5.9.3)
@@ -14450,7 +14368,7 @@ snapshots:
       eslint-plugin-react: 7.37.5(eslint@7.32.0)
       eslint-plugin-react-hooks: 4.6.2(eslint@7.32.0)
     optionalDependencies:
-      eslint-plugin-jest: 29.15.2(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3)
+      eslint-plugin-jest: 29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3)
       typescript: 5.9.3
 
   eslint-import-resolver-node@0.3.10:
@@ -14458,32 +14376,6 @@ snapshots:
       debug: 3.2.7
       is-core-module: 2.16.1
       resolve: 2.0.0-next.6
-    transitivePeerDependencies:
-      - supports-color
-
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@5.62.0(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0))(eslint@10.2.0):
-    dependencies:
-      '@nolyfill/is-core-module': 1.0.39
-      debug: 4.4.3
-      eslint: 10.2.0
-      get-tsconfig: 4.13.7
-      is-bun-module: 2.0.0
-      stable-hash: 0.0.5
-      tinyglobby: 0.2.16
-      unrs-resolver: 1.11.1
-    optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@5.62.0(eslint@10.2.0)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@10.2.0)
-    transitivePeerDependencies:
-      - supports-color
-
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@5.62.0(eslint@10.2.0)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@5.62.0(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0))(eslint@10.2.0))(eslint@10.2.0):
-    dependencies:
-      debug: 3.2.7
-    optionalDependencies:
-      '@typescript-eslint/parser': 5.62.0(eslint@10.2.0)(typescript@5.9.3)
-      eslint: 10.2.0
-      eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@5.62.0(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0))(eslint@10.2.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -14502,35 +14394,6 @@ snapshots:
       eslint: 7.32.0
       lodash: 4.18.1
       string-natural-compare: 3.0.1
-
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@5.62.0(eslint@10.2.0)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@10.2.0):
-    dependencies:
-      '@rtsao/scc': 1.1.0
-      array-includes: 3.1.9
-      array.prototype.findlastindex: 1.2.6
-      array.prototype.flat: 1.3.3
-      array.prototype.flatmap: 1.3.3
-      debug: 3.2.7
-      doctrine: 2.1.0
-      eslint: 10.2.0
-      eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@5.62.0(eslint@10.2.0)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@5.62.0(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0))(eslint@10.2.0))(eslint@10.2.0)
-      hasown: 2.0.2
-      is-core-module: 2.16.1
-      is-glob: 4.0.3
-      minimatch: 3.1.5
-      object.fromentries: 2.0.8
-      object.groupby: 1.0.3
-      object.values: 1.2.1
-      semver: 6.3.1
-      string.prototype.trimend: 1.0.9
-      tsconfig-paths: 3.15.0
-    optionalDependencies:
-      '@typescript-eslint/parser': 5.62.0(eslint@10.2.0)(typescript@5.9.3)
-    transitivePeerDependencies:
-      - eslint-import-resolver-typescript
-      - eslint-import-resolver-webpack
-      - supports-color
 
   eslint-plugin-import@2.32.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.9.3))(eslint@7.32.0):
     dependencies:
@@ -14561,11 +14424,12 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-jest@29.15.2(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3):
+  eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3):
     dependencies:
       '@typescript-eslint/utils': 8.58.1(eslint@10.2.0)(typescript@5.9.3)
       eslint: 10.2.0
     optionalDependencies:
+      '@typescript-eslint/eslint-plugin': 8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(typescript@5.9.3)
       jest: 30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0)
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -14627,10 +14491,6 @@ snapshots:
   eslint-plugin-react-hooks@4.6.2(eslint@7.32.0):
     dependencies:
       eslint: 7.32.0
-
-  eslint-plugin-react-hooks@5.2.0(eslint@10.2.0):
-    dependencies:
-      eslint: 10.2.0
 
   eslint-plugin-react-hooks@7.0.1(eslint@10.2.0):
     dependencies:
@@ -15017,14 +14877,6 @@ snapshots:
 
   fast-fifo@1.3.2: {}
 
-  fast-glob@3.3.1:
-    dependencies:
-      '@nodelib/fs.stat': 2.0.5
-      '@nodelib/fs.walk': 1.2.8
-      glob-parent: 5.1.2
-      merge2: 1.4.1
-      micromatch: 4.0.8
-
   fast-glob@3.3.3:
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -15352,23 +15204,23 @@ snapshots:
       '@parcel/transformer-js': 2.8.3(@parcel/core@2.8.3)
       '@parcel/transformer-json': 2.8.3(@parcel/core@2.8.3)
 
-  gatsby-plugin-emotion@8.16.0(@babel/core@7.29.0)(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3)):
+  gatsby-plugin-emotion@8.16.0(@babel/core@7.29.0)(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3)):
     dependencies:
       '@babel/core': 7.29.0
       '@babel/runtime': 7.29.2
       '@emotion/babel-preset-css-prop': 11.12.0(@babel/core@7.29.0)
       '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.5)
-      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3)
+      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3)
     transitivePeerDependencies:
       - supports-color
 
-  gatsby-plugin-feed@5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3))(graphql@16.13.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
+  gatsby-plugin-feed@5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3))(graphql@16.13.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
     dependencies:
       '@babel/runtime': 7.29.2
       common-tags: 1.8.2
       fs-extra: 11.3.4
-      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3)
-      gatsby-plugin-utils: 4.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3))(graphql@16.13.2)
+      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3)
+      gatsby-plugin-utils: 4.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3))(graphql@16.13.2)
       lodash.merge: 4.6.2
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
@@ -15379,20 +15231,20 @@ snapshots:
       - graphql
       - react-native-b4a
 
-  gatsby-plugin-google-gtag@5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@10.2.0))(eslint-plugin-jest@29.15.2(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
+  gatsby-plugin-google-gtag@5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@10.2.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
     dependencies:
       '@babel/runtime': 7.29.2
-      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@10.2.0))(eslint-plugin-jest@29.15.2(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3)
+      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@10.2.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3)
       minimatch: 3.1.5
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
 
-  gatsby-plugin-manifest@5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3))(graphql@16.13.2):
+  gatsby-plugin-manifest@5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3))(graphql@16.13.2):
     dependencies:
       '@babel/runtime': 7.29.2
-      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3)
+      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3)
       gatsby-core-utils: 4.16.0
-      gatsby-plugin-utils: 4.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3))(graphql@16.13.2)
+      gatsby-plugin-utils: 4.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3))(graphql@16.13.2)
       semver: 7.7.4
       sharp: 0.32.6
     transitivePeerDependencies:
@@ -15401,7 +15253,7 @@ snapshots:
       - graphql
       - react-native-b4a
 
-  gatsby-plugin-mdx@5.16.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(gatsby-source-filesystem@5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3)))(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3))(graphql@16.13.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
+  gatsby-plugin-mdx@5.16.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(gatsby-source-filesystem@5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3)))(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3))(graphql@16.13.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
     dependencies:
       '@mdx-js/mdx': 2.3.0
       '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@19.2.5)
@@ -15411,10 +15263,10 @@ snapshots:
       deepmerge: 4.3.1
       estree-util-build-jsx: 2.2.2
       fs-extra: 11.3.4
-      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3)
+      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3)
       gatsby-core-utils: 4.16.0
-      gatsby-plugin-utils: 4.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3))(graphql@16.13.2)
-      gatsby-source-filesystem: 5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3))
+      gatsby-plugin-utils: 4.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3))(graphql@16.13.2)
+      gatsby-source-filesystem: 5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3))
       gray-matter: 4.0.3
       mdast-util-mdx: 2.0.1
       mdast-util-to-hast: 10.2.0
@@ -15434,7 +15286,7 @@ snapshots:
       - react-native-b4a
       - supports-color
 
-  gatsby-plugin-page-creator@5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@10.2.0))(eslint-plugin-jest@29.15.2(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3))(graphql@16.13.2):
+  gatsby-plugin-page-creator@5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@10.2.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3))(graphql@16.13.2):
     dependencies:
       '@babel/runtime': 7.29.2
       '@babel/traverse': 7.29.0
@@ -15442,10 +15294,10 @@ snapshots:
       chokidar: 3.6.0
       fs-exists-cached: 1.0.0
       fs-extra: 11.3.4
-      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@10.2.0))(eslint-plugin-jest@29.15.2(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3)
+      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@10.2.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3)
       gatsby-core-utils: 4.16.0
       gatsby-page-utils: 3.16.0
-      gatsby-plugin-utils: 4.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@10.2.0))(eslint-plugin-jest@29.15.2(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3))(graphql@16.13.2)
+      gatsby-plugin-utils: 4.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@10.2.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3))(graphql@16.13.2)
       globby: 11.1.0
       lodash: 4.18.1
     transitivePeerDependencies:
@@ -15455,7 +15307,7 @@ snapshots:
       - react-native-b4a
       - supports-color
 
-  gatsby-plugin-page-creator@5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3))(graphql@16.13.2):
+  gatsby-plugin-page-creator@5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3))(graphql@16.13.2):
     dependencies:
       '@babel/runtime': 7.29.2
       '@babel/traverse': 7.29.0
@@ -15463,10 +15315,10 @@ snapshots:
       chokidar: 3.6.0
       fs-exists-cached: 1.0.0
       fs-extra: 11.3.4
-      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3)
+      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3)
       gatsby-core-utils: 4.16.0
       gatsby-page-utils: 3.16.0
-      gatsby-plugin-utils: 4.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3))(graphql@16.13.2)
+      gatsby-plugin-utils: 4.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3))(graphql@16.13.2)
       globby: 11.1.0
       lodash: 4.18.1
     transitivePeerDependencies:
@@ -15476,13 +15328,13 @@ snapshots:
       - react-native-b4a
       - supports-color
 
-  gatsby-plugin-robots-txt@1.8.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@10.2.0))(eslint-plugin-jest@29.15.2(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3)):
+  gatsby-plugin-robots-txt@1.8.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@10.2.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3)):
     dependencies:
       '@babel/runtime': 7.29.2
-      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@10.2.0))(eslint-plugin-jest@29.15.2(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3)
+      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@10.2.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3)
       generate-robotstxt: 8.0.3
 
-  gatsby-plugin-sharp@5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3))(graphql@16.13.2):
+  gatsby-plugin-sharp@5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3))(graphql@16.13.2):
     dependencies:
       '@babel/runtime': 7.29.2
       async: 3.2.6
@@ -15490,9 +15342,9 @@ snapshots:
       debug: 4.4.3
       filenamify: 4.3.0
       fs-extra: 11.3.4
-      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3)
+      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3)
       gatsby-core-utils: 4.16.0
-      gatsby-plugin-utils: 4.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3))(graphql@16.13.2)
+      gatsby-plugin-utils: 4.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3))(graphql@16.13.2)
       lodash: 4.18.1
       probe-image-size: 7.2.3
       semver: 7.7.4
@@ -15504,27 +15356,27 @@ snapshots:
       - react-native-b4a
       - supports-color
 
-  gatsby-plugin-sitemap@6.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@10.2.0))(eslint-plugin-jest@29.15.2(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
+  gatsby-plugin-sitemap@6.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@10.2.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
     dependencies:
       '@babel/runtime': 7.29.2
       common-tags: 1.8.2
-      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@10.2.0))(eslint-plugin-jest@29.15.2(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3)
+      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@10.2.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3)
       minimatch: 3.1.5
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
       sitemap: 7.1.3
 
-  gatsby-plugin-theme-ui@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5)))(@theme-ui/mdx@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@types/mdx@2.0.13)(react@19.2.5))(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3))(react@19.2.5)(theme-ui@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(react@19.2.5)):
+  gatsby-plugin-theme-ui@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5)))(@theme-ui/mdx@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@types/mdx@2.0.13)(react@19.2.5))(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3))(react@19.2.5)(theme-ui@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(react@19.2.5)):
     dependencies:
       '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.5)
       '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@19.2.5)
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.5))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))
       '@theme-ui/mdx': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@types/mdx@2.0.13)(react@19.2.5)
-      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3)
+      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3)
       react: 19.2.5
-      theme-ui: 0.17.4(@emotion/react@11.14.0(react@19.2.5))(react@19.2.5)
+      theme-ui: 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(react@19.2.5)
 
-  gatsby-plugin-typescript@5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@10.2.0))(eslint-plugin-jest@29.15.2(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3)):
+  gatsby-plugin-typescript@5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@10.2.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3)):
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-proposal-nullish-coalescing-operator': 7.18.6(@babel/core@7.29.0)
@@ -15532,12 +15384,12 @@ snapshots:
       '@babel/plugin-proposal-optional-chaining': 7.21.0(@babel/core@7.29.0)
       '@babel/preset-typescript': 7.28.5(@babel/core@7.29.0)
       '@babel/runtime': 7.29.2
-      babel-plugin-remove-graphql-queries: 5.16.0(@babel/core@7.29.0)(gatsby@5.16.1(babel-eslint@10.1.0(eslint@10.2.0))(eslint-plugin-jest@29.15.2(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3))
-      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@10.2.0))(eslint-plugin-jest@29.15.2(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3)
+      babel-plugin-remove-graphql-queries: 5.16.0(@babel/core@7.29.0)(gatsby@5.16.1(babel-eslint@10.1.0(eslint@10.2.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3))
+      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@10.2.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3)
     transitivePeerDependencies:
       - supports-color
 
-  gatsby-plugin-typescript@5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3)):
+  gatsby-plugin-typescript@5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3)):
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-proposal-nullish-coalescing-operator': 7.18.6(@babel/core@7.29.0)
@@ -15545,17 +15397,17 @@ snapshots:
       '@babel/plugin-proposal-optional-chaining': 7.21.0(@babel/core@7.29.0)
       '@babel/preset-typescript': 7.28.5(@babel/core@7.29.0)
       '@babel/runtime': 7.29.2
-      babel-plugin-remove-graphql-queries: 5.16.0(@babel/core@7.29.0)(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3))
-      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3)
+      babel-plugin-remove-graphql-queries: 5.16.0(@babel/core@7.29.0)(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3))
+      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3)
     transitivePeerDependencies:
       - supports-color
 
-  gatsby-plugin-utils@4.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@10.2.0))(eslint-plugin-jest@29.15.2(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3))(graphql@16.13.2):
+  gatsby-plugin-utils@4.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@10.2.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3))(graphql@16.13.2):
     dependencies:
       '@babel/runtime': 7.29.2
       fastq: 1.20.1
       fs-extra: 11.3.4
-      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@10.2.0))(eslint-plugin-jest@29.15.2(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3)
+      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@10.2.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3)
       gatsby-core-utils: 4.16.0
       gatsby-sharp: 1.16.0
       graphql: 16.13.2
@@ -15568,12 +15420,12 @@ snapshots:
       - bare-buffer
       - react-native-b4a
 
-  gatsby-plugin-utils@4.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3))(graphql@16.13.2):
+  gatsby-plugin-utils@4.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3))(graphql@16.13.2):
     dependencies:
       '@babel/runtime': 7.29.2
       fastq: 1.20.1
       fs-extra: 11.3.4
-      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3)
+      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3)
       gatsby-core-utils: 4.16.0
       gatsby-sharp: 1.16.0
       graphql: 16.13.2
@@ -15594,10 +15446,10 @@ snapshots:
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
 
-  gatsby-remark-autolink-headers@6.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
+  gatsby-remark-autolink-headers@6.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
     dependencies:
       '@babel/runtime': 7.29.2
-      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3)
+      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3)
       github-slugger: 1.5.0
       lodash: 4.18.1
       mdast-util-to-string: 2.0.0
@@ -15605,12 +15457,12 @@ snapshots:
       react-dom: 19.2.5(react@19.2.5)
       unist-util-visit: 2.0.3
 
-  gatsby-remark-copy-linked-files@6.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3)):
+  gatsby-remark-copy-linked-files@6.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3)):
     dependencies:
       '@babel/runtime': 7.29.2
       cheerio: 1.0.0-rc.12
       fs-extra: 11.3.4
-      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3)
+      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3)
       is-relative-url: 3.0.0
       lodash: 4.18.1
       path-is-inside: 1.0.2
@@ -15625,14 +15477,14 @@ snapshots:
       remark-burger: 1.0.1
       unist-util-visit: 2.0.3
 
-  gatsby-remark-images@7.16.0(gatsby-plugin-sharp@5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3))(graphql@16.13.2))(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3)):
+  gatsby-remark-images@7.16.0(gatsby-plugin-sharp@5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3))(graphql@16.13.2))(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3)):
     dependencies:
       '@babel/runtime': 7.29.2
       chalk: 4.1.2
       cheerio: 1.0.0-rc.12
-      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3)
+      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3)
       gatsby-core-utils: 4.16.0
-      gatsby-plugin-sharp: 5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3))(graphql@16.13.2)
+      gatsby-plugin-sharp: 5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3))(graphql@16.13.2)
       is-relative-url: 3.0.0
       lodash: 4.18.1
       mdast-util-definitions: 4.0.0
@@ -15640,10 +15492,10 @@ snapshots:
       unist-util-select: 3.0.4
       unist-util-visit-parents: 3.1.1
 
-  gatsby-remark-prismjs@7.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3))(prismjs@1.30.0):
+  gatsby-remark-prismjs@7.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3))(prismjs@1.30.0):
     dependencies:
       '@babel/runtime': 7.29.2
-      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3)
+      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3)
       parse-numeric-range: 1.3.0
       prismjs: 1.30.0
       unist-util-visit: 2.0.3
@@ -15662,42 +15514,42 @@ snapshots:
       - bare-buffer
       - react-native-b4a
 
-  gatsby-source-filesystem@5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3)):
+  gatsby-source-filesystem@5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3)):
     dependencies:
       '@babel/runtime': 7.29.2
       chokidar: 3.6.0
       file-type: 16.5.4
       fs-extra: 11.3.4
-      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3)
+      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3)
       gatsby-core-utils: 4.16.0
       mime: 3.0.0
       pretty-bytes: 5.6.0
       valid-url: 1.0.9
       xstate: 4.38.3
 
-  gatsby-theme-style-guide@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5)))(@types/mdx@2.0.13)(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
+  gatsby-theme-style-guide@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5)))(@types/mdx@2.0.13)(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
     dependencies:
       '@theme-ui/mdx': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@types/mdx@2.0.13)(react@19.2.5)
       '@theme-ui/style-guide': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5)))(react@19.2.5)(theme-ui@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(react@19.2.5))
-      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3)
+      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3)
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
-      theme-ui: 0.17.4(@emotion/react@11.14.0(react@19.2.5))(react@19.2.5)
+      theme-ui: 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(react@19.2.5)
     transitivePeerDependencies:
       - '@emotion/react'
       - '@theme-ui/css'
       - '@types/mdx'
 
-  gatsby-transformer-json@5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3)):
+  gatsby-transformer-json@5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3)):
     dependencies:
       '@babel/runtime': 7.29.2
       bluebird: 3.7.2
-      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3)
+      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3)
 
-  gatsby-transformer-remark@6.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3)):
+  gatsby-transformer-remark@6.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3)):
     dependencies:
       '@babel/runtime': 7.29.2
-      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3)
+      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3)
       gatsby-core-utils: 4.16.0
       gray-matter: 4.0.3
       hast-util-raw: 6.1.0
@@ -15722,15 +15574,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  gatsby-transformer-sharp@5.16.0(gatsby-plugin-sharp@5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3))(graphql@16.13.2))(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3))(graphql@16.13.2):
+  gatsby-transformer-sharp@5.16.0(gatsby-plugin-sharp@5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3))(graphql@16.13.2))(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3))(graphql@16.13.2):
     dependencies:
       '@babel/runtime': 7.29.2
       bluebird: 3.7.2
       common-tags: 1.8.2
       fs-extra: 11.3.4
-      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3)
-      gatsby-plugin-sharp: 5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3))(graphql@16.13.2)
-      gatsby-plugin-utils: 4.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3))(graphql@16.13.2)
+      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3)
+      gatsby-plugin-sharp: 5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3))(graphql@16.13.2)
+      gatsby-plugin-utils: 4.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3))(graphql@16.13.2)
       probe-image-size: 7.2.3
       semver: 7.7.4
       sharp: 0.32.6
@@ -15750,7 +15602,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  gatsby@5.16.1(babel-eslint@10.1.0(eslint@10.2.0))(eslint-plugin-jest@29.15.2(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3):
+  gatsby@5.16.1(babel-eslint@10.1.0(eslint@10.2.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3):
     dependencies:
       '@babel/code-frame': 7.29.0
       '@babel/core': 7.29.0
@@ -15791,7 +15643,7 @@ snapshots:
       babel-loader: 8.4.1(@babel/core@7.29.0)(webpack@5.98.0)
       babel-plugin-add-module-exports: 1.0.4
       babel-plugin-dynamic-import-node: 2.3.3
-      babel-plugin-remove-graphql-queries: 5.16.0(@babel/core@7.29.0)(gatsby@5.16.1(babel-eslint@10.1.0(eslint@10.2.0))(eslint-plugin-jest@29.15.2(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3))
+      babel-plugin-remove-graphql-queries: 5.16.0(@babel/core@7.29.0)(gatsby@5.16.1(babel-eslint@10.1.0(eslint@10.2.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3))
       babel-preset-gatsby: 3.16.0(@babel/core@7.29.0)(core-js@3.49.0)
       better-opn: 2.1.1
       bluebird: 3.7.2
@@ -15816,7 +15668,7 @@ snapshots:
       enhanced-resolve: 5.20.1
       error-stack-parser: 2.1.4
       eslint: 7.32.0
-      eslint-config-react-app: 6.0.0(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.9.3))(eslint@7.32.0)(typescript@5.9.3))(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.9.3))(babel-eslint@10.1.0(eslint@10.2.0))(eslint-plugin-flowtype@5.10.0(eslint@7.32.0))(eslint-plugin-import@2.32.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.9.3))(eslint@7.32.0))(eslint-plugin-jest@29.15.2(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(eslint-plugin-jsx-a11y@6.10.2(eslint@10.2.0))(eslint-plugin-react-hooks@4.6.2(eslint@7.32.0))(eslint-plugin-react@7.37.5(eslint@10.2.0))(eslint@7.32.0)(typescript@5.9.3)
+      eslint-config-react-app: 6.0.0(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.9.3))(eslint@7.32.0)(typescript@5.9.3))(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.9.3))(babel-eslint@10.1.0(eslint@10.2.0))(eslint-plugin-flowtype@5.10.0(eslint@7.32.0))(eslint-plugin-import@2.32.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.9.3))(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(eslint-plugin-jsx-a11y@6.10.2(eslint@10.2.0))(eslint-plugin-react-hooks@4.6.2(eslint@7.32.0))(eslint-plugin-react@7.37.5(eslint@10.2.0))(eslint@7.32.0)(typescript@5.9.3)
       eslint-plugin-flowtype: 5.10.0(eslint@7.32.0)
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.9.3))(eslint@7.32.0)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@7.32.0)
@@ -15840,9 +15692,9 @@ snapshots:
       gatsby-link: 5.16.0(@gatsbyjs/reach-router@2.0.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       gatsby-page-utils: 3.16.0
       gatsby-parcel-config: 1.16.0(@parcel/core@2.8.3)
-      gatsby-plugin-page-creator: 5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@10.2.0))(eslint-plugin-jest@29.15.2(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3))(graphql@16.13.2)
-      gatsby-plugin-typescript: 5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@10.2.0))(eslint-plugin-jest@29.15.2(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3))
-      gatsby-plugin-utils: 4.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@10.2.0))(eslint-plugin-jest@29.15.2(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3))(graphql@16.13.2)
+      gatsby-plugin-page-creator: 5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@10.2.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3))(graphql@16.13.2)
+      gatsby-plugin-typescript: 5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@10.2.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3))
+      gatsby-plugin-utils: 4.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@10.2.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3))(graphql@16.13.2)
       gatsby-react-router-scroll: 6.16.0(@gatsbyjs/reach-router@2.0.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       gatsby-script: 2.16.0(@gatsbyjs/reach-router@2.0.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       gatsby-worker: 2.16.0
@@ -15950,7 +15802,7 @@ snapshots:
       - webpack-hot-middleware
       - webpack-plugin-serve
 
-  gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3):
+  gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3):
     dependencies:
       '@babel/code-frame': 7.29.0
       '@babel/core': 7.29.0
@@ -15991,7 +15843,7 @@ snapshots:
       babel-loader: 8.4.1(@babel/core@7.29.0)(webpack@5.98.0)
       babel-plugin-add-module-exports: 1.0.4
       babel-plugin-dynamic-import-node: 2.3.3
-      babel-plugin-remove-graphql-queries: 5.16.0(@babel/core@7.29.0)(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3))
+      babel-plugin-remove-graphql-queries: 5.16.0(@babel/core@7.29.0)(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3))
       babel-preset-gatsby: 3.16.0(@babel/core@7.29.0)(core-js@3.49.0)
       better-opn: 2.1.1
       bluebird: 3.7.2
@@ -16016,7 +15868,7 @@ snapshots:
       enhanced-resolve: 5.20.1
       error-stack-parser: 2.1.4
       eslint: 7.32.0
-      eslint-config-react-app: 6.0.0(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.9.3))(eslint@7.32.0)(typescript@5.9.3))(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.9.3))(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-flowtype@5.10.0(eslint@7.32.0))(eslint-plugin-import@2.32.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.9.3))(eslint@7.32.0))(eslint-plugin-jest@29.15.2(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(eslint-plugin-jsx-a11y@6.10.2(eslint@7.32.0))(eslint-plugin-react-hooks@4.6.2(eslint@7.32.0))(eslint-plugin-react@7.37.5(eslint@7.32.0))(eslint@7.32.0)(typescript@5.9.3)
+      eslint-config-react-app: 6.0.0(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.9.3))(eslint@7.32.0)(typescript@5.9.3))(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.9.3))(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-flowtype@5.10.0(eslint@7.32.0))(eslint-plugin-import@2.32.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.9.3))(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(eslint-plugin-jsx-a11y@6.10.2(eslint@7.32.0))(eslint-plugin-react-hooks@4.6.2(eslint@7.32.0))(eslint-plugin-react@7.37.5(eslint@7.32.0))(eslint@7.32.0)(typescript@5.9.3)
       eslint-plugin-flowtype: 5.10.0(eslint@7.32.0)
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.9.3))(eslint@7.32.0)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@7.32.0)
@@ -16040,9 +15892,9 @@ snapshots:
       gatsby-link: 5.16.0(@gatsbyjs/reach-router@2.0.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       gatsby-page-utils: 3.16.0
       gatsby-parcel-config: 1.16.0(@parcel/core@2.8.3)
-      gatsby-plugin-page-creator: 5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3))(graphql@16.13.2)
-      gatsby-plugin-typescript: 5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3))
-      gatsby-plugin-utils: 4.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3))(graphql@16.13.2)
+      gatsby-plugin-page-creator: 5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3))(graphql@16.13.2)
+      gatsby-plugin-typescript: 5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3))
+      gatsby-plugin-utils: 4.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(jest@30.3.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(type-fest@4.41.0)(typescript@5.9.3))(graphql@16.13.2)
       gatsby-react-router-scroll: 6.16.0(@gatsbyjs/reach-router@2.0.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       gatsby-script: 2.16.0(@gatsbyjs/reach-router@2.0.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       gatsby-worker: 2.16.0
@@ -16200,10 +16052,6 @@ snapshots:
       call-bound: 1.0.4
       es-errors: 1.3.0
       get-intrinsic: 1.3.0
-
-  get-tsconfig@4.13.7:
-    dependencies:
-      resolve-pkg-maps: 1.0.0
 
   get-video-id@3.7.0: {}
 
@@ -16825,10 +16673,6 @@ snapshots:
       has-tostringtag: 1.0.2
 
   is-buffer@2.0.5: {}
-
-  is-bun-module@2.0.0:
-    dependencies:
-      semver: 7.7.4
 
   is-callable@1.2.7: {}
 
@@ -18602,11 +18446,11 @@ snapshots:
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.13
+      brace-expansion: 1.1.14
 
   minimatch@9.0.9:
     dependencies:
-      brace-expansion: 2.0.3
+      brace-expansion: 2.1.0
 
   minimist-options@4.1.0:
     dependencies:
@@ -18692,24 +18536,25 @@ snapshots:
 
   next-tick@1.1.0: {}
 
-  next@15.5.15(@babel/core@7.29.0)(babel-plugin-macros@3.1.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
+  next@16.2.3(@babel/core@7.29.0)(babel-plugin-macros@3.1.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
     dependencies:
-      '@next/env': 15.5.15
+      '@next/env': 16.2.3
       '@swc/helpers': 0.5.15
+      baseline-browser-mapping: 2.10.18
       caniuse-lite: 1.0.30001787
       postcss: 8.4.31
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
       styled-jsx: 5.1.6(@babel/core@7.29.0)(babel-plugin-macros@3.1.0)(react@19.2.5)
     optionalDependencies:
-      '@next/swc-darwin-arm64': 15.5.15
-      '@next/swc-darwin-x64': 15.5.15
-      '@next/swc-linux-arm64-gnu': 15.5.15
-      '@next/swc-linux-arm64-musl': 15.5.15
-      '@next/swc-linux-x64-gnu': 15.5.15
-      '@next/swc-linux-x64-musl': 15.5.15
-      '@next/swc-win32-arm64-msvc': 15.5.15
-      '@next/swc-win32-x64-msvc': 15.5.15
+      '@next/swc-darwin-arm64': 16.2.3
+      '@next/swc-darwin-x64': 16.2.3
+      '@next/swc-linux-arm64-gnu': 16.2.3
+      '@next/swc-linux-arm64-musl': 16.2.3
+      '@next/swc-linux-x64-gnu': 16.2.3
+      '@next/swc-linux-x64-musl': 16.2.3
+      '@next/swc-win32-arm64-msvc': 16.2.3
+      '@next/swc-win32-x64-msvc': 16.2.3
       sharp: 0.34.5
     transitivePeerDependencies:
       - '@babel/core'
@@ -18764,7 +18609,7 @@ snapshots:
   normalize-package-data@2.5.0:
     dependencies:
       hosted-git-info: 2.8.9
-      resolve: 1.22.11
+      resolve: 1.22.12
       semver: 5.7.2
       validate-npm-package-license: 3.0.4
 
@@ -19854,10 +19699,9 @@ snapshots:
 
   resolve-from@5.0.0: {}
 
-  resolve-pkg-maps@1.0.0: {}
-
-  resolve@1.22.11:
+  resolve@1.22.12:
     dependencies:
+      es-errors: 1.3.0
       is-core-module: 2.16.1
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
@@ -20302,8 +20146,6 @@ snapshots:
 
   sprintf-js@1.1.3: {}
 
-  stable-hash@0.0.5: {}
-
   stable@0.1.8: {}
 
   stack-trace@0.0.10: {}
@@ -20672,15 +20514,15 @@ snapshots:
 
   text-table@0.2.0: {}
 
-  theme-ui@0.17.4(@emotion/react@11.14.0(react@19.2.5))(react@19.2.5):
+  theme-ui@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(react@19.2.5):
     dependencies:
       '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.5)
-      '@theme-ui/color-modes': 0.17.4(@emotion/react@11.14.0(react@19.2.5))(react@19.2.5)
-      '@theme-ui/components': 0.17.4(@emotion/react@11.14.0(react@19.2.5))(@theme-ui/theme-provider@0.17.4(@emotion/react@11.14.0(react@19.2.5))(react@19.2.5))(react@19.2.5)
-      '@theme-ui/core': 0.17.4(@emotion/react@11.14.0(react@19.2.5))(react@19.2.5)
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.5))
-      '@theme-ui/global': 0.17.4(@emotion/react@11.14.0(react@19.2.5))(react@19.2.5)
-      '@theme-ui/theme-provider': 0.17.4(@emotion/react@11.14.0(react@19.2.5))(react@19.2.5)
+      '@theme-ui/color-modes': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(react@19.2.5)
+      '@theme-ui/components': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@theme-ui/theme-provider@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(react@19.2.5))(react@19.2.5)
+      '@theme-ui/core': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(react@19.2.5)
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))
+      '@theme-ui/global': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(react@19.2.5)
+      '@theme-ui/theme-provider': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(react@19.2.5)
       react: 19.2.5
 
   three@0.183.2: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,19 +9,18 @@ packages:
 catalog:
   '@emotion/cache': ^11.14.0
   '@emotion/react': ^11.14.0
-  '@theme-toggles/react': ^4.1.0
   '@mdx-js/react': ^3.1.1
+  '@theme-toggles/react': ^4.1.0
   '@theme-ui/components': ^0.17.4
   '@theme-ui/mdx': ^0.17.4
   boxen: ^8.0.1
-  eslint-config-next: ^15.1.0
   # All Gatsby sites and theme tooling resolve this; bump here when upgrading Gatsby.
   gatsby: ^5.16.1
   gatsby-plugin-google-gtag: ^5.16.0
   gatsby-plugin-robots-txt: ^1.8.0
   gatsby-plugin-sitemap: ^6.16.0
   lightgallery: ^2.9.0
-  next: ^15.1.0
+  next: ^16.2.3
   prettier: ^3.8.2
   react: ^19.2.5
   react-dom: ^19.2.5

--- a/theme/package.json
+++ b/theme/package.json
@@ -70,7 +70,7 @@
     "@mdx-js/loader": "^3.1.1",
     "@mdx-js/mdx": "^3.1.1",
     "@mdx-js/react": "^3.1.1",
-    "@tanstack/react-query": "^5.97.0",
+    "@tanstack/react-query": "^5.99.0",
     "@theme-toggles/react": "^4.1.0",
     "@theme-ui/color": "^0.17.4",
     "@theme-ui/components": "catalog:",


### PR DESCRIPTION
## Summary
This PR updates workspace tooling and the Next.js reference app: **Next.js 16**, catalog alignment, lockfile refresh, and a simpler ESLint story for the `chronogrove-next` example.

## Changes
- **Catalog / Next**: Bump `next` (and related catalog entries) to **^16.2.3**; extend `@chronogrove/ui` optional `next` peer to **^16**.
- **chronogrove-next**: Add direct `@theme-ui/components` for Turbopack resolution; **remove `eslint-config-next`** — example lint uses the **root** `eslint.config.js` (same rules as `pnpm lint`).
- **ESLint**: Keep **ESLint 10** at the repo root (no eslint-config-next compatibility pin).
- **Lockfile**: Refresh `pnpm-lock.yaml`; theme `@tanstack/react-query` range adjustment as included in the branch.

## Testing
- `pnpm lint`
- `pnpm --filter chronogrove-next lint` / `build`
- `pnpm test` (workspace)


Made with [Cursor](https://cursor.com)