### PR TITLE
blog(voice): voice charter + Wave 1 recap rewrites

### DIFF
--- a/.cursor/rules/www-content-voice.mdc
+++ b/.cursor/rules/www-content-voice.mdc
@@ -1,0 +1,44 @@
+---
+description: Editorial voice for www.chrisvogt.me blog and music content
+globs: www.chrisvogt.me/content/**/*.mdx
+alwaysApply: false
+---
+
+# Content Voice for www.chrisvogt.me
+
+Canonical example: `www.chrisvogt.me/content/blog/2026-04-30-april-2026-recap/` (MDX + `photos.js`).
+
+## Two Tiers
+
+| Tier | Categories | Approach |
+|------|-----------|----------|
+| **Narrative** | `personal` recaps, `travel`, music posts with story-led intros | Full voice: scene-first, rhythm, texture. |
+| **Utility-first** | `meta`, incident reports, cost breakdowns | Lead with clarity. Apply texture in short opening/closing only — never inside procedural steps, quoted correspondence, or tables. |
+
+## Narrative Primitives
+
+- **Scene-first openers**: Start with time, place, or social frame. Never "This is my Nth recap" or "In this post I will..."
+- **No meta-commentary in body**: Remove lines that explain the writing format ("a monthly ritual I started in June 2025", "what's a now page?", "Thanks for reading ✌️").
+- **Chronological spine**: Each section opens with a concrete beat before going topical.
+- **Texture without bloat**: One well-chosen metaphor or institutional detail per paragraph max. Facts (dates, venue names, ship names, book titles) stay accurate.
+- **Clean closings**: Omit "Feel free to share your thoughts!", "Happy listening! 🎹", generic sign-offs.
+
+## Music Post Openings
+
+Do not open with `Hey everyone,`, `Hi, 👋`, or `Hi everyone,`. Open with the song, session, or moment directly.
+
+## Caption Discipline (`photos.js`)
+
+- Short, magazine-style: subject + location. No full sentences.
+- Name people when the frame features them: `Nick at the bridge optics — harbor geometry through glass`.
+- No "Here is a photo of..." constructions.
+
+## Frontmatter Rules
+
+- `description`: SEO-readable — literary but **literal** (include places, events, key names). 1–2 sentences.
+- `excerpt`: Compressed phrase or list — not a copy of `description`. No "A roundup of..." boilerplate.
+- `keywords`: Keep factual/topical terms; drop abstract filler.
+
+## Never Change
+
+`slug`, `banner`, `thumbnails`, image URLs, component imports, MDX syntax, internal/external links, quoted correspondence, structured tables, YouTube/SoundCloud embed IDs.

--- a/www.chrisvogt.me/content/blog/2025-06-30-june-2025-recap/2025-06-30-june-2025-recap.mdx
+++ b/www.chrisvogt.me/content/blog/2025-06-30-june-2025-recap/2025-06-30-june-2025-recap.mdx
@@ -10,32 +10,37 @@ thumbnails:
   - https://res.cloudinary.com/chrisvogt/image/upload/f_auto/v1751355485/chrisvogt-me/galleries/now-june-2025/mission-mural.avif
 date: '2025-06-30T14:00:00.000Z'
 description: >
-  A personal recap of what I've been working on, exploring, and thinking about in June 2025.
+  June 2025: shipping overdue side projects (teachersalary.info, Steam widget, CI migration), six Pride parties, a first home-brewed Cascade IPA bottled just in time, vinyl collecting, indoor gardening, and a July trip to Puerto Vallarta on the horizon.
 excerpt: >
-  A roundup of June 2025—projects, travel, thoughts, and the little things in between.
-keywords: [june 2025, personal blog, monthly recap, chris vogt, software projects, music practice, travel highlights]
+  June 2025 — side projects shipped, Pride in full swing, first batch of beer bottled, vinyl taking over the shelf.
+keywords:
+  [
+    june 2025,
+    personal blog,
+    monthly recap,
+    chris vogt,
+    software projects,
+    music practice,
+    pride,
+    teachersalary.info,
+    steam widget,
+    vinyl,
+    home brewing
+  ]
 ---
 
 import { PhotoGallery } from '../../../components/PhotoGallery'
 import { brewing, favoritePhotos, gardening, pridePhotos, vinylCollection } from './photos'
 
