### PR TITLE
feat: add April 2026 recap, /now update, and gallery metadata

### DIFF
--- a/theme/src/pages/now.js
+++ b/theme/src/pages/now.js
@@ -4,7 +4,7 @@ import { navigate } from 'gatsby'
 // Redirect /now to the latest recap
 const NowPage = () => {
   useEffect(() => {
-    navigate('/personal/january-2026', { replace: true })
+    navigate('/personal/april-2026', { replace: true })
   }, [])
 
   return null

--- a/theme/src/pages/now.spec.js
+++ b/theme/src/pages/now.spec.js
@@ -17,7 +17,7 @@ describe('NowPage', () => {
   it('redirects to the latest recap on mount', () => {
     render(<NowPage />)
 
-    expect(navigate).toHaveBeenCalledWith('/personal/january-2026', { replace: true })
+    expect(navigate).toHaveBeenCalledWith('/personal/april-2026', { replace: true })
   })
 
   it('uses replace to avoid adding to browser history', () => {

--- a/www.chrisvogt.me/content/blog/2026-01-31-january-2026-recap/2026-01-31-january-2026-recap.mdx
+++ b/www.chrisvogt.me/content/blog/2026-01-31-january-2026-recap/2026-01-31-january-2026-recap.mdx
@@ -45,10 +45,6 @@ import {
   horseRanch
 } from './photos'
 
-<Note>
-  <strong>Note:</strong> I'm running late on my February 2026 recap—it's coming soon!
-</Note>
-
 Happy new year! January 2026 had me bouncing between San Francisco, Palm Springs, and Phoenix.
 
 ## 🌉 San Francisco

--- a/www.chrisvogt.me/content/blog/2026-04-30-april-2026-recap/2026-04-30-april-2026-recap.mdx
+++ b/www.chrisvogt.me/content/blog/2026-04-30-april-2026-recap/2026-04-30-april-2026-recap.mdx
@@ -10,9 +10,9 @@ thumbnails:
   - https://res.cloudinary.com/chrisvogt/image/upload/f_auto/v1777694469/chrisvogt-me/galleries/now-april-2026/20260418-IMG_4344.jpg
 date: '2026-05-01T20:00:00.000Z'
 description: >
-  April 2026 in scenes: Easter and Hunky Jesus with my partner, Gayme Show at the reopened Castro Theatre, L.A. and Long Beach, then Brilliant Lady on an Atlantis Events charter with friends—while San Francisco weather wobbled and the fault lines had other ideas at home.
+  April 2026 in scenes: Easter and Hunky Jesus, Gayme Show at the reopened Castro Theatre, L.A. and Long Beach, then Brilliant Lady on an Atlantis Events charter with friends—while San Francisco weather wobbled and the fault lines had other ideas at home.
 excerpt: >
-  April with my partner—Hunky Jesus, Gayme Show, Grand Prix, Battleship IOWA, and Brilliant Lady on an Atlantis charter with our San Francisco crew—plus grow lights back home.
+  April—Hunky Jesus, Gayme Show, Grand Prix, Battleship IOWA, and Brilliant Lady on an Atlantis charter with our San Francisco crew.
 keywords:
   [
     april 2026,

--- a/www.chrisvogt.me/content/blog/2026-04-30-april-2026-recap/2026-04-30-april-2026-recap.mdx
+++ b/www.chrisvogt.me/content/blog/2026-04-30-april-2026-recap/2026-04-30-april-2026-recap.mdx
@@ -2,17 +2,17 @@
 title: 'April 2026 Recap'
 slug: april-2026
 category: personal
-banner: https://res.cloudinary.com/chrisvogt/image/upload/f_auto/v1770093154/chrisvogt-me/thumbnails/jan-2026-recap.jpg
+banner: https://res.cloudinary.com/chrisvogt/image/upload/f_auto/v1777694478/chrisvogt-me/galleries/now-april-2026/20260405-IMG_3974.jpg
 thumbnails:
-  - https://res.cloudinary.com/chrisvogt/image/upload/f_auto/v1770085939/chrisvogt-me/galleries/now-jan-2026/20260102-IMG_2393.jpg
-  - https://res.cloudinary.com/chrisvogt/image/upload/f_auto/v1770085941/chrisvogt-me/galleries/now-jan-2026/20260115-IMG_2615.jpg
-  - https://res.cloudinary.com/chrisvogt/image/upload/f_auto/v1770085921/chrisvogt-me/galleries/now-jan-2026/20260124-IMG_2871.jpg
-  - https://res.cloudinary.com/chrisvogt/image/upload/f_auto/v1770085924/chrisvogt-me/galleries/now-jan-2026/20260124-IMG_2913.jpg
+  - https://res.cloudinary.com/chrisvogt/image/upload/f_auto/v1777694460/chrisvogt-me/galleries/now-april-2026/20260405-IMG_3947.jpg
+  - https://res.cloudinary.com/chrisvogt/image/upload/f_auto/v1777694464/chrisvogt-me/galleries/now-april-2026/20260408-IMG_4130.jpg
+  - https://res.cloudinary.com/chrisvogt/image/upload/f_auto/v1777694486/chrisvogt-me/galleries/now-april-2026/20260417-IMG_4281.jpg
+  - https://res.cloudinary.com/chrisvogt/image/upload/f_auto/v1777694469/chrisvogt-me/galleries/now-april-2026/20260418-IMG_4344.jpg
 date: '2026-05-01T20:00:00.000Z'
 description: >
-  A personal recap of April 2026: Easter and Hunky Jesus at Dolores Park and the Castro, Gayme Show at the reopened Castro Theatre, flying to Los Angeles, the Grand Prix in Long Beach, the Battleship IOWA Museum, Virgin Voyages' Brilliant Lady to the Mexican Riviera, and plant updates back home.
+  April 2026 in scenes: Easter and Hunky Jesus with my partner, Gayme Show at the reopened Castro Theatre, L.A. and Long Beach, then Brilliant Lady on an Atlantis Events charter with friends—while San Francisco weather wobbled and the fault lines had other ideas at home.
 excerpt: >
-  April 2026 in photos — Hunky Jesus at Dolores and The Mix, Gayme Show at the Castro Theatre, L.A. and Long Beach, Brilliant Lady, and home garden notes.
+  April with my partner—Hunky Jesus, Gayme Show, Grand Prix, Battleship IOWA, and Brilliant Lady on an Atlantis charter with our San Francisco crew—plus grow lights back home.
 keywords:
   [
     april 2026,
@@ -35,7 +35,9 @@ keywords:
     mexican riviera,
     cruise,
     plants,
-    travel
+    travel,
+    atlantis events,
+    partner
   ]
 ---
 
@@ -51,56 +53,60 @@ import {
   plantUpdates
 } from './photos'
 
-April stacked a lot into a few weeks: a classic San Francisco spring weekend, a hop down to Southern California for racing and history, then straight onto Brilliant Lady for a Mexican Riviera sailing. Below is a photo-first recap of the highlights; a longer post journaling the cruise itself is coming soon.
+April did not so much arrive as accrete—my partner and I threading one of those San Francisco spring weekends that can feel like a civic sacrament, then a lateral move to Southern California for speed and steel, then—without much room to catch our breath—embarkation on Brilliant Lady for a Mexican Riviera run with six of our friends from the city (eight of us in all). The weather had been doing its usual April trick: sun, fog, wind, repeat. Getting out of town felt less like indulgence than like swapping a mercurial thermostat for a different set of problems entirely. What follows is the month in pictures, with the cruise kept deliberately thin here; the ports, sea days, meals, and the rest of the film roll are reserved for a longer piece still in draft.
 
 ## ✝️ Hunky Jesus — Part 1, Dolores Park
 
-If you do not spend April in San Francisco, _Hunky Jesus_ sounds made up. The [Sisters of Perpetual Indulgence](https://www.thesisters.org/)—a queer order known here for decades of AIDS-era activism, fundraising, and grants to smaller nonprofits—host [Easter in the Park](https://www.thesisters.org/easter) each Easter Sunday on the north end of Mission Dolores Park: a free, donation-supported street fair and variety show. _Hunky Jesus_ is one of three long-running contests (with Foxy Mary and Easter Bonnet) where contestants turn up in campy, satirical Jesuses (the name is the joke), finalists are screened backstage, and the crowd more or less cheers and laughs someone into a winner.
+If you are not in town for April in San Francisco, _Hunky Jesus_ registers as pure invention, a phrase you might misread on a flyer and never think of again. The [Sisters of Perpetual Indulgence](https://www.thesisters.org/)—the queer order that has, for decades, braided AIDS-era activism with camp and serious fundraising—host [Easter in the Park](https://www.thesisters.org/easter) each Easter Sunday on the north bowl of Mission Dolores Park: a donation-supported fair and variety show that behaves, at scale, like a neighborhood block party with better lighting and worse boundaries. Among the long-running contests (Foxy Mary, Easter Bonnet, and this one), _Hunky Jesus_ is exactly what it sounds like, which is also the joke: contestants arrive as satirical Jesuses, finalists vanish backstage for whatever adjudication the universe allows, and the hillside votes with laughter.
 
-These photos are from Easter Sunday, April 5. This year's theme was "Love Thy Neighbor," and the Sisters posted a run-of-show with Hunky Jesus on the main stage around 2:55 in the afternoon (after Easter Bonnet and Foxy Mary). The city does not publish a headcount; in fundraising copy the Sisters describe underwriting a production on the order of a ten-thousand-person block party, and on a sunny Easter the north lawn still feels bigger than that figure once you count everyone spilling past the blankets. The crown went to Renewable Energy Jesus—complete with a full-size windmill strapped to his back—which felt very on-theme for a hillside full of people celebrating spring in the city this April.
+These frames are from Easter Sunday, April 5. The theme was "Love Thy Neighbor"; the Sisters’ posted schedule had Hunky Jesus on the main stage around 2:55 p.m., after the bonnets and the Marys had done their work. The city does not issue a turnstile count; in fundraising language the Sisters talk about underwriting something on the order of a ten-thousand-person gathering, and on a clear day the north lawn argues the number upward once you account for everyone who has spilled past the edge of the blankets. The crown went to Renewable Energy Jesus—complete with a windmill lashed to his back—which landed with the unsubtle aptness good satire sometimes earns: spring on a hill, a crowd in sunglasses, and a winner who had brought his own grid.
 
-Blankets on the slope, DJs and picnics, and this mix of street theater and neighborhood ritual—San Francisco spring at full volume.
+Blankets, DJs, picnic archaeology, and the low-grade thunder of a city that still knows how to throw a ritual. That was the afternoon.
 
 <PhotoGallery key='hunky-jesus-dolores' photos={hunkyJesus} />
 
 ## ✝️ Hunky Jesus — Part 2, Walking to The Mix
 
-After Dolores Park we drifted toward the Castro and The Mix — sidewalk energy, patio sun, and someone with a bubble gun turning the whole patio into a soap-bubble snow globe.
+When Dolores had done what Dolores does, we drifted toward the Castro and The Mix—sidewalk theater giving way to patio sun, drinks sweating on metal tables, and someone with a bubble gun who turned the whole terrace into a soap-bubble weather system. Not snow; something sillier and warmer.
 
 <PhotoGallery key='hunky-jesus-castro-mix' photos={hunkyJesusCastroMix} />
 
 ## 🎭 Gayme Show! at the Castro Theatre
 
-A few nights later we caught [Gayme Show! with Matt Rogers and Dave Mizzoni](https://thecastro.com/events/gayme-show-260408) at the [Castro Theatre](https://thecastro.com/) — my first time back since the renovation and reopening. The show is a live game-show chaos engine: they pulled random audience members on stage and ran the men against the women to crown a Queen of the Castro. Loud, silly, and a lot of fun.
+A few nights later: [Gayme Show! with Matt Rogers and Dave Mizzoni](https://thecastro.com/events/gayme-show-260408) at the [Castro Theatre](https://thecastro.com/), my first time through the doors since the renovation and reopening. The format is a live game-show entropy machine—audience members hauled up, teams sorted with cheerful cruelty, a crown at stake for the Queen of the Castro. The bit that still replays in my head: they located, with prosecutorial glee, the one straight man in the building (there with his girlfriend), flashed a slideshow of decoys, and demanded he answer a single question—“Is this a _Chappel Roan_?”—where “Chappel Roan” was whatever pun the writers could staple to the name: a cocktail, a church chapel, whatever else the projector coughed up. Loud, stupid in the best sense, and exactly the kind of night you want when the marquee has been dark long enough that its return feels like news.
 
 <PhotoGallery key='gayme-show-castro-theater' photos={gaymeShowCastroTheater} />
 
 ## ✈️ Flying to LAX
 
-I flew Delta down to Los Angeles — clear air over the west side of San Francisco, then a hazy golden-hour sweep over the city as we came in toward the airport.
+Delta down to Los Angeles: first the west side of San Francisco in hard-edged clarity—Ocean Beach, the grid, the bridge a thin line on the horizon—then the long gold haze of approach, the basin opening below you like a map someone has half erased with an eraser made of smog and sunset.
 
 <PhotoGallery key='flying-to-lax' photos={flyingToLax} />
 
 ## 🏎️ Grand Prix in Long Beach
 
-My friend Mateo scored a couple of extra tickets and brought us along to the Acura Grand Prix of Long Beach festival — downtown streets as a circuit, vendor halls full of cars, and energy you can feel in your ribs. I didn't see much of the on-track action, but I _heard_ all of it; next time I'm packing earplugs and I suggest you do too if you're sound-sensitive.
+My friend Mateo had a pair of spare tickets to the Acura Grand Prix of Long Beach and brought my partner and me along—downtown streets temporarily reclassified as a circuit, exhibition halls full of carbon fiber and nostalgia, and a sound field you feel in your sternum before your brain catches up. I caught more of the race by ear than by eye; if you are sound-sensitive, pack earplugs and thank yourself later.
 
 <PhotoGallery key='grand-prix-long-beach' photos={grandPrixLongBeach} />
 
 ## ⚓ Exploring Battleship IOWA Museum
 
-Before embarkation we had a few hours in San Pedro, so we toured Battleship IOWA — a retired museum ship that still reads like a small steel city. We spent about an hour winding through the main deck, enlisted berthing, the captain's quarters, the navigating bridge forward, and the upper levels for views over the harbor. It was a slow, tactile way to pass the time before heading to the cruise terminal.
+Before embarkation we had a few hours in San Pedro, enough to walk Battleship IOWA end to end—or as much of her as the museum route allows—which is less a ship in the romantic sense than a steel municipality moored to a pier. An hour or so of companionways, enlisted berthing that still smells faintly of paint and policy, the captain’s quarters with their odd domestic politeness, the navigating bridge forward, then the upper decks for the money shot: harbor, cranes, the ordinary world looking small from a platform built for another century’s arguments.
 
 <PhotoGallery key='battleship-iowa' photos={battleshipIowa} />
 
 ## 🚢 LAX to Mexican Riviera Cruise on Brilliant Lady
 
-From Los Angeles we sailed Brilliant Lady on a Virgin Voyages Mexican Riviera itinerary. This recap keeps the cruise section intentionally small — mostly friends and a few favorite frames. Ports, sea days, food, and a bigger gallery will sit in a dedicated post journaling the whole sailing; the full cruise journal is coming soon.
+From Los Angeles we joined Brilliant Lady on Virgin Voyages’ Mexican Riviera itinerary—this time under an [Atlantis Events](https://www.atlantisevents.com/) charter, my first sailing with that crowd, though the ship herself was already familiar. I had been on Brilliant Lady not long before, over Thanksgiving 2025—a trip I never wrote up; April was the same hull, different house lights.
+
+This section stays intentionally small: six friends from San Francisco, my partner and me, a few favorite frames, the shape of the trip without the ledger of every port and plate. While we were offshore, San Francisco shook—our phones did that modern ritual of lighting up all at once with alerts and group chats—and we pieced together the rest through the usual feeds, including [SFGate’s story on the quake](https://www.sfgate.com/news/article/earthquakes-san-francisco-zoo-22226142.php).
+
+The longer account of this sailing—sea days, food, shore leave, the rest of the gallery—will live in its own post when the sentences have cooled.
 
 <PhotoGallery key='brilliant-lady-cruise' photos={cruiseBrilliantLady} />
 
 ## 🪴 Back Home — Plant Updates
 
-Back home in San Francisco by the end of the month, the indoor setup was doing what it does best: herbs and flowers under the AeroGarden lights, with a salt lamp warming the corner of the counter.
+By month’s end we were home in San Francisco, where the indoor garden resumed its quiet coup: herbs and flowers under the AeroGarden’s honest, slightly alien light, a salt lamp holding down one corner of the counter like a small sun that had given up on spectra and committed to orange.
 
 <PhotoGallery key='plant-updates' photos={plantUpdates} />

--- a/www.chrisvogt.me/content/blog/2026-04-30-april-2026-recap/2026-04-30-april-2026-recap.mdx
+++ b/www.chrisvogt.me/content/blog/2026-04-30-april-2026-recap/2026-04-30-april-2026-recap.mdx
@@ -1,0 +1,106 @@
+---
+title: 'April 2026 Recap'
+slug: april-2026
+category: personal
+banner: https://res.cloudinary.com/chrisvogt/image/upload/f_auto/v1770093154/chrisvogt-me/thumbnails/jan-2026-recap.jpg
+thumbnails:
+  - https://res.cloudinary.com/chrisvogt/image/upload/f_auto/v1770085939/chrisvogt-me/galleries/now-jan-2026/20260102-IMG_2393.jpg
+  - https://res.cloudinary.com/chrisvogt/image/upload/f_auto/v1770085941/chrisvogt-me/galleries/now-jan-2026/20260115-IMG_2615.jpg
+  - https://res.cloudinary.com/chrisvogt/image/upload/f_auto/v1770085921/chrisvogt-me/galleries/now-jan-2026/20260124-IMG_2871.jpg
+  - https://res.cloudinary.com/chrisvogt/image/upload/f_auto/v1770085924/chrisvogt-me/galleries/now-jan-2026/20260124-IMG_2913.jpg
+date: '2026-05-01T20:00:00.000Z'
+description: >
+  A personal recap of April 2026: Easter and Hunky Jesus at Dolores Park and the Castro, Gayme Show at the reopened Castro Theatre, flying to Los Angeles, the Grand Prix in Long Beach, the Battleship IOWA Museum, Virgin Voyages' Brilliant Lady to the Mexican Riviera, and plant updates back home.
+excerpt: >
+  April 2026 in photos — Hunky Jesus at Dolores and The Mix, Gayme Show at the Castro Theatre, L.A. and Long Beach, Brilliant Lady, and home garden notes.
+keywords:
+  [
+    april 2026,
+    personal blog,
+    monthly recap,
+    chris vogt,
+    san francisco,
+    hunky jesus,
+    the mix,
+    castro district,
+    castro theatre,
+    gayme show,
+    matt rogers,
+    dave mizzoni,
+    los angeles,
+    long beach grand prix,
+    battleship iowa,
+    virgin voyages,
+    brilliant lady,
+    mexican riviera,
+    cruise,
+    plants,
+    travel
+  ]
+---
+
+import { PhotoGallery } from '../../../components/PhotoGallery'
+import {
+  hunkyJesus,
+  hunkyJesusCastroMix,
+  gaymeShowCastroTheater,
+  flyingToLax,
+  grandPrixLongBeach,
+  battleshipIowa,
+  cruiseBrilliantLady,
+  plantUpdates
+} from './photos'
+
+April stacked a lot into a few weeks: a classic San Francisco spring weekend, a hop down to Southern California for racing and history, then straight onto Brilliant Lady for a Mexican Riviera sailing. Below is a photo-first recap of the highlights; a longer post journaling the cruise itself is coming soon.
+
+## ✝️ Hunky Jesus — Part 1, Dolores Park
+
+If you do not spend April in San Francisco, _Hunky Jesus_ sounds made up. The [Sisters of Perpetual Indulgence](https://www.thesisters.org/)—a queer order known here for decades of AIDS-era activism, fundraising, and grants to smaller nonprofits—host [Easter in the Park](https://www.thesisters.org/easter) each Easter Sunday on the north end of Mission Dolores Park: a free, donation-supported street fair and variety show. _Hunky Jesus_ is one of three long-running contests (with Foxy Mary and Easter Bonnet) where contestants turn up in campy, satirical Jesuses (the name is the joke), finalists are screened backstage, and the crowd more or less cheers and laughs someone into a winner.
+
+These photos are from Easter Sunday, April 5. This year's theme was "Love Thy Neighbor," and the Sisters posted a run-of-show with Hunky Jesus on the main stage around 2:55 in the afternoon (after Easter Bonnet and Foxy Mary). The city does not publish a headcount; in fundraising copy the Sisters describe underwriting a production on the order of a ten-thousand-person block party, and on a sunny Easter the north lawn still feels bigger than that figure once you count everyone spilling past the blankets. The crown went to Renewable Energy Jesus—complete with a full-size windmill strapped to his back—which felt very on-theme for a hillside full of people celebrating spring in the city this April.
+
+Blankets on the slope, DJs and picnics, and this mix of street theater and neighborhood ritual—San Francisco spring at full volume.
+
+<PhotoGallery key='hunky-jesus-dolores' photos={hunkyJesus} />
+
+## ✝️ Hunky Jesus — Part 2, Walking to The Mix
+
+After Dolores Park we drifted toward the Castro and The Mix — sidewalk energy, patio sun, and someone with a bubble gun turning the whole patio into a soap-bubble snow globe.
+
+<PhotoGallery key='hunky-jesus-castro-mix' photos={hunkyJesusCastroMix} />
+
+## 🎭 Gayme Show! at the Castro Theatre
+
+A few nights later we caught [Gayme Show! with Matt Rogers and Dave Mizzoni](https://thecastro.com/events/gayme-show-260408) at the [Castro Theatre](https://thecastro.com/) — my first time back since the renovation and reopening. The show is a live game-show chaos engine: they pulled random audience members on stage and ran the men against the women to crown a Queen of the Castro. Loud, silly, and a lot of fun.
+
+<PhotoGallery key='gayme-show-castro-theater' photos={gaymeShowCastroTheater} />
+
+## ✈️ Flying to LAX
+
+I flew Delta down to Los Angeles — clear air over the west side of San Francisco, then a hazy golden-hour sweep over the city as we came in toward the airport.
+
+<PhotoGallery key='flying-to-lax' photos={flyingToLax} />
+
+## 🏎️ Grand Prix in Long Beach
+
+My friend Mateo scored a couple of extra tickets and brought us along to the Acura Grand Prix of Long Beach festival — downtown streets as a circuit, vendor halls full of cars, and energy you can feel in your ribs. I didn't see much of the on-track action, but I _heard_ all of it; next time I'm packing earplugs and I suggest you do too if you're sound-sensitive.
+
+<PhotoGallery key='grand-prix-long-beach' photos={grandPrixLongBeach} />
+
+## ⚓ Exploring Battleship IOWA Museum
+
+Before embarkation we had a few hours in San Pedro, so we toured Battleship IOWA — a retired museum ship that still reads like a small steel city. We spent about an hour winding through the main deck, enlisted berthing, the captain's quarters, the navigating bridge forward, and the upper levels for views over the harbor. It was a slow, tactile way to pass the time before heading to the cruise terminal.
+
+<PhotoGallery key='battleship-iowa' photos={battleshipIowa} />
+
+## 🚢 LAX to Mexican Riviera Cruise on Brilliant Lady
+
+From Los Angeles we sailed Brilliant Lady on a Virgin Voyages Mexican Riviera itinerary. This recap keeps the cruise section intentionally small — mostly friends and a few favorite frames. Ports, sea days, food, and a bigger gallery will sit in a dedicated post journaling the whole sailing; the full cruise journal is coming soon.
+
+<PhotoGallery key='brilliant-lady-cruise' photos={cruiseBrilliantLady} />
+
+## 🪴 Back Home — Plant Updates
+
+Back home in San Francisco by the end of the month, the indoor setup was doing what it does best: herbs and flowers under the AeroGarden lights, with a salt lamp warming the corner of the counter.
+
+<PhotoGallery key='plant-updates' photos={plantUpdates} />

--- a/www.chrisvogt.me/content/blog/2026-04-30-april-2026-recap/photos.js
+++ b/www.chrisvogt.me/content/blog/2026-04-30-april-2026-recap/photos.js
@@ -3,31 +3,31 @@
 export const hunkyJesus = [
   {
     src: 'https://res.cloudinary.com/chrisvogt/image/upload/f_auto/v1777694460/chrisvogt-me/galleries/now-april-2026/20260405-IMG_3947.jpg',
-    title: 'Easter Sunday in Mission Dolores Park',
+    title: 'Easter Sunday, north bowl — Mission Dolores Park',
     width: 3,
     height: 4
   },
   {
     src: 'https://res.cloudinary.com/chrisvogt/image/upload/f_auto/v1777694462/chrisvogt-me/galleries/now-april-2026/20260405-IMG_3959.jpg',
-    title: 'Hunky Jesus contest — Cheez-It cross and crowd on the hill',
+    title: 'Hunky Jesus: Cheez-It cross, crowd on the slope',
     width: 3,
     height: 4
   },
   {
     src: 'https://res.cloudinary.com/chrisvogt/image/upload/f_auto/v1777694461/chrisvogt-me/galleries/now-april-2026/20260405-IMG_3963.jpg',
-    title: 'Mission High School tower above the Easter crowd',
+    title: 'Mission High tower over the Easter crowd',
     width: 3,
     height: 4
   },
   {
     src: 'https://res.cloudinary.com/chrisvogt/image/upload/f_auto/v1777694478/chrisvogt-me/galleries/now-april-2026/20260405-IMG_3974.jpg',
-    title: 'Dolores Park lawn, Mission High, and downtown skyline',
+    title: 'Dolores lawn, Mission High, downtown skyline',
     width: 4,
     height: 3
   },
   {
     src: 'https://res.cloudinary.com/chrisvogt/image/upload/f_auto/v1777694460/chrisvogt-me/galleries/now-april-2026/20260405-IMG_3980.jpg',
-    title: 'Balloon Hunky Jesus and the Sisters of Perpetual Indulgence booth',
+    title: 'Balloon Hunky Jesus at the Sisters’ booth',
     width: 3,
     height: 4
   }
@@ -36,25 +36,25 @@ export const hunkyJesus = [
 export const hunkyJesusCastroMix = [
   {
     src: 'https://res.cloudinary.com/chrisvogt/image/upload/f_auto/v1777694462/chrisvogt-me/galleries/now-april-2026/20260405-IMG_3987.jpg',
-    title: 'Walking through the Castro toward The Mix',
+    title: 'Castro sidewalk, walking toward The Mix',
     width: 3,
     height: 4
   },
   {
     src: 'https://res.cloudinary.com/chrisvogt/image/upload/f_auto/v1777694462/chrisvogt-me/galleries/now-april-2026/20260405-IMG_3989.jpg',
-    title: 'Sunny patio afternoon near The Mix',
+    title: 'Patio sun, drinks, afternoon near The Mix',
     width: 3,
     height: 4
   },
   {
     src: 'https://res.cloudinary.com/chrisvogt/image/upload/f_auto/v1777694463/chrisvogt-me/galleries/now-april-2026/20260405-IMG_4009.jpg',
-    title: 'Bubble gun and patio energy at The Mix',
+    title: 'Bubble gun: the patio goes monochrome with soap',
     width: 3,
     height: 4
   },
   {
     src: 'https://res.cloudinary.com/chrisvogt/image/upload/f_auto/v1777694464/chrisvogt-me/galleries/now-april-2026/20260405-IMG_4010.jpg',
-    title: 'Bubbles, drinks, and crowd shots at The Mix',
+    title: 'Bubbles, glasses, bodies — The Mix in full cry',
     width: 3,
     height: 4
   }
@@ -63,7 +63,7 @@ export const hunkyJesusCastroMix = [
 export const gaymeShowCastroTheater = [
   {
     src: 'https://res.cloudinary.com/chrisvogt/image/upload/f_auto/v1777694464/chrisvogt-me/galleries/now-april-2026/20260408-IMG_4130.jpg',
-    title: 'GAYME SHOW! on stage at the Castro Theatre',
+    title: 'GAYME SHOW! — lights and chaos, Castro Theatre',
     width: 4,
     height: 3
   }
@@ -72,19 +72,19 @@ export const gaymeShowCastroTheater = [
 export const flyingToLax = [
   {
     src: 'https://res.cloudinary.com/chrisvogt/image/upload/f_auto/v1777694465/chrisvogt-me/galleries/now-april-2026/20260415-IMG_4231.jpg',
-    title: 'Leaving San Francisco — Ocean Beach, Lake Merced, and the Golden Gate in the distance',
+    title: 'Climb-out: Ocean Beach, Lake Merced, Golden Gate faint astern',
     width: 3,
     height: 4
   },
   {
     src: 'https://res.cloudinary.com/chrisvogt/image/upload/f_auto/v1777694465/chrisvogt-me/galleries/now-april-2026/20260415-IMG_4233.jpg',
-    title: 'Western SF grid and the Pacific coast on climb-out, headed south',
+    title: 'Western SF grid and Pacific coast, southbound',
     width: 4,
     height: 3
   },
   {
     src: 'https://res.cloudinary.com/chrisvogt/image/upload/f_auto/v1777694465/chrisvogt-me/galleries/now-april-2026/20260415-IMG_4243.jpg',
-    title: 'Golden-hour approach toward L.A. — Exposition Park, Coliseum, and BMO Stadium from the air',
+    title: 'Golden-hour approach: Exposition Park, Coliseum, BMO Stadium',
     width: 3,
     height: 4
   }
@@ -93,25 +93,25 @@ export const flyingToLax = [
 export const grandPrixLongBeach = [
   {
     src: 'https://res.cloudinary.com/chrisvogt/image/upload/f_auto/v1777694486/chrisvogt-me/galleries/now-april-2026/20260417-IMG_4281.jpg',
-    title: 'First-generation Acura NSX on display at the Grand Prix festival',
+    title: 'First-generation Acura NSX, Grand Prix festival floor',
     width: 4,
     height: 3
   },
   {
     src: 'https://res.cloudinary.com/chrisvogt/image/upload/f_auto/v1777694466/chrisvogt-me/galleries/now-april-2026/20260417-IMG_4282.jpg',
-    title: 'Le Mans prototype — TruSpeed / LIQUI MOLY livery in the exhibition hall',
+    title: 'Le Mans prototype — TruSpeed / LIQUI MOLY livery',
     width: 3,
     height: 4
   },
   {
     src: 'https://res.cloudinary.com/chrisvogt/image/upload/f_auto/v1777694467/chrisvogt-me/galleries/now-april-2026/20260417-IMG_4284.jpg',
-    title: 'Porsche 911 GT3 R in the RIGID booth',
+    title: 'Porsche 911 GT3 R in the RIGID display',
     width: 3,
     height: 4
   },
   {
     src: 'https://res.cloudinary.com/chrisvogt/image/upload/f_auto/v1777694467/chrisvogt-me/galleries/now-april-2026/20260417-IMG_4285.jpg',
-    title: '1987–88 IMSA GTO "Skoal Bandit" Camaro and vintage race row',
+    title: '1987–88 IMSA GTO “Skoal Bandit” Camaro, vintage row',
     width: 3,
     height: 4
   }
@@ -120,7 +120,7 @@ export const grandPrixLongBeach = [
 export const battleshipIowa = [
   {
     src: 'https://res.cloudinary.com/chrisvogt/image/upload/f_auto/v1777694468/chrisvogt-me/galleries/now-april-2026/20260418-IMG_4309.jpg',
-    title: 'Naval artillery shell on display — teak decks of USS Iowa',
+    title: 'Naval shell on display — teak decks, USS Iowa',
     width: 3,
     height: 4
   },
@@ -132,7 +132,7 @@ export const battleshipIowa = [
   },
   {
     src: 'https://res.cloudinary.com/chrisvogt/image/upload/f_auto/v1777694468/chrisvogt-me/galleries/now-april-2026/20260418-IMG_4316.jpg',
-    title: 'Bridge optics toward the harbor',
+    title: 'Bridge optics: harbor geometry through glass',
     width: 4,
     height: 3
   }
@@ -141,19 +141,19 @@ export const battleshipIowa = [
 export const cruiseBrilliantLady = [
   {
     src: 'https://res.cloudinary.com/chrisvogt/image/upload/f_auto/v1777694467/chrisvogt-me/galleries/now-april-2026/20260418-IMG_0991.jpg',
-    title: 'Friends on deck in San Pedro — Vincent Thomas Bridge in the background',
+    title: 'Our San Francisco crew on deck, San Pedro — Vincent Thomas Bridge astern',
     width: 4,
     height: 3
   },
   {
     src: 'https://res.cloudinary.com/chrisvogt/image/upload/f_auto/v1777694469/chrisvogt-me/galleries/now-april-2026/20260418-IMG_4330.jpg',
-    title: 'Sea Terrace cabin — hammock on the balcony before sailaway',
+    title: 'Sea Terrace: balcony hammock before sailaway',
     width: 3,
     height: 4
   },
   {
     src: 'https://res.cloudinary.com/chrisvogt/image/upload/f_auto/v1777694469/chrisvogt-me/galleries/now-april-2026/20260418-IMG_4344.jpg',
-    title: 'Pacific sunset with light rays through the cloud deck',
+    title: 'Pacific sunset — crepuscular rays through broken cloud',
     width: 3,
     height: 4
   },
@@ -165,13 +165,13 @@ export const cruiseBrilliantLady = [
   },
   {
     src: 'https://res.cloudinary.com/chrisvogt/image/upload/f_auto/v1777694471/chrisvogt-me/galleries/now-april-2026/20260419-IMG_4385.jpg',
-    title: 'Ensenada waterfront — landmark sign with the ship in port',
+    title: 'Ensenada waterfront — landmark sign, ship alongside',
     width: 4,
     height: 3
   },
   {
     src: 'https://res.cloudinary.com/chrisvogt/image/upload/f_auto/v1777694484/chrisvogt-me/galleries/now-april-2026/20260425-IMG_4930.jpg',
-    title: "Dinner with friends under the ship's bulb ceiling",
+    title: 'Dinner with friends under the ship’s bulb ceiling',
     width: 4,
     height: 3
   }
@@ -180,7 +180,7 @@ export const cruiseBrilliantLady = [
 export const plantUpdates = [
   {
     src: 'https://res.cloudinary.com/chrisvogt/image/upload/f_auto/v1777694485/chrisvogt-me/galleries/now-april-2026/20260426-IMG_4984.jpg',
-    title: 'Countertop AeroGardens, herbs, and blooms under the grow lights',
+    title: 'AeroGardens on the counter — herbs, blooms, grow lights',
     width: 4,
     height: 3
   }

--- a/www.chrisvogt.me/content/blog/2026-04-30-april-2026-recap/photos.js
+++ b/www.chrisvogt.me/content/blog/2026-04-30-april-2026-recap/photos.js
@@ -36,13 +36,13 @@ export const hunkyJesus = [
 export const hunkyJesusCastroMix = [
   {
     src: 'https://res.cloudinary.com/chrisvogt/image/upload/f_auto/v1777694462/chrisvogt-me/galleries/now-april-2026/20260405-IMG_3987.jpg',
-    title: 'Castro sidewalk, walking toward The Mix',
+    title: 'Castro sidewalk toward The Mix — Augustin, Allen, and Nick',
     width: 3,
     height: 4
   },
   {
     src: 'https://res.cloudinary.com/chrisvogt/image/upload/f_auto/v1777694462/chrisvogt-me/galleries/now-april-2026/20260405-IMG_3989.jpg',
-    title: 'Patio sun, drinks, afternoon near The Mix',
+    title: 'Patio sun, drinks, afternoon near The Mix — Nick cooling off under a fan',
     width: 3,
     height: 4
   },
@@ -120,19 +120,19 @@ export const grandPrixLongBeach = [
 export const battleshipIowa = [
   {
     src: 'https://res.cloudinary.com/chrisvogt/image/upload/f_auto/v1777694468/chrisvogt-me/galleries/now-april-2026/20260418-IMG_4309.jpg',
-    title: 'Naval shell on display — teak decks, USS Iowa',
+    title: 'Nick hugging a naval shell on display — teak decks, USS Iowa',
     width: 3,
     height: 4
   },
   {
     src: 'https://res.cloudinary.com/chrisvogt/image/upload/f_auto/v1777694468/chrisvogt-me/galleries/now-april-2026/20260418-IMG_4314.jpg',
-    title: 'Ship-mounted binoculars on the superstructure',
+    title: 'Mateo at the ship-mounted binoculars on the superstructure',
     width: 3,
     height: 4
   },
   {
     src: 'https://res.cloudinary.com/chrisvogt/image/upload/f_auto/v1777694468/chrisvogt-me/galleries/now-april-2026/20260418-IMG_4316.jpg',
-    title: 'Bridge optics: harbor geometry through glass',
+    title: 'Nick at the bridge optics — harbor geometry through glass',
     width: 4,
     height: 3
   }

--- a/www.chrisvogt.me/content/blog/2026-04-30-april-2026-recap/photos.js
+++ b/www.chrisvogt.me/content/blog/2026-04-30-april-2026-recap/photos.js
@@ -1,0 +1,187 @@
+// Photo arrays for April 2026 recap
+
+export const hunkyJesus = [
+  {
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/f_auto/v1777694460/chrisvogt-me/galleries/now-april-2026/20260405-IMG_3947.jpg',
+    title: 'Easter Sunday in Mission Dolores Park',
+    width: 3,
+    height: 4
+  },
+  {
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/f_auto/v1777694462/chrisvogt-me/galleries/now-april-2026/20260405-IMG_3959.jpg',
+    title: 'Hunky Jesus contest — Cheez-It cross and crowd on the hill',
+    width: 3,
+    height: 4
+  },
+  {
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/f_auto/v1777694461/chrisvogt-me/galleries/now-april-2026/20260405-IMG_3963.jpg',
+    title: 'Mission High School tower above the Easter crowd',
+    width: 3,
+    height: 4
+  },
+  {
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/f_auto/v1777694478/chrisvogt-me/galleries/now-april-2026/20260405-IMG_3974.jpg',
+    title: 'Dolores Park lawn, Mission High, and downtown skyline',
+    width: 4,
+    height: 3
+  },
+  {
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/f_auto/v1777694460/chrisvogt-me/galleries/now-april-2026/20260405-IMG_3980.jpg',
+    title: 'Balloon Hunky Jesus and the Sisters of Perpetual Indulgence booth',
+    width: 3,
+    height: 4
+  }
+]
+
+export const hunkyJesusCastroMix = [
+  {
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/f_auto/v1777694462/chrisvogt-me/galleries/now-april-2026/20260405-IMG_3987.jpg',
+    title: 'Walking through the Castro toward The Mix',
+    width: 3,
+    height: 4
+  },
+  {
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/f_auto/v1777694462/chrisvogt-me/galleries/now-april-2026/20260405-IMG_3989.jpg',
+    title: 'Sunny patio afternoon near The Mix',
+    width: 3,
+    height: 4
+  },
+  {
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/f_auto/v1777694463/chrisvogt-me/galleries/now-april-2026/20260405-IMG_4009.jpg',
+    title: 'Bubble gun and patio energy at The Mix',
+    width: 3,
+    height: 4
+  },
+  {
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/f_auto/v1777694464/chrisvogt-me/galleries/now-april-2026/20260405-IMG_4010.jpg',
+    title: 'Bubbles, drinks, and crowd shots at The Mix',
+    width: 3,
+    height: 4
+  }
+]
+
+export const gaymeShowCastroTheater = [
+  {
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/f_auto/v1777694464/chrisvogt-me/galleries/now-april-2026/20260408-IMG_4130.jpg',
+    title: 'GAYME SHOW! on stage at the Castro Theatre',
+    width: 4,
+    height: 3
+  }
+]
+
+export const flyingToLax = [
+  {
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/f_auto/v1777694465/chrisvogt-me/galleries/now-april-2026/20260415-IMG_4231.jpg',
+    title: 'Leaving San Francisco — Ocean Beach, Lake Merced, and the Golden Gate in the distance',
+    width: 3,
+    height: 4
+  },
+  {
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/f_auto/v1777694465/chrisvogt-me/galleries/now-april-2026/20260415-IMG_4233.jpg',
+    title: 'Western SF grid and the Pacific coast on climb-out, headed south',
+    width: 4,
+    height: 3
+  },
+  {
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/f_auto/v1777694465/chrisvogt-me/galleries/now-april-2026/20260415-IMG_4243.jpg',
+    title: 'Golden-hour approach toward L.A. — Exposition Park, Coliseum, and BMO Stadium from the air',
+    width: 3,
+    height: 4
+  }
+]
+
+export const grandPrixLongBeach = [
+  {
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/f_auto/v1777694486/chrisvogt-me/galleries/now-april-2026/20260417-IMG_4281.jpg',
+    title: 'First-generation Acura NSX on display at the Grand Prix festival',
+    width: 4,
+    height: 3
+  },
+  {
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/f_auto/v1777694466/chrisvogt-me/galleries/now-april-2026/20260417-IMG_4282.jpg',
+    title: 'Le Mans prototype — TruSpeed / LIQUI MOLY livery in the exhibition hall',
+    width: 3,
+    height: 4
+  },
+  {
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/f_auto/v1777694467/chrisvogt-me/galleries/now-april-2026/20260417-IMG_4284.jpg',
+    title: 'Porsche 911 GT3 R in the RIGID booth',
+    width: 3,
+    height: 4
+  },
+  {
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/f_auto/v1777694467/chrisvogt-me/galleries/now-april-2026/20260417-IMG_4285.jpg',
+    title: '1987–88 IMSA GTO "Skoal Bandit" Camaro and vintage race row',
+    width: 3,
+    height: 4
+  }
+]
+
+export const battleshipIowa = [
+  {
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/f_auto/v1777694468/chrisvogt-me/galleries/now-april-2026/20260418-IMG_4309.jpg',
+    title: 'Naval artillery shell on display — teak decks of USS Iowa',
+    width: 3,
+    height: 4
+  },
+  {
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/f_auto/v1777694468/chrisvogt-me/galleries/now-april-2026/20260418-IMG_4314.jpg',
+    title: 'Ship-mounted binoculars on the superstructure',
+    width: 3,
+    height: 4
+  },
+  {
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/f_auto/v1777694468/chrisvogt-me/galleries/now-april-2026/20260418-IMG_4316.jpg',
+    title: 'Bridge optics toward the harbor',
+    width: 4,
+    height: 3
+  }
+]
+
+export const cruiseBrilliantLady = [
+  {
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/f_auto/v1777694467/chrisvogt-me/galleries/now-april-2026/20260418-IMG_0991.jpg',
+    title: 'Friends on deck in San Pedro — Vincent Thomas Bridge in the background',
+    width: 4,
+    height: 3
+  },
+  {
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/f_auto/v1777694469/chrisvogt-me/galleries/now-april-2026/20260418-IMG_4330.jpg',
+    title: 'Sea Terrace cabin — hammock on the balcony before sailaway',
+    width: 3,
+    height: 4
+  },
+  {
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/f_auto/v1777694469/chrisvogt-me/galleries/now-april-2026/20260418-IMG_4344.jpg',
+    title: 'Pacific sunset with light rays through the cloud deck',
+    width: 3,
+    height: 4
+  },
+  {
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/f_auto/v1777694460/chrisvogt-me/galleries/now-april-2026/20260422-IMG_4604.jpg',
+    title: 'Aboard Brilliant Lady — April 22',
+    width: 3,
+    height: 4
+  },
+  {
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/f_auto/v1777694471/chrisvogt-me/galleries/now-april-2026/20260419-IMG_4385.jpg',
+    title: 'Ensenada waterfront — landmark sign with the ship in port',
+    width: 4,
+    height: 3
+  },
+  {
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/f_auto/v1777694484/chrisvogt-me/galleries/now-april-2026/20260425-IMG_4930.jpg',
+    title: "Dinner with friends under the ship's bulb ceiling",
+    width: 4,
+    height: 3
+  }
+]
+
+export const plantUpdates = [
+  {
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/f_auto/v1777694485/chrisvogt-me/galleries/now-april-2026/20260426-IMG_4984.jpg',
+    title: 'Countertop AeroGardens, herbs, and blooms under the grow lights',
+    width: 4,
+    height: 3
+  }
+]


### PR DESCRIPTION
## Summary

This adds the **April 2026** monthly recap as MDX with a `PhotoGallery`-backed `photos.js`, updates the **Now** page to point at it (and adjusts the Jest spec), and removes a short stale note from the January 2026 recap.

## Highlights

- **Content**: Photo-first recap (Hunky Jesus, Castro / The Mix, Gayme Show, LAX approach, Long Beach GP, USS Iowa, Brilliant Lady / Atlantis charter, home plants) with narrative copy, frontmatter **banner/thumbnails** from April assets so recent-post cards are not January placeholders.
- **Captions**: Named friends where relevant; Grand Prix / cruise / earthquake / Atlantis context as discussed.
- **Housekeeping**: `theme/src/pages/now.js` + `now.spec.js` aligned to the new recap slug.

## Commits

- Add April 2026 recap, point `/now` to it, and drop stale January note
- blog: April 2026 recap copy, gallery captions, and card art
- blog: April recap captions and excerpt trim


Made with [Cursor](https://cursor.com)