### PR TITLE
blog(voice): Wave 2 — Narrative tier applied to travel posts

### DIFF
--- a/www.chrisvogt.me/content/blog/2019-06-27-nyc-world-pride/2019-06-27-nyc-world-pride.mdx
+++ b/www.chrisvogt.me/content/blog/2019-06-27-nyc-world-pride/2019-06-27-nyc-world-pride.mdx
@@ -6,11 +6,8 @@ category: travel
 slug: world-pride-2019
 keywords: [world pride, NYC, street photography, photo gallery, Pride 2019]
 description: >
-  In 2019 I went to New York City for WorldPride 2019. This gallery contains
-  my favorite shots taken while there.
-excerpt: >
-  In 2019 I went to New York City for WorldPride 2019. This gallery contains
-  my favorite shots taken while exploring Manhattan and attending the marches.
+  New York City for Stonewall 50 and WorldPride NYC 2019 — the first WorldPride held in the United States. Street photography from Manhattan, NYC Pride, the Queer Liberation March, and the Dyke March.
+excerpt: Street photography from WorldPride NYC 2019 — Stonewall 50, the Queer Liberation March, and Manhattan in June.
 thumbnails:
   - https://res.cloudinary.com/chrisvogt/image/upload/f_auto/v1573540598/photos/2019-nyc-world-pride/IMG_6622
   - https://res.cloudinary.com/chrisvogt/image/upload/f_auto/v1573540598/photos/2019-nyc-world-pride/IMG_6644
@@ -18,9 +15,7 @@ thumbnails:
   - https://res.cloudinary.com/chrisvogt/image/upload/f_auto/v1573540598/photos/2019-nyc-world-pride/IMG_6658
 ---
 
-This year I was in New York City for Stonewall 50 – WorldPride NYC 2019, which recognized the 50th anniversary of the 1969 Stonewall Riots and was the first WorldPride event held in the United States.
-
-Following are some of my favorite shots from exploring Manhattan, attending NYC Pride 2019, the Queer Liberation March and the Dyke March.
+New York City, June 2019: Stonewall 50 and the first WorldPride ever held in the United States. The city was packed, the marches were enormous, and the energy of that weekend was unlike anything I had seen. Below are my favorite shots from exploring Manhattan, the NYC Pride march, the Queer Liberation March, and the Dyke March.
 
 import { PhotoGallery } from '../../../components/PhotoGallery'
 import { photos } from './photos'

--- a/www.chrisvogt.me/content/blog/2019-12-28-christmas-in-la/2019-12-28-christmas-in-la.mdx
+++ b/www.chrisvogt.me/content/blog/2019-12-28-christmas-in-la/2019-12-28-christmas-in-la.mdx
@@ -6,9 +6,8 @@ category: travel
 slug: christmas-2019-in-la
 keywords: [world pride, NYC, street photography, photo gallery, Pride 2019]
 description: >
-  A photo gallery showcasing my time spent in Los Angeles over Christmas week in 2019.
-excerpt: >
-  A photo gallery showcasing my time spent in Los Angeles over Christmas week in 2019.
+  Christmas week 2019 in Los Angeles — beach walks, warm December light, and a few favorite frames from the second half of the holiday.
+excerpt: Favorite shots from Christmas week 2019 in Los Angeles.
 thumbnails:
   - https://res.cloudinary.com/chrisvogt/image/upload/f_auto/v1578376203/photos/2019-christmas-in-la/1D7F6EBC-60E2-4919-94AD-131722D6154D
   - https://res.cloudinary.com/chrisvogt/image/upload/f_auto/v1578376203/photos/2019-christmas-in-la/IMG_2804
@@ -16,7 +15,7 @@ thumbnails:
   - https://res.cloudinary.com/chrisvogt/image/upload/f_auto/v1578376203/photos/2019-christmas-in-la/IMG_2929
 ---
 
-This year I spent the second half of Christmas week exploring the beaches in Los Angeles. Following are some of my favorite shots from the trip.
+Christmas 2019, second half of the week: Los Angeles and its beaches in December light. A few favorite frames from the trip.
 
 import { PhotoGallery } from '../../../components/PhotoGallery'
 import { laPhotos } from './la'

--- a/www.chrisvogt.me/content/blog/2024-07-06-belize/2024-07-06-belize.mdx
+++ b/www.chrisvogt.me/content/blog/2024-07-06-belize/2024-07-06-belize.mdx
@@ -6,8 +6,8 @@ category: travel
 slug: belize
 keywords: [Belize, Ambergris Caye, Caye Caulker, Belize Barrier Reef, travel photography, photo gallery]
 description: >