-This is my first _now_ page update — a look back at what I've been up to this month.
-
-## 🎯 June Overview
-
-June has been all about revisiting old projects, leveling up personal hobbies, and making space for community and creativity. I even dusted off a few things I hadn't touched in eight years.
+June arrived with a stack of neglected side projects and no excuse not to address them. teachersalary.info had been drawing a quiet thousand-plus visitors a month—more traffic than this blog—for eight years without a line of updated code. The Steam widget had been staged in a PR for weeks. CircleCI and TravisCI were running parallel pipelines that had diverged enough to count as archaeology. All of it landed in June, which still left room for six Pride parties, a first batch of home-brewed Cascade IPA bottled just in time to hand out at one of them, and the beginning of a vinyl habit I owe entirely to my friends.
 
 ## 🤖 AI at Work
 
-AI continues to be front and center at work. All of my June projects tied into logged-in customer navigation and building AI-powered experiences. I'm lucky to be at a company that's embracing AI tools for developers and integrating them meaningfully into products.
-
-## 💻 Development Tools
-
-At home (and now at work too), I've switched from VS Code to [Cursor](https://www.cursor.com/), and have been using it to improve test coverage on this site and its API. I'm using it to polish and fill my content too, but have reservations and that may change in the near future.
+AI is front and center at work: all of my June projects tied into logged-in customer navigation and building AI-powered experiences. At home I've switched from VS Code to [Cursor](https://www.cursor.com/) and have been using it to improve test coverage on this site and its API.
 
 ## 🌴 Upcoming Travel
 
-And — I'm prepping for a short July getaway! I'll be spending five days in Puerto Vallarta, Mexico 🌴
+July brings a short trip to Puerto Vallarta, Mexico.
 
 ---
 
@@ -165,9 +170,3 @@ Here are a few of my favorite shots from June.
 <PhotoGallery photos={favoritePhotos} />
 
 ---
