### PR TITLE
feat(theme): configurable navigation.footer links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 ### `gatsby-theme-chronogrove` — configurable footer links
 
-- **Feature**: Optional **`siteMetadata.navigation.footer`** (same item shape as header links: `path`, `slug`, `text`, `title`). Site-relative **`path`** values render with Gatsby **`Link`**; **`https://` / `http://` paths** render as external links. Default **`footer`** in theme config is **[]** so the published theme does not embed site-specific URLs.
-- **API**: GraphQL type **`SiteSiteMetadataNavigation`** includes **`footer`**. **`useNavigationData`** returns **`footer`** (and always returns defined **`header` / `footer` arrays**; footer-only config is supported). Selectors **`getFooterLinkItems`** and **`isExternalNavigationPath`** in [`theme/src/selectors/navigation.js`](theme/src/selectors/navigation.js).
+- **Feature**: Optional **`siteMetadata.navigation.footer`** (same item shape as header links: `path`, `slug`, `text`, `title`, optional **`nativeAnchor`**). Internal pages use Gatsby **`Link`**; **`https://` / `http://` paths**, site-relative paths that look like static outputs (e.g. **`.xml`**, **`.rss`**, **`.atom`**), and items with **`nativeAnchor: true`** use a plain anchor so feeds and other non-page assets are not routed through **`gatsby-link`**. Default **`footer`** in theme config is **[]** so the published theme does not embed site-specific URLs. Header **`left`** links use the same rules.
+- **API**: GraphQL type **`SiteSiteMetadataNavigation`** includes **`footer`**. Navigation items may set **`nativeAnchor`**. **`useNavigationData`** returns **`footer`** (and always returns defined **`header` / `footer` arrays**; footer-only config is supported). Selectors **`getFooterLinkItems`**, **`isExternalNavigationPath`**, **`isStaticOutputNavigationPath`**, and **`shouldUseNativeNavigationLink`** in [`theme/src/selectors/navigation.js`](theme/src/selectors/navigation.js).
 - **Site**: [`www.chrisvogt.me`](www.chrisvogt.me) supplies RSS, Privacy, View Source, and Status (**`https://api.chrisvogt.me`**) via theme options.
 - **Docs**: [`theme/README.md`](theme/README.md) (navigation.footer).
 - **Version**: **0.84.0**
@@ -20,7 +20,7 @@
 
 ### Files changed
 
-- `theme/package.json` (version **0.84.0**), `theme/gatsby-node.js`, `theme/src/data/theme-config.js`, `theme/src/hooks/use-navigation-data.js`, `theme/src/selectors/navigation.js`, `theme/src/components/footer/footer.js`, related specs and layout snapshots, `theme/README.md`
+- `theme/package.json` (version **0.84.0**), `theme/gatsby-node.js`, `theme/src/data/theme-config.js`, `theme/src/hooks/use-navigation-data.js`, `theme/src/selectors/navigation.js`, `theme/src/components/footer/footer.js`, `theme/src/components/top-navigation.js`, related specs and layout snapshots, `theme/README.md`
 - `www.chrisvogt.me/package.json` (version **1.15.0**), `www.chrisvogt.me/gatsby-config.js`
 - `www.chronogrove.com/package.json` (version **1.2.0**), `www.chronogrove.com/gatsby-config.js`
 - `CHANGELOG.md`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog
 
+## 0.84.0
+
+### `gatsby-theme-chronogrove` — configurable footer links
+
+- **Feature**: Optional **`siteMetadata.navigation.footer`** (same item shape as header links: `path`, `slug`, `text`, `title`). Site-relative **`path`** values render with Gatsby **`Link`**; **`https://` / `http://` paths** render as external links. Default **`footer`** in theme config is **[]** so the published theme does not embed site-specific URLs.
+- **API**: GraphQL type **`SiteSiteMetadataNavigation`** includes **`footer`**. **`useNavigationData`** returns **`footer`** (and always returns defined **`header` / `footer` arrays**; footer-only config is supported). Selectors **`getFooterLinkItems`** and **`isExternalNavigationPath`** in [`theme/src/selectors/navigation.js`](theme/src/selectors/navigation.js).
+- **Site**: [`www.chrisvogt.me`](www.chrisvogt.me) supplies RSS, Privacy, View Source, and Status (**`https://api.chrisvogt.me`**) via theme options.
+- **Docs**: [`theme/README.md`](theme/README.md) (navigation.footer).
+- **Version**: **0.84.0**
+
+### `www.chrisvogt.me`
+
+- **Version**: **1.15.0** (theme options: `navigation.footer`).
+
+### `www.chronogrove.com` (demo)
+
+- **Version**: **1.2.0** — theme options add **`navigation.footer`** with **View Source** (GitHub) so the public demo shows configurable footer links. RSS is omitted here because this package does not ship **`gatsby-plugin-feed`** (unlike **`www.chrisvogt.me`**); adding a feed plugin first would be required for a real **`/rss.xml`** link.
+
+### Files changed
+
+- `theme/package.json` (version **0.84.0**), `theme/gatsby-node.js`, `theme/src/data/theme-config.js`, `theme/src/hooks/use-navigation-data.js`, `theme/src/selectors/navigation.js`, `theme/src/components/footer/footer.js`, related specs and layout snapshots, `theme/README.md`
+- `www.chrisvogt.me/package.json` (version **1.15.0**), `www.chrisvogt.me/gatsby-config.js`
+- `www.chronogrove.com/package.json` (version **1.2.0**), `www.chronogrove.com/gatsby-config.js`
+- `CHANGELOG.md`
+
+---
+
 ## 0.83.2
 
 ### `@chronogrove/ui` — configurable cross-subdomain color mode