-  From July 1 through 8, 2023, I explored Belize, visiting Ambergris Caye, Caye Caulker, and the Belize Barrier Reef. This gallery contains my favorite shots from the trip, showcasing the natural beauty and unique experiences of each location.
-excerpt: A photo gallery from my July 2023 trip to Belize, featuring Ambergris Caye, Caye Caulker, and the Belize Barrier Reef.
+  A week in Belize in July 2023: Ambergris Caye by golf cart, swimming with sharks and stingrays at the Belize Barrier Reef, Caye Caulker, the Secret Beach, Pelican Reef Villas, and Belizean and Caribbean food.
+excerpt: July 2023 in Belize — shark snorkeling, golf carts on Ambergris Caye, Caye Caulker, and the Secret Beach.
 thumbnails:
   - https://res.cloudinary.com/chrisvogt/image/upload/v1720327677/chrisvogt-me/galleries/belize/20230701-IMG_0939.webp
   - https://res.cloudinary.com/chrisvogt/image/upload/v1720327674/chrisvogt-me/galleries/belize/20230708-CJV08677.webp
@@ -31,8 +31,7 @@ import {
   whereWeStayed
 } from './photos'
 
-In July 2023, I spent the first week exploring Belize with my partner on his family's "let's travel somewhere outside of the country" vacation. During my trip, I swam with sharks, stingrays, and even a manatee; savored Belizean, Caribbean, and Texan cuisine; and drove around in golf carts to discover the enchanting "Secret Beach." This photo gallery captures my visits to Ambergris
-Caye, Caye Caulker, and the Belize Barrier Reef, highlighting the natural beauty and unique experiences of each location.
+July 2023, the first week: Belize with my partner on a family trip that needed somewhere outside the country. The week delivered sharks, stingrays, a manatee, golf carts on unpaved island roads, a place called the Secret Beach that lived up to the name, and a Cessna so small the pilot doubled as flight attendant and onboard comedian.
 
 ## Where is Belize?
 
@@ -71,7 +70,7 @@ Check out this video I got of us landing to drop off passengers at Caye Caulker 
 
 ## Driving around Ambergris Caye
 
-Once on Ambergris Caye, golf carts became my primary mode of transportation. These small, versatile vehicles are the island's main way of getting around due to its limited road infrastructure. My group rented a few golf carts for the week, which were essential for traveling in and out of San Pedro. Driving a golf cart is quite an experience, with speed limits around 5-15 miles per hour and the need to navigate the island's narrow streets and bustling town center. They come with steering wheel locks or "clubs" so you can lock your golf cart when you're not using it. 😅
+On Ambergris Caye, golf carts are how you get around. Speed limits run 5–15 mph, the streets are narrow, and they come with steering wheel clubs so you can lock your cart when you're not in it.
 
 <PhotoGallery photos={drivingAroundBelize} />
 

--- a/www.chrisvogt.me/content/blog/2024-07-07-alaska/2024-07-07-alaska.mdx
+++ b/www.chrisvogt.me/content/blog/2024-07-07-alaska/2024-07-07-alaska.mdx
@@ -6,8 +6,8 @@ category: travel
 slug: alaska-victoria
 keywords: [Alaska, Victoria, Canada, Ketchikan, Sitka, Juneau, travel photography, photo gallery]
 description: >
-  In September 2022, I embarked on an 8-day Royal Caribbean cruise with my family, exploring the majestic landscapes of Alaska and the charming city of Victoria, Canada. This gallery contains my favorite shots from the trip, showcasing the natural beauty and unique experiences of each location.
-excerpt: A photo gallery from my September 2022 Royal Caribbean cruise through Alaska and Victoria, Canada — featuring Ketchikan, Sitka, and Juneau.
+  A September 2022 Royal Caribbean cruise through Alaska and Victoria, Canada with family: Seattle departure, Ketchikan and Creek Street, Sitka bears and totem trails, Mendenhall Glacier in Juneau, Victoria's Butchart Gardens, and the return to Seattle.
+excerpt: September 2022 on the Quantum of the Seas — Ketchikan, Sitka totem trails, Mendenhall Glacier, and Victoria with family.
 thumbnails:
   - https://res.cloudinary.com/chrisvogt/image/upload/v1720417250/chrisvogt-me/galleries/alaska/20220917-IMG_7238.webp
   - https://res.cloudinary.com/chrisvogt/image/upload/v1720420436/chrisvogt-me/galleries/alaska/20220914-IMG_6895.webp