-
-## 💭 Final Thoughts
-
-This is my first time using the _now page_ format ([what's a now page?](https://nownownow.com/about)), and I really like it. Once I publish my July update, I'll archive this one and keep the flow going.
-
-Thanks for reading. ✌️

--- a/www.chrisvogt.me/content/blog/2025-07-31-july-2025-recap/2025-07-31-july-2025-recap.mdx
+++ b/www.chrisvogt.me/content/blog/2025-07-31-july-2025-recap/2025-07-31-july-2025-recap.mdx
@@ -10,16 +10,28 @@ thumbnails:
   - https://res.cloudinary.com/chrisvogt/image/upload/f_auto/v1754281184/chrisvogt-me/galleries/now-july-2025/IMG_5068.jpg
 date: '2025-08-03T20:00:00.000Z'
 description: >
-  A personal recap of what I've been working on, exploring, and thinking about in July 2025.
+  July 2025: five days in Puerto Vallarta with friends at an LGBTQ resort in Amapas, website updates with a Discogs widget and Steam UI refresh, 37 LPs and a new Audio-Technica turntable, and finishing two books—Flowers for Algernon and Finding My Humanity.
 excerpt: >
-  A roundup of July 2025. Projects, travel, thoughts, and things in between.
-keywords: [july 2025, personal blog, monthly recap, chris vogt, software projects, music practice, travel highlights]
+  July 2025 — Puerto Vallarta with Francis, a record player and 37 LPs, and finishing two books.
+keywords:
+  [
+    july 2025,
+    personal blog,
+    monthly recap,
+    chris vogt,
+    puerto vallarta,
+    vinyl,
+    discogs,
+    steam,
+    software projects,
+    travel
+  ]
 ---
 
 import { PhotoGallery } from '../../../components/PhotoGallery'
 import { pvrFlight, pvrHotel, pvrZonaRomantica, vinylCollection } from './photos'
 
-This is my second monthly recap, a monthly writing ritual I started June 2025 where I recap the month work in a topic-organized journal entry. When these articles are published, they can be accessed on my [Now](/now) page. When the next recap publishes, I move the previous post into the blog to archive it.
+July compressed itself around one lateral move south. Francis—met in 2021 when our Celebrity cruise docked in Curaçao—had been planning his first Puerto Vallarta trip and sent an invitation; the 4th of July holiday handed me the extra days I needed. I landed on a Wednesday, settled into a resort in Amapas just south of the Zona Romántica, and found a former coworker had turned up in town as well—San Francisco has a way of following you. Back home, the vinyl habit crossed 37 LPs and finally justified a turntable.
 
 ## ✨ Updates to My Website
 
@@ -33,9 +45,7 @@ Continuing with the theme of last month, AI is still a big focus at work. Both a
 
 ## 🌴 Puerto Vallarta, Mexico
 
-In 2021 I met Francis while docked in Curaçao on a Celebrity Cruise ship. We've kept in touch over the years and met up last year in NYC. A couple months before July he invited me to join him and a friend for their first visit to Puerto Vallarta.
-
-I already had 2 days off work for the 4th of July holiday, and learned a friend and former coworker was also going to be in town with his partner, and so I took an extra day off work and flew down for a Wednesday-Sunday trip.
+I met Francis in 2021, docked in Curaçao on a Celebrity cruise ship. We'd kept in touch and a couple of months before July he extended the invitation. I already had two days off for the 4th of July holiday and took one more—a Wednesday-to-Sunday run.
 
 My United flight from SFO to PVR was fast—only 3 hours, 45 minutes. I recommend sitting on the left side of the plane for the best views, because you'll face inland and see the mountains.
 
@@ -45,7 +55,7 @@ I stayed at an LGBTQ resort in Amapas, a neighborhood (colonia) just south of th
 
 <PhotoGallery photos={pvrHotel} />
 
-Here are a few of the photos I took around the area while I was there.
+A few frames from around the neighborhood.
 
 <PhotoGallery photos={pvrZonaRomantica} />
 

--- a/www.chrisvogt.me/content/blog/2025-09-30-september-2025-recap/2025-09-30-september-2025-recap.mdx
+++ b/www.chrisvogt.me/content/blog/2025-09-30-september-2025-recap/2025-09-30-september-2025-recap.mdx
@@ -10,9 +10,9 @@ thumbnails:
   - https://res.cloudinary.com/chrisvogt/image/upload/v1759727070/chrisvogt-me/galleries/now-sept-2025/IMG_5913-2.jpg
 date: '2025-10-05T20:00:00.000Z'
 description: >
-  A personal recap of what I've been working on, exploring, and thinking about in September 2025.
+  September 2025: Labor Day weekend in Guerneville and Healdsburg wine country, the drive home on Highway 1, San Diego Zoo and seals at La Jolla Cove, vinyl collection reaching 63 LPs, multi-AeroGarden indoor gardening, and a work stretch on AI tools and experimentation platforms.
 excerpt: >
-  A roundup of September 2025. Projects, travel, thoughts, and things in between.
+  September 2025 — Sonoma road trip, seals at La Jolla Cove, vinyl reaches 63 LPs, and cucumber vines on the march.
 keywords:
   [
     september 2025,
@@ -40,7 +40,7 @@ import {
   friendsHighlights
 } from './photos'
 
-This marks my fourth monthly recap, a writing practice I began in June 2025 as a way to reflect on the month's experiences through organized journal entries. These pieces live on my Now page until the next recap arrives, when they migrate to the blog archives.
+September drove north first. Labor Day weekend in Guerneville—the Russian River town that fills up with LGBTQ+ travelers through summer—hit the mid-90s, which put the pool in a different category than a courtesy amenity. From there it was Healdsburg for wine tastings, then Highway 1 back south, then the city for most of the month before a trip down to San Diego at the end. Between those bookends: the vinyl collection crossed 60 LPs, three AeroGardens were running indoors, and work demanded most of the attention everything else didn't.
 
 ## 🚗 Road Trip to Sonoma County
 
@@ -147,7 +147,7 @@ I've become quite absorbed in indoor gardening this month. Three countertop Aero
 
 ## 🦁 San Diego
 
-At month's end, Nick traveled to San Diego for his great aunt's celebration of life. While there, I experienced two firsts: visiting La Jolla Cove to observe the seals on the beach.
+At month's end, Nick traveled to San Diego for his great aunt's celebration of life. Two firsts on that trip: La Jolla Cove, where the seals treat the beach as their living room and the tourists as a mild inconvenience.
 
 <PhotoGallery photos={sanDiego} />
 
@@ -169,7 +169,7 @@ I also visited the San Diego Zoo, observing bears, elephants, and meerkats. We s
 
 ## 👥 Time with Friends
 
-September offered several meaningful moments with friends—exploring new restaurants, attending events, and simply spending time together. These connections and shared experiences continue to feel essential, grounding the month in genuine human interaction.
+September had its share of good tables and better company—new restaurants, a few events, and the kind of unhurried time with friends that makes a busy month feel worth it.
 
 <PhotoGallery photos={friendsHighlights} />
 

--- a/www.chrisvogt.me/content/blog/2025-10-31-october-2025-recap/2025-10-31-october-2025-recap.mdx
+++ b/www.chrisvogt.me/content/blog/2025-10-31-october-2025-recap/2025-10-31-october-2025-recap.mdx
@@ -10,9 +10,9 @@ thumbnails:
   - https://res.cloudinary.com/chrisvogt/image/upload/f_auto/v1762072239/chrisvogt-me/galleries/now-oct-2025/20251031-IMG_0344.jpg
 date: '2025-11-01T20:00:00.000Z'
 description: >
-  A personal recap of October 2025 covering Castro Street Fair, a return trip to Puerto Vallarta, indoor gardening updates, work projects on AI tools and experimentation platforms, and Halloween celebrations in the Castro.
+  October 2025: Castro Street Fair with a friend from Phoenix, a surprise work-holiday return trip to Puerto Vallarta, jalapeños and cherry tomatoes ripening in the AeroGardens, a Halloween Castro Night Market on a Friday night, and AI tools and MAB experiments at work.
 excerpt: >
-  A roundup of October 2025. Festivals, travel, work projects, and Halloween in San Francisco's Castro District.
+  October 2025 — Castro Street Fair, Puerto Vallarta again, AeroGarden updates, and Halloween in the Castro.
 keywords:
   [
     october 2025,
@@ -34,7 +34,7 @@ keywords:
 import { PhotoGallery } from '../../../components/PhotoGallery'
 import { castroStreetFair, indoorGardening, puertoVallarta, halloweenInTheCastro } from './photos'
 
-The warmest months in San Francisco are said to be September and October. It's during these months that the city really comes to life with tourists and warm-weather activities. October 2025 kicked off with people in a festive spirit as businesses and neighborhoods decorated with Halloween and Día de Muertos themes.
+San Francisco's warmest months are September and October—the fog pulls back, the sidewalks fill, and the city's social metabolism picks up. October 2025 opened with that particular combination of golden-hour light and storefronts fully committed to Halloween and Día de Muertos themes, a friend visiting from Phoenix for the Castro Street Fair, and a Thursday/Friday off from work that turned into a return trip to Puerto Vallarta before the month had found its rhythm.
 
 ## 🎪 Castro Street Fair
 
@@ -50,7 +50,7 @@ My indoor AeroGardens are continuing to thrive, with jalapeños and cherry tomat
 
 ## 🌴 Puerto Vallarta
 
-For the effort my org at work put in over the last quarter on new customer-facing AI tools, we were given a Thursday and Friday off at the beginning of October. So, from October 9–12, I flew back down to Puerto Vallarta, which has become my happy escape a few times this year because the flights are cheap and fast. It takes just 3.5 hours to get to PVR from SFO, and when booked in advance, the flights can be as low as $300 round trip — faster than driving to Los Angeles and about the same time it takes to reach Tahoe, Mendocino, or Paso Robles.
+The org got a Thursday and Friday off for shipping new AI tools, and by October 9 I was back in Puerto Vallarta for the third time this year—October 9–12. At 3.5 hours from SFO and $300 round-trip when booked ahead, it has become my default pressure valve: faster than driving to Los Angeles, about the same time as Tahoe or Mendocino, and considerably warmer.
 
 <PhotoGallery key='puerto-vallarta' photos={puertoVallarta} />
 

--- a/www.chrisvogt.me/content/blog/2026-01-31-january-2026-recap/2026-01-31-january-2026-recap.mdx
+++ b/www.chrisvogt.me/content/blog/2026-01-31-january-2026-recap/2026-01-31-january-2026-recap.mdx
@@ -10,9 +10,9 @@ thumbnails:
   - https://res.cloudinary.com/chrisvogt/image/upload/f_auto/v1770085924/chrisvogt-me/galleries/now-jan-2026/20260124-IMG_2913.jpg
 date: '2026-02-01T20:00:00.000Z'
 description: >
-  A personal recap of January 2026 covering New Year celebrations, exploring San Francisco with friends from around the world, a first-time trip to Palm Springs for MLK weekend, and a road trip to Phoenix to visit family and work from the Tempe office.
+  January 2026: New Year in San Francisco with Chinatown, North Beach, and friends from out of town; a first trip to Palm Springs for MLK weekend; then a rented car instead of a return flight and a week working from the GoDaddy Tempe office with family and a horse ranch in Scottsdale.
 excerpt: >
-  A roundup of January 2026. New Year, San Francisco explorations, Palm Springs adventures, and a Phoenix road trip.
+  January 2026 — Chinatown, MLK weekend in Palm Springs, and a desert road trip to Phoenix.
 keywords:
   [
     january 2026,
@@ -45,7 +45,7 @@ import {
   horseRanch
 } from './photos'
 
-Happy new year! January 2026 had me bouncing between San Francisco, Palm Springs, and Phoenix.
+January threaded three cities. San Francisco held the first half of the month—Chinatown, North Beach, friends in from New York and out of town; Palm Springs was a first, over MLK weekend, landing in a small Embraer next to an Emirates A380 and making VillageFest before sundown. Then a rented car instead of a return flight, and a week working from the Tempe office while visiting family and a horse ranch in North Scottsdale.
 
 ## 🌉 San Francisco
 
@@ -104,5 +104,3 @@ We visited Lindi's horse ranch in North Scottsdale. Nick spent most of the time 
 Lindi also showed us her quilting project.
 
 <PhotoGallery key='horse-ranch' photos={horseRanch} />
-
-And that's a brief, photo-heavy recap of my month.


### PR DESCRIPTION
## Summary

- Adds `.cursor/rules/www-content-voice.mdc` scoped to `www.chrisvogt.me/content/**/*.mdx`: Narrative/Utility-first tier table, scene-first primitives, caption discipline, and frontmatter rules. The April 2026 recap is cited as the canonical example.
- Rewrites the five monthly recap posts (**June, July, September, October 2025**, **January 2026**): removes meta-commentary openers ("This is my Nth recap"), replaces them with scene-first paragraphs, updates frontmatter `description`/`excerpt` to be literal and specific, and polishes stilted section transitions.

## Posts changed

| File | Key change |
|------|-----------|
| June 2025 | New scene opener, removed "June Overview" + "Final Thoughts" sections |
| July 2025 | New scene opener, tightened PVR preamble and gallery transition |
| September 2025 | New scene opener, polished San Diego section intro and friends closing |
| October 2025 | Rewrote opener and PVR section, frontmatter refresh |
| January 2026 | Tightened opener, removed trailing "that's a brief recap" line |

## Test plan

- [x] Build site locally and verify all five recap pages render without errors
- [x] Confirm no slug, image URL, or MDX component was altered

Made with [Cursor](https://cursor.com)