--- a/theme/README.md
+++ b/theme/README.md
@@ -166,6 +166,8 @@ Customize your site's navigation menu:
       },
       // Optional footer link row (same item shape as header links). Omitted or [] = no links.
       // Use site-relative paths for internal pages; use https://… in `path` for external links.
+      // Paths ending in .xml, .rss, .atom, etc. use a plain <a> (not Gatsby Link) so feeds and
+      // other static outputs work with gatsby-plugin-feed. For other static URLs, set nativeAnchor: true.
       footer: [
         {
           path: '/rss.xml',

--- a/theme/README.md
+++ b/theme/README.md
@@ -163,7 +163,23 @@ Customize your site's navigation menu:
             title: 'Reading Activity'
           }
         ]
-      }
+      },
+      // Optional footer link row (same item shape as header links). Omitted or [] = no links.
+      // Use site-relative paths for internal pages; use https://… in `path` for external links.
+      footer: [
+        {
+          path: '/rss.xml',
+          slug: 'rss',
+          text: 'Subscribe via RSS',
+          title: 'RSS feed'
+        },
+        {
+          path: '/privacy',
+          slug: 'privacy',
+          text: 'Privacy Policy',
+          title: 'Privacy Policy'
+        }
+      ]
     }
   }
 }

--- a/theme/gatsby-node.js
+++ b/theme/gatsby-node.js
@@ -145,6 +145,8 @@ exports.createSchemaCustomization = ({ actions }) => {
       slug: String!
       text: String!
       title: String!
+      """If true, render with a plain anchor instead of Gatsby Link (e.g. odd static paths without a known file extension)."""
+      nativeAnchor: Boolean
     }
 
     type SiteSiteMetadataWidgets {

--- a/theme/gatsby-node.js
+++ b/theme/gatsby-node.js
@@ -132,6 +132,7 @@ exports.createSchemaCustomization = ({ actions }) => {
 
     type SiteSiteMetadataNavigation {
       header: SiteSiteMetadataNavigationHeader
+      footer: [SiteSiteMetadataNavigationItem]
     }
 
     type SiteSiteMetadataNavigationHeader {

--- a/theme/gatsby-node.spec.js
+++ b/theme/gatsby-node.spec.js
@@ -90,6 +90,7 @@ describe('gatsby-node', () => {
       expect(typeDefs).toContain('slug: String!')
       expect(typeDefs).toContain('text: String!')
       expect(typeDefs).toContain('title: String!')
+      expect(typeDefs).toContain('nativeAnchor: Boolean')
 
       // Check that widget config has optional fields
       expect(typeDefs).toContain('username: String')

--- a/theme/gatsby-node.spec.js
+++ b/theme/gatsby-node.spec.js
@@ -80,6 +80,7 @@ describe('gatsby-node', () => {
       expect(typeDefs).toContain('type SiteSiteMetadataNavigation')
       expect(typeDefs).toContain('type SiteSiteMetadataNavigationHeader')
       expect(typeDefs).toContain('type SiteSiteMetadataNavigationItem')
+      expect(typeDefs).toContain('footer: [SiteSiteMetadataNavigationItem]')
       expect(typeDefs).toContain('type SiteSiteMetadataWidgets')
       expect(typeDefs).toContain('type SiteSiteMetadataWidgetConfig')
       expect(typeDefs).toContain('type SiteSiteMetadataHCard')

--- a/theme/package.json
+++ b/theme/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-theme-chronogrove",
   "description": "A personal website and digital garden theme for GatsbyJS.",
-  "version": "0.83.2",
+  "version": "0.84.0",
   "author": "Chris Vogt <mail@chrisvogt.me> (https://www.chrisvogt.me)",
   "main": "index.js",
   "license": "MIT",

--- a/theme/src/components/__snapshots__/layout.spec.js.snap
+++ b/theme/src/components/__snapshots__/layout.spec.js.snap
@@ -110,44 +110,6 @@ exports[`Layout matches the snapshot 1`] = `
               </a>
             </div>
           </div>
-          <div
-            class="css-k5zx4s"
-          >
-            <span>
-              <a
-                class="css-4d1obe"
-                href="/rss.xml"
-              >
-                Subscribe via RSS
-              </a>
-            </span>
-             | 
-            <span>
-              <a
-                href="/privacy"
-              >
-                Privacy Policy
-              </a>
-            </span>
-             | 
-            <span>
-              <a
-                class="css-4d1obe"
-                href="https://github.com/chrisvogt/gatsby-theme-chronogrove"
-              >
-                View Source
-              </a>
-            </span>
-             | 
-            <span>
-              <a
-                class="css-4d1obe"
-                href="https://metrics.chrisvogt.me/"
-              >
-                Status
-              </a>
-            </span>
-          </div>
         </div>
       </div>
     </footer>
@@ -264,44 +226,6 @@ exports[`Layout renders with audio player hidden state 1`] = `
                 </svg>
               </a>
             </div>
-          </div>
-          <div
-            class="css-k5zx4s"
-          >
-            <span>
-              <a
-                class="css-4d1obe"
-                href="/rss.xml"
-              >
-                Subscribe via RSS
-              </a>
-            </span>
-             | 
-            <span>
-              <a
-                href="/privacy"
-              >
-                Privacy Policy
-              </a>
-            </span>
-             | 
-            <span>
-              <a
-                class="css-4d1obe"
-                href="https://github.com/chrisvogt/gatsby-theme-chronogrove"
-              >
-                View Source
-              </a>
-            </span>
-             | 
-            <span>
-              <a
-                class="css-4d1obe"
-                href="https://metrics.chrisvogt.me/"
-              >
-                Status
-              </a>
-            </span>
           </div>
         </div>
       </div>
@@ -420,44 +344,6 @@ exports[`Layout renders with audio player visible state 1`] = `
               </a>
             </div>
           </div>
-          <div
-            class="css-k5zx4s"
-          >
-            <span>
-              <a
-                class="css-4d1obe"
-                href="/rss.xml"
-              >
-                Subscribe via RSS
-              </a>
-            </span>
-             | 
-            <span>
-              <a
-                href="/privacy"
-              >
-                Privacy Policy
-              </a>
-            </span>
-             | 
-            <span>
-              <a
-                class="css-4d1obe"
-                href="https://github.com/chrisvogt/gatsby-theme-chronogrove"
-              >
-                View Source
-              </a>
-            </span>
-             | 
-            <span>
-              <a
-                class="css-4d1obe"
-                href="https://metrics.chrisvogt.me/"
-              >
-                Status
-              </a>
-            </span>
-          </div>
         </div>
       </div>
     </footer>
@@ -564,44 +450,6 @@ exports[`Layout renders with disableMainWrapper prop 1`] = `
                 </svg>
               </a>
             </div>
-          </div>
-          <div
-            class="css-k5zx4s"
-          >
-            <span>
-              <a
-                class="css-4d1obe"
-                href="/rss.xml"
-              >
-                Subscribe via RSS
-              </a>
-            </span>
-             | 
-            <span>
-              <a
-                href="/privacy"
-              >
-                Privacy Policy
-              </a>
-            </span>
-             | 
-            <span>
-              <a
-                class="css-4d1obe"
-                href="https://github.com/chrisvogt/gatsby-theme-chronogrove"
-              >
-                View Source
-              </a>
-            </span>
-             | 
-            <span>
-              <a
-                class="css-4d1obe"
-                href="https://metrics.chrisvogt.me/"
-              >
-                Status
-              </a>
-            </span>
           </div>
         </div>
       </div>
@@ -749,44 +597,6 @@ exports[`Layout renders with hideHeader prop 1`] = `
                 </svg>
               </a>
             </div>
-          </div>
-          <div
-            class="css-k5zx4s"
-          >
-            <span>
-              <a
-                class="css-4d1obe"
-                href="/rss.xml"
-              >
-                Subscribe via RSS
-              </a>
-            </span>
-             | 
-            <span>
-              <a
-                href="/privacy"
-              >
-                Privacy Policy
-              </a>
-            </span>
-             | 
-            <span>
-              <a
-                class="css-4d1obe"
-                href="https://github.com/chrisvogt/gatsby-theme-chronogrove"
-              >
-                View Source
-              </a>
-            </span>
-             | 
-            <span>
-              <a
-                class="css-4d1obe"
-                href="https://metrics.chrisvogt.me/"
-              >
-                Status
-              </a>
-            </span>
           </div>
         </div>
       </div>

--- a/theme/src/components/footer/footer.js
+++ b/theme/src/components/footer/footer.js
@@ -8,7 +8,7 @@ import Profiles from './profiles'
 import useNavigationData from '../../hooks/use-navigation-data'
 import useSiteMetadata from '../../hooks/use-site-metadata'
 import { getFooterText } from '../../selectors/metadata'
-import { getFooterLinkItems, isExternalNavigationPath } from '../../selectors/navigation'
+import { getFooterLinkItems, shouldUseNativeNavigationLink } from '../../selectors/navigation'
 
 const footerLinkSx = { textDecoration: 'underline' }
 
@@ -30,7 +30,7 @@ export default () => {
               {footerLinks.map((item, i) => (
                 <span key={item.slug}>
                   {i > 0 ? ' | ' : null}
-                  {isExternalNavigationPath(item.path) ? (
+                  {shouldUseNativeNavigationLink(item.path, item) ? (
                     <ThemedLink href={item.path} title={item.title} sx={footerLinkSx}>
                       {item.text}
                     </ThemedLink>

--- a/theme/src/components/footer/footer.js
+++ b/theme/src/components/footer/footer.js
@@ -5,12 +5,18 @@ import { Link as ThemedLink } from 'theme-ui'
 
 import Profiles from './profiles'
 
-import { getFooterText } from '../../selectors/metadata'
+import useNavigationData from '../../hooks/use-navigation-data'
 import useSiteMetadata from '../../hooks/use-site-metadata'
+import { getFooterText } from '../../selectors/metadata'
+import { getFooterLinkItems, isExternalNavigationPath } from '../../selectors/navigation'
+
+const footerLinkSx = { textDecoration: 'underline' }
 
 export default () => {
   const metadata = useSiteMetadata()
+  const navigation = useNavigationData()
   const footerText = getFooterText(metadata)
+  const footerLinks = getFooterLinkItems(navigation)
 
   return (
     <footer role='contentinfo' id='footer' sx={{ variant: 'styles.PageFooter' }}>
@@ -18,33 +24,25 @@ export default () => {
         <div sx={{ mb: 3, py: [2, 3] }}>
           <Profiles />
 
-          <div sx={{ mt: [0, 1] }}>
-            {footerText ? <div>{footerText}</div> : null}
-            <span>
-              <ThemedLink href='/rss.xml' sx={{ textDecoration: 'underline' /* synced with Gatsby Link */ }}>
-                Subscribe via RSS
-              </ThemedLink>
-            </span>
-            {' | '}
-            <span>
-              <Link to='/privacy'>Privacy Policy</Link>
-            </span>
-            {' | '}
-            <span>
-              <ThemedLink
-                href='https://github.com/chrisvogt/gatsby-theme-chronogrove'
-                sx={{ textDecoration: 'underline' }}
-              >
-                View Source
-              </ThemedLink>
-            </span>
-            {' | '}
-            <span>
-              <ThemedLink href='https://metrics.chrisvogt.me/' sx={{ textDecoration: 'underline' }}>
-                Status
-              </ThemedLink>
-            </span>
-          </div>
+          {footerText || footerLinks.length > 0 ? (
+            <div sx={{ mt: [0, 1] }}>
+              {footerText ? <div>{footerText}</div> : null}
+              {footerLinks.map((item, i) => (
+                <span key={item.slug}>
+                  {i > 0 ? ' | ' : null}
+                  {isExternalNavigationPath(item.path) ? (
+                    <ThemedLink href={item.path} title={item.title} sx={footerLinkSx}>
+                      {item.text}
+                    </ThemedLink>
+                  ) : (
+                    <Link to={item.path} title={item.title} sx={footerLinkSx}>
+                      {item.text}
+                    </Link>
+                  )}
+                </span>
+              ))}
+            </div>
+          ) : null}
         </div>
       </Container>
     </footer>

--- a/theme/src/components/footer/footer.spec.js
+++ b/theme/src/components/footer/footer.spec.js
@@ -9,7 +9,7 @@ import { getFooterText } from '../../selectors/metadata'
 
 jest.mock('gatsby', () => ({
   Link: ({ to, children, title, ...rest }) => (
-    <a href={to} title={title} {...rest}>
+    <a data-gatsby-link href={to} title={title} {...rest}>
       {children}
     </a>
   )
@@ -95,15 +95,38 @@ describe('Footer', () => {
     const rssLink = screen.getByText('Subscribe via RSS')
     expect(rssLink).toBeInTheDocument()
     expect(rssLink).toHaveAttribute('href', '/rss.xml')
+    expect(rssLink).not.toHaveAttribute('data-gatsby-link')
 
     const privacyLink = screen.getByText('Privacy Policy')
     expect(privacyLink).toHaveAttribute('href', '/privacy')
+    expect(privacyLink).toHaveAttribute('data-gatsby-link')
 
     const sourceLink = screen.getByText('View Source')
     expect(sourceLink).toHaveAttribute('href', 'https://github.com/chrisvogt/gatsby-theme-chronogrove')
+    expect(sourceLink).not.toHaveAttribute('data-gatsby-link')
 
     const statusLink = screen.getByText('Status')
     expect(statusLink).toHaveAttribute('href', 'https://api.chrisvogt.me')
+    expect(statusLink).not.toHaveAttribute('data-gatsby-link')
+  })
+
+  it('uses a plain anchor when nativeAnchor is set for a non-extension path', () => {
+    useNavigationData.mockImplementation(() => ({
+      header: { left: [], home: [] },
+      footer: [
+        {
+          path: '/sitemap-index',
+          slug: 'sitemap',
+          text: 'Sitemap',
+          title: 'Sitemap',
+          nativeAnchor: true
+        }
+      ]
+    }))
+    renderWithTheme(<Footer />)
+    const link = screen.getByText('Sitemap')
+    expect(link).toHaveAttribute('href', '/sitemap-index')
+    expect(link).not.toHaveAttribute('data-gatsby-link')
   })
 
   it('does not render footer text if none is available', () => {

--- a/theme/src/components/footer/footer.spec.js
+++ b/theme/src/components/footer/footer.spec.js
@@ -3,40 +3,76 @@ import { render, screen } from '@testing-library/react'
 import '@testing-library/jest-dom'
 import Footer from './footer'
 import { ThemeUIProvider } from 'theme-ui'
-import useSiteMetadata from '../../hooks/use-site-metadata' // Ensure correct import
+import useSiteMetadata from '../../hooks/use-site-metadata'
+import useNavigationData from '../../hooks/use-navigation-data'
 import { getFooterText } from '../../selectors/metadata'
 
-// Mock dependencies
 jest.mock('gatsby', () => ({
-  Link: ({ to, children }) => <a href={to}>{children}</a> // Mock Gatsby's Link component
+  Link: ({ to, children, title, ...rest }) => (
+    <a href={to} title={title} {...rest}>
+      {children}
+    </a>
+  )
 }))
 
 jest.mock('theme-ui', () => ({
   ...jest.requireActual('theme-ui'),
-  Link: ({ href, children }) => <a href={href}>{children}</a> // Mock Theme UI's Link component
+  Link: ({ href, children, title, ...rest }) => (
+    <a href={href} title={title} {...rest}>
+      {children}
+    </a>
+  )
 }))
 
-jest.mock('../../hooks/use-site-metadata') // Correct mock for useSiteMetadata
+jest.mock('../../hooks/use-site-metadata')
+jest.mock('../../hooks/use-navigation-data')
 jest.mock('../../selectors/metadata')
 jest.mock('./profiles', () => () => <div data-testid='profiles'>Profiles</div>)
 
-// Mock Theme
 const mockTheme = {
   colors: {
     'panel-background': '#f0f0f0'
   }
 }
 
-// Helper function to render with theme
 const renderWithTheme = component => render(<ThemeUIProvider theme={mockTheme}>{component}</ThemeUIProvider>)
+
+const defaultNavigation = {
+  header: { left: [], home: [] },
+  footer: [
+    {
+      path: '/rss.xml',
+      slug: 'rss',
+      text: 'Subscribe via RSS',
+      title: 'RSS feed'
+    },
+    {
+      path: '/privacy',
+      slug: 'privacy',
+      text: 'Privacy Policy',
+      title: 'Privacy Policy'
+    },
+    {
+      path: 'https://github.com/chrisvogt/gatsby-theme-chronogrove',
+      slug: 'source',
+      text: 'View Source',
+      title: 'View source'
+    },
+    {
+      path: 'https://api.chrisvogt.me',
+      slug: 'status',
+      text: 'Status',
+      title: 'Status'
+    }
+  ]
+}
 
 describe('Footer', () => {
   beforeEach(() => {
-    // Ensure the mock implementation of useSiteMetadata is correct
     useSiteMetadata.mockReturnValue({
       title: 'Test Site'
     })
-
+    useNavigationData.mockImplementation(() => defaultNavigation)
     getFooterText.mockReturnValue('Test Footer Text')
   })
 
@@ -54,37 +90,32 @@ describe('Footer', () => {
     expect(screen.getByTestId('profiles')).toBeInTheDocument()
   })
 
-  it('renders the Subscribe via RSS link', () => {
+  it('renders footer links from navigation config', () => {
     renderWithTheme(<Footer />)
     const rssLink = screen.getByText('Subscribe via RSS')
     expect(rssLink).toBeInTheDocument()
     expect(rssLink).toHaveAttribute('href', '/rss.xml')
-  })
 
-  it('renders the Privacy Policy link', () => {
-    renderWithTheme(<Footer />)
     const privacyLink = screen.getByText('Privacy Policy')
-    expect(privacyLink).toBeInTheDocument()
     expect(privacyLink).toHaveAttribute('href', '/privacy')
-  })
 
-  it('renders the View Source link', () => {
-    renderWithTheme(<Footer />)
     const sourceLink = screen.getByText('View Source')
-    expect(sourceLink).toBeInTheDocument()
     expect(sourceLink).toHaveAttribute('href', 'https://github.com/chrisvogt/gatsby-theme-chronogrove')
-  })
 
-  it('renders the Status link', () => {
-    renderWithTheme(<Footer />)
     const statusLink = screen.getByText('Status')
-    expect(statusLink).toBeInTheDocument()
-    expect(statusLink).toHaveAttribute('href', 'https://metrics.chrisvogt.me/')
+    expect(statusLink).toHaveAttribute('href', 'https://api.chrisvogt.me')
   })
 
   it('does not render footer text if none is available', () => {
     getFooterText.mockReturnValue(null)
     renderWithTheme(<Footer />)
     expect(screen.queryByText('Test Footer Text')).toBeNull()
+  })
+
+  it('renders nothing below Profiles when there is no footer text and no footer links', () => {
+    getFooterText.mockReturnValue(null)
+    useNavigationData.mockImplementation(() => ({ header: { left: [], home: [] }, footer: [] }))
+    const { container } = renderWithTheme(<Footer />)
+    expect(container.querySelector('#footer [href]')).toBeNull()
   })
 })

--- a/theme/src/components/top-navigation.js
+++ b/theme/src/components/top-navigation.js
@@ -1,11 +1,11 @@
 /** @jsx jsx */
-import { jsx, Container } from 'theme-ui'
+import { jsx, Container, Link as ThemedLink } from 'theme-ui'
 import { Link } from 'gatsby'
 import { useLocation } from '@gatsbyjs/reach-router'
 import { Themed } from '@theme-ui/mdx'
 
 import ColorToggle from '../components/color-toggle'
-import { getHeaderLeftItems } from '../selectors/navigation'
+import { getHeaderLeftItems, shouldUseNativeNavigationLink } from '../selectors/navigation'
 import { getTitle } from '../selectors/metadata'
 import useNavigationData from '../hooks/use-navigation-data'
 import useSiteMetadata from '../hooks/use-site-metadata'
@@ -88,22 +88,25 @@ const TopNavigation = () => {
           }}
         >
           <nav role='navigation'>
-            {menuItems.map(({ slug, path, title, text }) => (
-              <Link
-                key={slug}
-                sx={{
-                  fontSize: 2,
-                  variant: 'styles.a',
-                  color: 'text',
-                  mr: 3,
-                  mb: [1, '', 0]
-                }}
-                title={title}
-                to={path}
-              >
-                {text}
-              </Link>
-            ))}
+            {menuItems.map(item => {
+              const { slug, path, title, text } = item
+              const linkSx = {
+                fontSize: 2,
+                variant: 'styles.a',
+                color: 'text',
+                mr: 3,
+                mb: [1, '', 0]
+              }
+              return shouldUseNativeNavigationLink(path, item) ? (
+                <ThemedLink key={slug} href={path} title={title} sx={linkSx}>
+                  {text}
+                </ThemedLink>
+              ) : (
+                <Link key={slug} sx={linkSx} title={title} to={path}>
+                  {text}
+                </Link>
+              )
+            })}
           </nav>
         </Themed.div>
       </Container>

--- a/theme/src/data/theme-config.js
+++ b/theme/src/data/theme-config.js
@@ -126,7 +126,8 @@ const defaultConfig = {
           title: 'Instagram'
         }
       ]
-    }
+    },
+    footer: []
   },
 
   // Widget configuration

--- a/theme/src/data/theme-config.spec.js
+++ b/theme/src/data/theme-config.spec.js
@@ -86,10 +86,12 @@ describe('theme-config', () => {
 
     it('should have default navigation structure', () => {
       expect(defaultConfig.navigation).toHaveProperty('header')
+      expect(defaultConfig.navigation).toHaveProperty('footer')
       expect(defaultConfig.navigation.header).toHaveProperty('left')
       expect(defaultConfig.navigation.header).toHaveProperty('home')
       expect(Array.isArray(defaultConfig.navigation.header.left)).toBe(true)
       expect(Array.isArray(defaultConfig.navigation.header.home)).toBe(true)
+      expect(defaultConfig.navigation.footer).toEqual([])
     })
 
     it('should have default navigation items', () => {
@@ -210,6 +212,7 @@ describe('theme-config', () => {
         text: 'Custom Widget',
         title: 'Custom Widget'
       })
+      expect(result.navigation.footer).toEqual([])
     })
 
     it('should merge widgets correctly', () => {
@@ -272,6 +275,7 @@ describe('theme-config', () => {
       // Should preserve other defaults
       expect(result.siteMetadata.description).toBe('A personal website and blog')
       expect(result.navigation.header.home).toHaveLength(2)
+      expect(result.navigation.footer).toEqual([])
       expect(result.widgets.instagram.username).toBe('')
     })
 

--- a/theme/src/hooks/use-navigation-data.js
+++ b/theme/src/hooks/use-navigation-data.js
@@ -12,12 +12,14 @@ const useNavigationData = () => {
                 slug
                 text
                 title
+                nativeAnchor
               }
               left {
                 path
                 slug
                 text
                 title
+                nativeAnchor
               }
             }
             footer {
@@ -25,6 +27,7 @@ const useNavigationData = () => {
               slug
               text
               title
+              nativeAnchor
             }
           }
         }

--- a/theme/src/hooks/use-navigation-data.js
+++ b/theme/src/hooks/use-navigation-data.js
@@ -20,26 +20,32 @@ const useNavigationData = () => {
                 title
               }
             }
+            footer {
+              path
+              slug
+              text
+              title
+            }
           }
         }
       }
     }
   `)
 
-  // Return empty object if no navigation data exists
-  if (!navigation || !navigation.header) {
-    return {}
-  }
-
-  // Defensive: always return arrays for header.left and header.home
-  const result = {
-    header: {
-      left: navigation.header.left || [],
-      home: navigation.header.home || []
+  if (!navigation) {
+    return {
+      header: { left: [], home: [] },
+      footer: []
     }
   }
 
-  return result
+  return {
+    header: {
+      left: navigation.header?.left || [],
+      home: navigation.header?.home || []
+    },
+    footer: Array.isArray(navigation.footer) ? navigation.footer : []
+  }
 }
 
 export default useNavigationData

--- a/theme/src/hooks/use-navigation-data.spec.js
+++ b/theme/src/hooks/use-navigation-data.spec.js
@@ -38,28 +38,66 @@ const data = {
 jest.mock('gatsby')
 
 describe('useNavigationData', () => {
-  it('returns navigation data from site metadata', () => {
+  it('returns navigation data from site metadata with normalized footer', () => {
     useStaticQuery.mockImplementation(() => data)
     const { result } = renderHook(() => useNavigationData())
-    expect(result.current).toEqual(data.site.siteMetadata.navigation)
+    expect(result.current).toEqual({
+      header: {
+        left: data.site.siteMetadata.navigation.header.left,
+        home: data.site.siteMetadata.navigation.header.home
+      },
+      footer: []
+    })
+  })
+
+  it('returns footer items when present', () => {
+    const footer = [
+      {
+        path: '/rss.xml',
+        slug: 'rss',
+        text: 'RSS',
+        title: 'RSS'
+      }
+    ]
+    useStaticQuery.mockImplementation(() => ({
+      site: {
+        siteMetadata: {
+          navigation: {
+            ...data.site.siteMetadata.navigation,
+            footer
+          }
+        }
+      }
+    }))
+    const { result } = renderHook(() => useNavigationData())
+    expect(result.current.footer).toEqual(footer)
   })
 
   it('handles missing navigation data', () => {
     useStaticQuery.mockImplementation(() => ({ site: { siteMetadata: {} } }))
     const { result } = renderHook(() => useNavigationData())
-    expect(result.current).toEqual({})
+    expect(result.current).toEqual({
+      header: { left: [], home: [] },
+      footer: []
+    })
   })
 
   it('handles missing site metadata', () => {
     useStaticQuery.mockImplementation(() => ({ site: {} }))
     const { result } = renderHook(() => useNavigationData())
-    expect(result.current).toEqual({})
+    expect(result.current).toEqual({
+      header: { left: [], home: [] },
+      footer: []
+    })
   })
 
   it('handles missing site', () => {
     useStaticQuery.mockImplementation(() => ({}))
     const { result } = renderHook(() => useNavigationData())
-    expect(result.current).toEqual({})
+    expect(result.current).toEqual({
+      header: { left: [], home: [] },
+      footer: []
+    })
   })
 
   it('returns empty arrays when header.left or header.home are missing', () => {
@@ -77,7 +115,39 @@ describe('useNavigationData', () => {
       header: {
         left: [],
         home: []
+      },
+      footer: []
+    })
+  })
+
+  it('returns header when only footer is configured', () => {
+    useStaticQuery.mockImplementation(() => ({
+      site: {
+        siteMetadata: {
+          navigation: {
+            footer: [
+              {
+                path: 'https://example.com',
+                slug: 'ext',
+                text: 'Example',
+                title: 'Example'
+              }
+            ]
+          }
+        }
       }
+    }))
+    const { result } = renderHook(() => useNavigationData())
+    expect(result.current).toEqual({
+      header: { left: [], home: [] },
+      footer: [
+        {
+          path: 'https://example.com',
+          slug: 'ext',
+          text: 'Example',
+          title: 'Example'
+        }
+      ]
     })
   })
 
@@ -96,5 +166,21 @@ describe('useNavigationData', () => {
     const { result } = renderHook(() => useNavigationData())
     expect(result.current.header.left).toHaveLength(1)
     expect(result.current.header.home).toEqual([])
+    expect(result.current.footer).toEqual([])
+  })
+
+  it('treats non-array footer as empty', () => {
+    useStaticQuery.mockImplementation(() => ({
+      site: {
+        siteMetadata: {
+          navigation: {
+            header: data.site.siteMetadata.navigation.header,
+            footer: null
+          }
+        }
+      }
+    }))
+    const { result } = renderHook(() => useNavigationData())
+    expect(result.current.footer).toEqual([])
   })
 })

--- a/theme/src/selectors/navigation.js
+++ b/theme/src/selectors/navigation.js
@@ -1,10 +1,31 @@
 const HTTP_SCHEME = /^https?:\/\//i
 
+// Feeds, manifests, and other build outputs are not Gatsby pages — gatsby-link prefetch/page-data can 404 or hang.
+const STATIC_OUTPUT_EXT = /\.(?:atom|ico|pdf|rss|txt|webmanifest|xml|zip)$/i
+
+const pathWithoutQueryOrHash = path => (typeof path === 'string' ? path.replace(/[?#].*/, '') : '')
+
 /**
  * @param {string|undefined} path
  * @returns {boolean} True if `path` is an http(s) URL (footer/source links), false for site-relative paths.
  */
 export const isExternalNavigationPath = path => Boolean(path && HTTP_SCHEME.test(path))
+
+/**
+ * @param {string|undefined} path
+ * @returns {boolean} True if `path` is site-relative and looks like a static file (e.g. `/rss.xml`).
+ */
+export const isStaticOutputNavigationPath = path =>
+  Boolean(path && !isExternalNavigationPath(path) && STATIC_OUTPUT_EXT.test(pathWithoutQueryOrHash(path)))
+
+/**
+ * Prefer a native `<a href>` (Theme UI link) instead of Gatsby `Link` when client routing / prefetch is unsafe.
+ *
+ * @param {string|undefined} path
+ * @param {{ nativeAnchor?: boolean }} [item]
+ */
+export const shouldUseNativeNavigationLink = (path, item) =>
+  Boolean(isExternalNavigationPath(path) || isStaticOutputNavigationPath(path) || (item && item.nativeAnchor === true))
 
 export const getHeaderLeftItems = navigation => (Array.isArray(navigation?.header?.left) ? navigation.header.left : [])
 

--- a/theme/src/selectors/navigation.js
+++ b/theme/src/selectors/navigation.js
@@ -1,1 +1,11 @@
+const HTTP_SCHEME = /^https?:\/\//i
+
+/**
+ * @param {string|undefined} path
+ * @returns {boolean} True if `path` is an http(s) URL (footer/source links), false for site-relative paths.
+ */
+export const isExternalNavigationPath = path => Boolean(path && HTTP_SCHEME.test(path))
+
 export const getHeaderLeftItems = navigation => (Array.isArray(navigation?.header?.left) ? navigation.header.left : [])
+
+export const getFooterLinkItems = navigation => (Array.isArray(navigation?.footer) ? navigation.footer : [])

--- a/theme/src/selectors/navigation.spec.js
+++ b/theme/src/selectors/navigation.spec.js
@@ -1,4 +1,10 @@
-import { getHeaderLeftItems, getFooterLinkItems, isExternalNavigationPath } from './navigation'
+import {
+  getHeaderLeftItems,
+  getFooterLinkItems,
+  isExternalNavigationPath,
+  isStaticOutputNavigationPath,
+  shouldUseNativeNavigationLink
+} from './navigation'
 
 const navigation = {
   header: {
@@ -44,5 +50,23 @@ describe('navigation selectors', () => {
   it('isExternalNavigationPath is false for site-relative paths', () => {
     expect(isExternalNavigationPath('/rss.xml')).toBe(false)
     expect(isExternalNavigationPath('/privacy')).toBe(false)
+  })
+
+  it('isStaticOutputNavigationPath is true for common static output paths', () => {
+    expect(isStaticOutputNavigationPath('/rss.xml')).toBe(true)
+    expect(isStaticOutputNavigationPath('/feed.atom')).toBe(true)
+    expect(isStaticOutputNavigationPath('/rss.xml?v=1')).toBe(true)
+  })
+
+  it('isStaticOutputNavigationPath is false for pages and external URLs', () => {
+    expect(isStaticOutputNavigationPath('/privacy')).toBe(false)
+    expect(isStaticOutputNavigationPath('https://example.com/feed.xml')).toBe(false)
+  })
+
+  it('shouldUseNativeNavigationLink is true for external, static output, or nativeAnchor', () => {
+    expect(shouldUseNativeNavigationLink('https://x.com', {})).toBe(true)
+    expect(shouldUseNativeNavigationLink('/rss.xml', {})).toBe(true)
+    expect(shouldUseNativeNavigationLink('/odd-path', { nativeAnchor: true })).toBe(true)
+    expect(shouldUseNativeNavigationLink('/privacy', {})).toBe(false)
   })
 })

--- a/theme/src/selectors/navigation.spec.js
+++ b/theme/src/selectors/navigation.spec.js
@@ -1,4 +1,4 @@
-import { getHeaderLeftItems } from './navigation'
+import { getHeaderLeftItems, getFooterLinkItems, isExternalNavigationPath } from './navigation'
 
 const navigation = {
   header: {
@@ -10,12 +10,39 @@ const navigation = {
         title: 'About Me'
       }
     ]
-  }
+  },
+  footer: [
+    {
+      path: '/rss.xml',
+      slug: 'rss',
+      text: 'RSS',
+      title: 'RSS'
+    }
+  ]
 }
 
-describe('Metadata Selectors', () => {
-  it('selects the avatar URL', () => {
+describe('navigation selectors', () => {
+  it('getHeaderLeftItems returns header left links', () => {
     const result = getHeaderLeftItems(navigation)
     expect(result).toEqual(navigation.header.left)
+  })
+
+  it('getFooterLinkItems returns footer links', () => {
+    expect(getFooterLinkItems(navigation)).toEqual(navigation.footer)
+  })
+
+  it('getFooterLinkItems returns empty array when missing', () => {
+    expect(getFooterLinkItems({})).toEqual([])
+    expect(getFooterLinkItems({ header: { left: [] } })).toEqual([])
+  })
+
+  it('isExternalNavigationPath is true for http(s) URLs', () => {
+    expect(isExternalNavigationPath('https://example.com/x')).toBe(true)
+    expect(isExternalNavigationPath('http://example.com')).toBe(true)
+  })
+
+  it('isExternalNavigationPath is false for site-relative paths', () => {
+    expect(isExternalNavigationPath('/rss.xml')).toBe(false)
+    expect(isExternalNavigationPath('/privacy')).toBe(false)
   })
 })

--- a/www.chrisvogt.me/gatsby-config.js
+++ b/www.chrisvogt.me/gatsby-config.js
@@ -240,7 +240,33 @@ module.exports = {
                 title: 'Steam'
               }
             ]
-          }
+          },
+          footer: [
+            {
+              path: '/rss.xml',
+              slug: 'rss',
+              text: 'Subscribe via RSS',
+              title: 'RSS feed'
+            },
+            {
+              path: '/privacy',
+              slug: 'privacy',
+              text: 'Privacy Policy',
+              title: 'Privacy Policy'
+            },
+            {
+              path: 'https://github.com/chrisvogt/gatsby-theme-chronogrove',
+              slug: 'source',
+              text: 'View Source',
+              title: 'View theme source on GitHub'
+            },
+            {
+              path: 'https://api.chrisvogt.me',
+              slug: 'status',
+              text: 'Status',
+              title: 'API status'
+            }
+          ]
         },
         widgets: {
           discogs: {

--- a/www.chrisvogt.me/package.json
+++ b/www.chrisvogt.me/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "www.chrisvogt.me",
-  "version": "1.14.2",
+  "version": "1.15.0",
   "license": "GPL",
   "scripts": {
     "build": "gatsby build",

--- a/www.chronogrove.com/gatsby-config.js
+++ b/www.chronogrove.com/gatsby-config.js
@@ -119,7 +119,15 @@ module.exports = {
                 title: 'GitHub'
               }
             ]
-          }
+          },
+          footer: [
+            {
+              path: 'https://github.com/chrisvogt/gatsby-theme-chronogrove',
+              slug: 'source',
+              text: 'View Source',
+              title: 'View theme source on GitHub'
+            }
+          ]
         },
         widgets: {
           github: {

--- a/www.chronogrove.com/package.json
+++ b/www.chronogrove.com/package.json
@@ -1,6 +1,6 @@
 {
   "name": "www.chronogrove.com",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "description": "Official demo site for gatsby-theme-chronogrove",
   "scripts": {
     "develop": "gatsby develop",


### PR DESCRIPTION
## Summary

Adds optional `siteMetadata.navigation.footer` so footer links (RSS, privacy, source repo, status, etc.) are configured per site instead of hardcoded in the theme. Follow-up commit ensures feed and other static outputs use plain `<a href>` (not `gatsby-link`) where client prefetch would hit non-page assets.

## Changes

- **Schema / data**: `SiteSiteMetadataNavigation.footer` (reuses navigation item shape: `path`, `slug`, `text`, `title`, optional **`nativeAnchor`**).
- **Runtime**: `useNavigationData` exposes `footer`; supports footer-only config; normalized empty `header` / `footer` when missing; GraphQL includes **`nativeAnchor`** for header and footer items.
- **UI**: `Footer` maps config with ` | ` separators. **`shouldUseNativeNavigationLink`**: `http(s)` URLs, site-relative paths with common static extensions (e.g. `.xml`, `.rss`, `.atom`), or **`nativeAnchor: true`** → Theme UI `href` link; other internal paths → Gatsby **`Link`**. **`TopNavigation`** header-left items use the same rule.
- **Selectors**: `getFooterLinkItems`, `isExternalNavigationPath`, `isStaticOutputNavigationPath`, `shouldUseNativeNavigationLink`.
- **Defaults**: Theme `navigation.footer: []` (no site-specific URLs in the published theme).
- **Sites**: `www.chrisvogt.me` — full footer including Status at `https://api.chrisvogt.me`; `www.chronogrove.com` — View Source only (demo has no feed plugin for RSS).

## Versioning

- `gatsby-theme-chronogrove` **0.84.0**
- `www.chrisvogt.me` **1.15.0**
- `www.chronogrove.com` **1.2.0**

## Docs

- `theme/README.md`, root `CHANGELOG.md`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds optional `navigation.footer` and link rendering rules with defensive defaults; main behavior change is configurable footer/header-left links and avoiding `gatsby-link` for static outputs (feeds, etc.).
>
> **Overview**
> **Adds configurable footer links** via optional `siteMetadata.navigation.footer`, removing hardcoded site-specific URLs from the theme. **Follow-up:** static-looking paths and optional `nativeAnchor` use plain anchors so `gatsby-plugin-feed` output (e.g. `/rss.xml`) is not routed through `gatsby-link`.
>
> Schema, `useNavigationData`, `Footer`, and **`TopNavigation`** are updated; theme defaults use `navigation.footer: []`; docs/tests/snapshots and example sites are bumped.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 08db9a02f5f034516bb9efdbc2660b6acf1ae444; branch also includes 8b09b3e623a800c7d7247780adbf12af6ed3d718 (plain anchors for static nav paths). Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