@@ -39,9 +39,7 @@ import {
   victoriaCanada
 } from './photos'
 
-In September 2022, I embarked on a 7-night Alaskan cruise with my family on Royal Caribbean's Quantum of the Seas. We sailed from Seattle to Ketchikan, Alaska; to Sitka, Alaska; to Juneau, Alaska; and then to Victoria, British Columbia before returning to Seattle.
-
-This gallery showcases photos and video I took during our cruise.
+September 2022: a 7-night Alaskan cruise with my family aboard Royal Caribbean's Quantum of the Seas, sailing from Seattle through Ketchikan, Sitka, and Juneau before a stop in Victoria, British Columbia on the way home. My brother in Seattle, my dad from Palm Springs, my mom and other brother from Phoenix—one ship, everyone in the same place for a week.
 
 ## Day 1: Departure from Seattle, Washington
 
@@ -77,17 +75,17 @@ We took the "Ketchikan Waterfront and Wildlife Cruise" tour in Ketchikan, but di
 
 <PhotoGallery photos={katchikan} />
 
-Creek Street, a historic area in Ketchikan, deserves its own section. This vibrant locale is bustling with tourists and lined with charming gift shops. Known for its colorful totem poles, Creek Street offers a unique glimpse into the cultural heritage and lively atmosphere of Ketchikan.
+Creek Street is Ketchikan's historic waterfront district—storefronts on stilts over the creek, totem poles, and the particular energy of a place that has been selling its own history for a long time.
 
 <PhotoGallery photos={creekStreet} />
 
 ## Day 4: Sitka, Alaska
 
-Our next stop was Sitka, where we explored the town's rich history, beautiful landscapes, and vibrant wildlife. The first thing I noticed stepping off the ship were large crabs on display. They were huge! Check this out.
+Sitka was the stop that stuck. The first thing off the gangway: enormous crabs on display at the dock.
 
 <PhotoGallery photos={sitkaCrabs} />
 
-Next we walked into the city to have a look around. This is what Sitka looks like.
+A walk into town.
 
 <PhotoGallery photos={sitkaCity} />
 
@@ -95,7 +93,7 @@ I became captivated by a particular scene and decided to experiment with depth o
 
 <PhotoGallery photos={sitkaBoatFocusProgression} />
 
-Next, my family and I set out to hike the Totem Trail, a 1.0-mile loop trail that winds through the Sitka National Historical Park. The trail features totem poles, lush forests, and scenic views of the Sitka Sound. Here are a few totems we saw along the trail.
+We hiked the Totem Trail—a 1.0-mile loop through Sitka National Historical Park, totem poles spaced through old-growth forest with views of the Sound opening between the trees.
 
 <PhotoGallery photos={sitkaTotemTrail} />
 
@@ -107,13 +105,13 @@ Luckily, we didn't see any bears.
 
 <PhotoGallery photos={sitkaBearWarning} />
 
-Before we left, most people were exhausted from hiking, and I got some goofy photos and series photos of the group. Here are my travel companions.
+Before we left, with everyone suitably worn out from hiking, the group photos got less posed and better for it.
 
 <PhotoGallery photos={myGoofyTravelCompanions} />
 
 ## Day 5: Juneau, Alaska
 
-Juneau, the state capital, offered us a blend of urban charm and natural beauty. Here are a few shots I took when we pulled up to the city.
+Juneau is Alaska's capital and a dramatic arrival by sea—mountains dropping almost straight to the waterfront.
 
 <PhotoGallery photos={arrivingInJuneau} />
 
@@ -123,7 +121,7 @@ We visited the Mendenhall Glacier, which provided a fascinating look at glacial 
 
 ## Day 6: Cruising the Open Sea
 
-Another day at sea allowed us to relax and enjoy the ship's amenities. We attended various onboard activities, dined at the specialty restaurants, and took in the beautiful ocean views. For a brief moment there was a double rainbow outside the ship.
+A day at sea: specialty restaurants, the pool deck, and a double rainbow off the stern that lasted about thirty seconds before anyone could decide whether to run for a camera.
 
 <PhotoGallery photos={cruisingAtSea} />
 
@@ -143,10 +141,6 @@ After disembarking, I opted to go directly to the airport, and what I found was 
 
 <PhotoGallery photos={returnToSeattle} />
 
-## Final Thoughts
-
-This cruise was more than just a vacation; it was a chance to reconnect with family. My brother lives in a suburb of Seattle, I live in San Francisco, my dad was living in Palm Springs at the time, and my mom and other brother are in Phoenix. It was a chance for us to all be together in one place and enjoy each other's company.
-
-And, finally, for two things that did _not_ actually happen. 🤣
+The real value of the trip was the logistics: my brother in Seattle, my dad in Palm Springs, my mom and other brother in Phoenix—one itinerary that got everyone on the same ship for a week. And, for the record, two things that did _not_ actually happen.
 
 <PhotoGallery photos={goofyShipPhotos} />

--- a/www.chrisvogt.me/content/blog/2024-07-24-virgin-caribbean-cruise/2024-07-24-virgin-caribbean-cruise.mdx
+++ b/www.chrisvogt.me/content/blog/2024-07-24-virgin-caribbean-cruise/2024-07-24-virgin-caribbean-cruise.mdx
@@ -6,9 +6,8 @@ category: travel
 slug: virgin-caribbean-cruise
 keywords: [Virgin cruise, Caribbean, Mayan Sol, Valiant Lady, Costa Maya, Bimini, travel photography, photo gallery]
 description: >
-  Join me on a 2024 Virgin cruise through the Caribbean, visiting Costa Maya and Bimini, with photos and highlights.
-excerpt: >
-  Experience my journey on a Virgin cruise through the Caribbean, featuring Costa Maya and Bimini, with vivid photos and stories.
+  A 2024 Virgin Voyages Mayan Sol cruise aboard Valiant Lady: a flight evacuation at SFO, a day in South Beach Miami, 5 nights to Costa Maya and Mahahual Mexico, Bimini Bahamas stingrays, and a Scarlet Night party at sea.
+excerpt: July 2024 on Virgin's Valiant Lady — a plane fire at SFO, South Beach, Costa Maya, and Bimini stingrays.
 thumbnails:
   - https://res.cloudinary.com/chrisvogt/image/upload/v1722105413/chrisvogt-me/galleries/mayan-sol/2-south-beach/20240713-IMG_9129.webp
   - https://res.cloudinary.com/chrisvogt/image/upload/v1722105414/chrisvogt-me/galleries/mayan-sol/2-south-beach/20240713-IMG_9143.webp
@@ -34,7 +33,7 @@ import {
   biminiStingrays
 } from './photos'
 
-In July 2024, I embarked on a journey aboard Virgin Voyages' Valiant Lady. I did their 5-night Mayan Sol sailing from Miami to Costa Maya, MX, and Bimini, Bahamas. This blog post captures the highlights of my trip, from a dramatic start with a plane fire to vibrant experiences in Costa Maya and Bimini.
+July 2024: a 5-night Virgin Voyages Mayan Sol itinerary aboard Valiant Lady, Miami to Costa Maya and Bimini—which would have been a perfectly smooth trip if the plane at SFO had not caught fire on the tarmac.
 
 ## Being Evacuated from the Plane at SFO
 
@@ -48,17 +47,17 @@ A replacement airplane didn't arrive until 11:15 PM, turning the flight into a r
 
 ## A Day in South Beach, Miami
 
-The day before the cruise, I met up with another friend who was joining us on the cruise, and we spent the day walking around South Beach and trying out a restaurant called CVI.CHE 105 that was _so_ good. 🤤
+The day before the cruise I met up with a friend who was joining us for the sailing, and we spent it walking South Beach and eating at CVI.CHE 105—which was extremely good and is worth the trip on its own.
 
 <PhotoGallery photos={southBeachMiami} />
 
 ## Setting Sail on the Valiant Lady
 
-The day had finally arrived to board the Valiant Lady and set sail on the Mayan Sol itinerary. I decorated my room's door with refrigerator magnets to make it feel like home.
+Embarkation day. I decorated the cabin door with refrigerator magnets—a habit that started as a joke and has become a ritual.
 
 <PhotoGallery photos={settingSailRoom} />
 
-The views as we set sail were amazing. Every time I visit Miami, new buildings seem to pop up.
+Miami skyline on departure: more towers than last time, same as always.
 
 <PhotoGallery photos={settingSailShip} />
 

--- a/www.chrisvogt.me/content/blog/2025-06-18-virgin-southern-caribbean/2025-06-18-virgin-southern-caribbean.mdx
+++ b/www.chrisvogt.me/content/blog/2025-06-18-virgin-southern-caribbean/2025-06-18-virgin-southern-caribbean.mdx
@@ -16,8 +16,8 @@ keywords:
     photo gallery
   ]
 description: >
-  Join me on a 12-night Virgin Voyages cruise aboard the Resilient Lady, where I traveled with friends through Puerto Rico, Colombia, Antigua, Curaçao, and St. Maarten. This post highlights some of my favorite memories and photo galleries from each stop — from vibrant Old San Juan and rooftop bars in Cartagena to floating bars in Antigua and dancing on the beach in San Juan.
-excerpt: A photo-filled recap of my April 2025 Caribbean cruise aboard Virgin's Resilient Lady — exploring Old San Juan, Cartagena, Curaçao, and more.
+  A 12-night Virgin Voyages cruise aboard Resilient Lady in April 2025: Old San Juan (UNESCO, forts, cobblestones), Cartagena rooftop bars and bird photography, a floating bar in Antigua, Curaçao's Pietermaai waterfront, and a final night dancing in San Juan.
+excerpt: April 2025 on Resilient Lady — Old San Juan, Cartagena, Curaçao, Antigua, and friends from SF and Phoenix.
 thumbnails:
   - https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231638/chrisvogt-me/galleries/2025-vsc/20250328-IMG_2680.jpg
   - https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231682/chrisvogt-me/galleries/2025-vsc/20250328-IMG_2666.jpg
@@ -50,13 +50,11 @@ import {
   stMaarten
 } from './photos'
 
-In April I took a long break from work to travel through the Caribbean with a group of friends. We sailed aboard Virgin Voyages’ **Resilient Lady** on a 12-night cruise that left from San Juan, Puerto Rico.
+April 2025 was twelve nights on Virgin Voyages’ **Resilient Lady**, a southern Caribbean run departing San Juan, Puerto Rico—Cartagena, Curaçao, Antigua, and St. Maarten in between. My partner and I flew in early, more than 12 hours from San Francisco with a layover in Denver, landing on Saturday with three days before the ship sailed. Roc from SF and Matt from Phoenix arrived Sunday; we all stayed at Hotel Rumbao, right next to the cruise ports.
 
 <PhotoGallery photos={flightToSanJuan} />
 
-It took over 12 hours to get from San Francisco to San Juan, with a short layover in Denver. My partner and I arrived a few days early to explore before our friends — Roc from SF and Matt from Phoenix — flew in. We all stayed at Hotel Rumbao, which is right next to the cruise ports.
-
-Here's a 15-second clip showing the view from Hotel Rumbao room.
+A brief clip of the hotel view:
 
 <YouTube
   sx={{ mb: 4 }}
@@ -64,9 +62,7 @@ Here's a 15-second clip showing the view from Hotel Rumbao room.
   url='https://www.youtube.com/embed/CW0Pehl5c3I?si=SsTL5fGVpkb2sYbo'
 />
 
-I always get a little anxious about flights being delayed and missing the ship, so I try to arrive early just in case. We got in on a Saturday and didn’t set sail until Tuesday, which gave us plenty of time to wander around Old San Juan — a UNESCO World Heritage site.
-
-Old San Juan felt full of life, color, and history. Even late at night, the streets were lively — couples walking hand-in-hand, families hanging out on benches, kids playing in plazas. It reminded me how different that energy is compared to San Francisco, where weeknights at 11pm are usually dead quiet.
+Arriving early paid off: three days in Old San Juan before the ship sailed. The city is a UNESCO World Heritage site and earns it—cobblestone streets, buildings painted in blues, yellows, and pinks, forts that date to the 1500s. Even late at night the streets were alive in a way San Francisco weeknights rarely are.
 
 <PhotoGallery photos={exploringOldSanJuanBefore} />
 


### PR DESCRIPTION
## Summary

Applies the Narrative tier (scene-first openers, tightened section transitions, updated `description`/`excerpt` frontmatter) to all six travel posts.

## Posts changed

| File | Key changes |
|------|-------------|
| `2025-06-18-virgin-southern-caribbean` (Resilient Lady) | New scene opener naming route + timeline, tightened hotel/arrival preamble |
| `2024-07-07-alaska` (Quantum of the Seas) | New opener with family logistics context, polished Sitka/Ketchikan/Juneau section intros, removed "Final Thoughts" heading |
| `2024-07-06-belize` | New scene opener listing week highlights, condensed golf cart paragraph |
| `2024-07-24-virgin-caribbean-cruise` (Valiant Lady) | New opener leading with the plane-fire hook, tightened South Beach and embarkation beats |
| `2019-06-27-nyc-world-pride` | Updated description/excerpt, expanded one-sentence body intro |
| `2019-12-28-christmas-in-la` | Updated description/excerpt, polished one-sentence body intro |

## Test plan

- [x] Verify all six pages render without errors
- [x] Confirm no slug, image URL, or MDX component was altered

Made with [Cursor](https://cursor.com)