### PR TITLE
Home Latest Posts: recap cards and two-row music embeds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## 0.85.0
+
+### `gatsby-theme-chronogrove` — home “Latest Posts” widget layout
+
+- **Recaps**: `PostCard` no longer receives **`excerpt`** (matches Travel-style cards: thumbnails, title, meta). Recaps use the same **2-column** grid as Travel on large breakpoints instead of a dynamic 3-column layout.
+- **Music**: **`useCategorizedPosts`** exposes **`musicSoundcloud`** and **`musicYoutube`** (up to **two** newest music posts per embed type). The home widget renders **two rows** under one Music heading: SoundCloud first, then YouTube, with spacing between rows. Posts already shown in the SoundCloud row are excluded from the YouTube row so dual-embed posts do not duplicate. Each row passes **only** the relevant embed props so previews align. Music posts **without** `soundcloudId` or `youtubeSrc` do not appear in these rows.
+- **Version**: **0.85.0**
+
+### `www.chrisvogt.me`
+
+- **Version**: **1.16.0** (tracks theme **0.85.0**).
+
+### `www.chronogrove.com` (demo)
+
+- **Version**: **1.3.0** (tracks theme **0.85.0**).
+
+### Files changed
+
+- `theme/package.json` (version **0.85.0**), `theme/src/hooks/use-categorized-posts.js`, `theme/src/hooks/use-categorized-posts.spec.js`, `theme/src/components/widgets/recent-posts/recent-posts-widget.js`, `theme/src/components/widgets/recent-posts/recent-posts-widget.spec.js`
+- `www.chrisvogt.me/package.json` (version **1.16.0**)
+- `www.chronogrove.com/package.json` (version **1.3.0**)
+- `CHANGELOG.md`
+
+---
+
 ## 0.84.0
 
 ### `gatsby-theme-chronogrove` — configurable footer links

--- a/theme/package.json
+++ b/theme/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-theme-chronogrove",
   "description": "A personal website and digital garden theme for GatsbyJS.",
-  "version": "0.84.0",
+  "version": "0.85.0",
   "author": "Chris Vogt <mail@chrisvogt.me> (https://www.chrisvogt.me)",
   "main": "index.js",
   "license": "MIT",

--- a/theme/src/components/widgets/recent-posts/recent-posts-widget.js
+++ b/theme/src/components/widgets/recent-posts/recent-posts-widget.js
@@ -36,23 +36,22 @@ const SectionHeader = ({ icon, title }) => (
   </Box>
 )
 
+const musicGridSx = {
+  display: 'grid',
+  gridAutoRows: '1fr',
+  gridGap: [2, 2, 3, 3],
+  gridTemplateColumns: ['1fr', '1fr', '1fr', 'repeat(2, 1fr)']
+}
+
+const recapTravelGridSx = {
+  display: 'grid',
+  gridAutoRows: '1fr',
+  gridGap: [2, 2, 3, 3],
+  gridTemplateColumns: ['1fr', '1fr', '1fr', 'repeat(2, 1fr)']
+}
+
 export default () => {
   const { posts } = useCategorizedPosts()
-
-  const getColumnCount = postsCount => {
-    let columnCount
-    switch (postsCount) {
-      case 1:
-        columnCount = 1
-        break
-      case 2:
-        columnCount = 2
-        break
-      default:
-        columnCount = 3
-    }
-    return columnCount
-  }
 
   const callToAction = (
     <CallToAction title='Browse all published content' to='/blog'>
@@ -81,24 +80,12 @@ export default () => {
         {postsBySection.recaps && postsBySection.recaps.length > 0 && (
           <Box sx={{ mb: 4 }}>
             <SectionHeader icon={faCalendarAlt} title='Recaps' />
-            <Grid
-              sx={{
-                display: 'grid',
-                gridGap: [3, 3, 3, 4],
-                gridTemplateColumns: [
-                  '1fr',
-                  '1fr',
-                  '1fr',
-                  `repeat(${getColumnCount(postsBySection.recaps.length)}, 1fr)`
-                ]
-              }}
-            >
+            <Grid sx={recapTravelGridSx}>
               {postsBySection.recaps.map(post => (
                 <PostCard
                   key={post.fields.id}
                   category={post.fields.category}
                   date={post.frontmatter.date}
-                  excerpt={post.frontmatter.excerpt}
                   link={post.fields.path}
                   thumbnails={post.frontmatter.thumbnails}
                   title={post.frontmatter.title}
@@ -109,7 +96,10 @@ export default () => {
         )}
 
         {/* Single Post Sections - Order matches nav: Recaps, Posts, Music, Travel */}
-        {(postsBySection.other || postsBySection.music || postsBySection.travel) && (
+        {(postsBySection.other ||
+          postsBySection.musicSoundcloud ||
+          postsBySection.musicYoutube ||
+          postsBySection.travel) && (
           <Box>
             {/* Posts */}
             {postsBySection.other && postsBySection.other.length > 0 && (
@@ -138,30 +128,43 @@ export default () => {
               </Box>
             )}
 
-            {/* Music */}
-            {postsBySection.music && postsBySection.music.length > 0 && (
+            {/* Music: SoundCloud row, then YouTube row (2 each) */}
+            {(postsBySection.musicSoundcloud?.length > 0 || postsBySection.musicYoutube?.length > 0) && (
               <Box sx={{ mb: 4 }}>
                 <SectionHeader icon={faMusic} title='Music' />
-                <Grid
-                  sx={{
-                    display: 'grid',
-                    gridAutoRows: '1fr',
-                    gridGap: [2, 2, 3, 3],
-                    gridTemplateColumns: ['1fr', '1fr', '1fr', 'repeat(2, 1fr)']
-                  }}
-                >
-                  {postsBySection.music.map(post => (
-                    <PostCard
-                      key={post.fields.id}
-                      category={post.fields.category}
-                      date={post.frontmatter.date}
-                      link={post.fields.path}
-                      soundcloudId={post.frontmatter.soundcloudId}
-                      title={post.frontmatter.title}
-                      youtubeSrc={post.frontmatter.youtubeSrc}
-                    />
-                  ))}
-                </Grid>
+                {postsBySection.musicSoundcloud?.length > 0 && (
+                  <Grid sx={musicGridSx}>
+                    {postsBySection.musicSoundcloud.map(post => (
+                      <PostCard
+                        key={post.fields.id}
+                        category={post.fields.category}
+                        date={post.frontmatter.date}
+                        link={post.fields.path}
+                        soundcloudId={post.frontmatter.soundcloudId}
+                        title={post.frontmatter.title}
+                      />
+                    ))}
+                  </Grid>
+                )}
+                {postsBySection.musicYoutube?.length > 0 && (
+                  <Grid
+                    sx={{
+                      ...musicGridSx,
+                      mt: postsBySection.musicSoundcloud?.length > 0 ? [2, 2, 3, 3] : 0
+                    }}
+                  >
+                    {postsBySection.musicYoutube.map(post => (
+                      <PostCard
+                        key={post.fields.id}
+                        category={post.fields.category}
+                        date={post.frontmatter.date}
+                        link={post.fields.path}
+                        title={post.frontmatter.title}
+                        youtubeSrc={post.frontmatter.youtubeSrc}
+                      />
+                    ))}
+                  </Grid>
+                )}
               </Box>
             )}
 
@@ -169,14 +172,7 @@ export default () => {
             {postsBySection.travel && postsBySection.travel.length > 0 && (
               <Box sx={{ mb: 4 }}>
                 <SectionHeader icon={faMapMarkedAlt} title='Travel' />
-                <Grid
-                  sx={{
-                    display: 'grid',
-                    gridAutoRows: '1fr',
-                    gridGap: [2, 2, 3, 3],
-                    gridTemplateColumns: ['1fr', '1fr', '1fr', 'repeat(2, 1fr)']
-                  }}
-                >
+                <Grid sx={recapTravelGridSx}>
                   {postsBySection.travel.map(post => (
                     <PostCard
                       key={post.fields.id}

--- a/theme/src/components/widgets/recent-posts/recent-posts-widget.spec.js
+++ b/theme/src/components/widgets/recent-posts/recent-posts-widget.spec.js
@@ -298,6 +298,82 @@ describe('RecentPostsWidget', () => {
     expect(postCards[1]).toHaveAttribute('data-has-thumbnails', 'true')
   })
 
+  it('renders SoundCloud and YouTube music rows when both sections have posts', () => {
+    useCategorizedPosts.mockReturnValue({
+      posts: [
+        {
+          frontmatter: {
+            date: '2024-10-01',
+            title: 'SoundCloud Track',
+            soundcloudId: '12345'
+          },
+          fields: {
+            category: 'music',
+            id: '1',
+            path: '/music/soundcloud-track'
+          },
+          section: 'musicSoundcloud'
+        },
+        {
+          frontmatter: {
+            date: '2024-10-02',
+            title: 'YouTube Track',
+            youtubeSrc: 'https://www.youtube.com/embed/abc123def'
+          },
+          fields: {
+            category: 'music',
+            id: '2',
+            path: '/music/youtube-track'
+          },
+          section: 'musicYoutube'
+        }
+      ],
+      recaps: [],
+      musicSoundcloud: [],
+      musicYoutube: [],
+      travel: [],
+      other: []
+    })
+
+    render(<RecentPostsWidget />)
+
+    expect(screen.getByText('Music')).toBeInTheDocument()
+    const postCards = screen.getAllByTestId('post-card')
+    expect(postCards).toHaveLength(2)
+    expect(postCards[0]).toHaveTextContent('SoundCloud Track')
+    expect(postCards[1]).toHaveTextContent('YouTube Track')
+  })
+
+  it('renders YouTube-only music row without extra top margin', () => {
+    useCategorizedPosts.mockReturnValue({
+      posts: [
+        {
+          frontmatter: {
+            date: '2024-10-02',
+            title: 'YouTube Only',
+            youtubeSrc: 'https://www.youtube.com/embed/xyz789'
+          },
+          fields: {
+            category: 'music',
+            id: '1',
+            path: '/music/youtube-only'
+          },
+          section: 'musicYoutube'
+        }
+      ],
+      recaps: [],
+      musicSoundcloud: [],
+      musicYoutube: [],
+      travel: [],
+      other: []
+    })
+
+    render(<RecentPostsWidget />)
+
+    expect(screen.getByText('Music')).toBeInTheDocument()
+    expect(screen.getByTestId('post-card')).toHaveTextContent('YouTube Only')
+  })
+
   it('handles posts without thumbnails in recaps section', () => {
     useCategorizedPosts.mockReturnValue({
       posts: [

--- a/theme/src/components/widgets/recent-posts/recent-posts-widget.spec.js
+++ b/theme/src/components/widgets/recent-posts/recent-posts-widget.spec.js
@@ -57,7 +57,7 @@ describe('RecentPostsWidget', () => {
             id: '2',
             path: '/music/piano-practice'
           },
-          section: 'music'
+          section: 'musicSoundcloud'
         },
         {
           frontmatter: {
@@ -87,7 +87,8 @@ describe('RecentPostsWidget', () => {
         }
       ],
       recaps: [],
-      music: [],
+      musicSoundcloud: [],
+      musicYoutube: [],
       travel: [],
       other: []
     })
@@ -144,7 +145,8 @@ describe('RecentPostsWidget', () => {
         }
       ],
       recaps: [],
-      music: [],
+      musicSoundcloud: [],
+      musicYoutube: [],
       travel: [],
       other: []
     })
@@ -168,7 +170,8 @@ describe('RecentPostsWidget', () => {
     useCategorizedPosts.mockReturnValue({
       posts: [],
       recaps: [],
-      music: [],
+      musicSoundcloud: [],
+      musicYoutube: [],
       travel: [],
       other: []
     })
@@ -232,7 +235,8 @@ describe('RecentPostsWidget', () => {
         }
       ],
       recaps: [],
-      music: [],
+      musicSoundcloud: [],
+      musicYoutube: [],
       travel: [],
       other: []
     })
@@ -277,7 +281,8 @@ describe('RecentPostsWidget', () => {
         }
       ],
       recaps: [],
-      music: [],
+      musicSoundcloud: [],
+      musicYoutube: [],
       travel: [],
       other: []
     })
@@ -312,7 +317,8 @@ describe('RecentPostsWidget', () => {
         }
       ],
       recaps: [],
-      music: [],
+      musicSoundcloud: [],
+      musicYoutube: [],
       travel: [],
       other: []
     })

--- a/theme/src/hooks/use-categorized-posts.js
+++ b/theme/src/hooks/use-categorized-posts.js
@@ -63,8 +63,14 @@ const useCategorizedPosts = () => {
   // Get latest recaps (up to 2, including "now" page as the latest)
   const latestRecaps = allPosts.filter(post => isRecapPost(post)).slice(0, 2)
 
-  // Get latest music posts (2 posts)
-  const latestMusicPosts = allPosts.filter(post => isMusicPost(post)).slice(0, 2)
+  const musicPostsNewestFirst = allPosts.filter(post => isMusicPost(post))
+
+  // Two rows on the home widget: latest SoundCloud + latest YouTube (2 each, de-duped between rows)
+  const latestMusicSoundcloud = musicPostsNewestFirst.filter(post => post.frontmatter.soundcloudId).slice(0, 2)
+  const soundcloudRowIds = new Set(latestMusicSoundcloud.map(post => post.fields.id))
+  const latestMusicYoutube = musicPostsNewestFirst
+    .filter(post => post.frontmatter.youtubeSrc && !soundcloudRowIds.has(post.fields.id))
+    .slice(0, 2)
 
   // Get latest photography posts (2 posts)
   const latestPhotographyPosts = allPosts.filter(post => isPhotographyPost(post)).slice(0, 2)
@@ -97,10 +103,16 @@ const useCategorizedPosts = () => {
     }
   })
 
-  // Add music posts if not already included
-  latestMusicPosts.forEach(post => {
+  latestMusicSoundcloud.forEach(post => {
     if (!usedPostIds.has(post.fields.id)) {
-      deduplicatedPosts.push({ ...post, section: 'music' })
+      deduplicatedPosts.push({ ...post, section: 'musicSoundcloud' })
+      usedPostIds.add(post.fields.id)
+    }
+  })
+
+  latestMusicYoutube.forEach(post => {
+    if (!usedPostIds.has(post.fields.id)) {
+      deduplicatedPosts.push({ ...post, section: 'musicYoutube' })
       usedPostIds.add(post.fields.id)
     }
   })
@@ -132,7 +144,8 @@ const useCategorizedPosts = () => {
   return {
     posts: deduplicatedPosts,
     recaps: latestRecaps,
-    music: latestMusicPosts,
+    musicSoundcloud: latestMusicSoundcloud,
+    musicYoutube: latestMusicYoutube,
     photography: latestPhotographyPosts,
     travel: latestTravelPosts,
     other: latestOtherPosts

--- a/theme/src/hooks/use-categorized-posts.spec.js
+++ b/theme/src/hooks/use-categorized-posts.spec.js
@@ -66,7 +66,8 @@ describe('useCategorizedPosts', () => {
               title: 'Here and Now Piano Cover',
               slug: 'here-and-now',
               date: '2025-06-19',
-              banner: 'banner4.jpg'
+              banner: 'banner4.jpg',
+              soundcloudId: '12345'
             },
             fields: {
               category: 'music/piano-covers',
@@ -133,8 +134,9 @@ describe('useCategorizedPosts', () => {
     expect(result.recaps[0].frontmatter.title).toBe('September 2025 Recap')
     expect(result.recaps[1].frontmatter.title).toBe('July 2025 Recap')
 
-    expect(result.music).toHaveLength(1)
-    expect(result.music[0].frontmatter.title).toBe('Here and Now Piano Cover')
+    expect(result.musicSoundcloud).toHaveLength(1)
+    expect(result.musicSoundcloud[0].frontmatter.title).toBe('Here and Now Piano Cover')
+    expect(result.musicYoutube).toHaveLength(0)
 
     expect(result.photography).toHaveLength(1)
     expect(result.photography[0].frontmatter.title).toBe('Belize Travel Photos')
@@ -145,7 +147,7 @@ describe('useCategorizedPosts', () => {
     expect(result.other[0].frontmatter.title).toBe('Evolution of My Blog')
 
     // Check that posts array contains deduplicated posts
-    expect(result.posts).toHaveLength(5) // 2 recaps + 1 music + 1 photography + 1 other
+    expect(result.posts).toHaveLength(5) // 2 recaps + 1 music (SoundCloud) + 1 photography + 1 other
     expect(result.posts.every(post => post.section)).toBe(true)
   })
 
@@ -164,7 +166,8 @@ describe('useCategorizedPosts', () => {
     const result = useCategorizedPosts()
 
     expect(result.recaps).toHaveLength(0)
-    expect(result.music).toHaveLength(0)
+    expect(result.musicSoundcloud).toHaveLength(0)
+    expect(result.musicYoutube).toHaveLength(0)
     expect(result.photography).toHaveLength(0)
     expect(result.travel).toHaveLength(0)
     expect(result.other).toHaveLength(0)
@@ -177,7 +180,8 @@ describe('useCategorizedPosts', () => {
     const result = useCategorizedPosts()
 
     expect(result.recaps).toHaveLength(0)
-    expect(result.music).toHaveLength(0)
+    expect(result.musicSoundcloud).toHaveLength(0)
+    expect(result.musicYoutube).toHaveLength(0)
     expect(result.photography).toHaveLength(0)
     expect(result.travel).toHaveLength(0)
     expect(result.other).toHaveLength(0)
@@ -230,7 +234,7 @@ describe('useCategorizedPosts', () => {
     expect(result.recaps[0].frontmatter.title).toBe('Monthly Recap')
   })
 
-  it('correctly identifies music posts', () => {
+  it('correctly identifies music posts for SoundCloud and YouTube rows', () => {
     const mockData = {
       allMdx: {
         edges: [
@@ -240,7 +244,8 @@ describe('useCategorizedPosts', () => {
                 title: 'Piano Practice',
                 slug: 'piano-practice',
                 date: '2025-01-01',
-                banner: 'banner.jpg'
+                banner: 'banner.jpg',
+                soundcloudId: '111'
               },
               fields: {
                 category: 'music',
@@ -255,7 +260,8 @@ describe('useCategorizedPosts', () => {
                 title: 'Piano Covers',
                 slug: 'piano-covers',
                 date: '2025-01-02',
-                banner: 'banner2.jpg'
+                banner: 'banner2.jpg',
+                youtubeSrc: 'https://www.youtube.com/embed/abc123'
               },
               fields: {
                 category: 'music/piano-covers',
@@ -272,9 +278,10 @@ describe('useCategorizedPosts', () => {
 
     const result = useCategorizedPosts()
 
-    expect(result.music).toHaveLength(2)
-    expect(result.music[0].frontmatter.title).toBe('Piano Practice')
-    expect(result.music[1].frontmatter.title).toBe('Piano Covers')
+    expect(result.musicSoundcloud).toHaveLength(1)
+    expect(result.musicSoundcloud[0].frontmatter.title).toBe('Piano Practice')
+    expect(result.musicYoutube).toHaveLength(1)
+    expect(result.musicYoutube[0].frontmatter.title).toBe('Piano Covers')
   })
 
   it('correctly identifies photography posts', () => {
@@ -383,7 +390,8 @@ describe('useCategorizedPosts', () => {
                 title: 'Music Post',
                 slug: 'music-post',
                 date: '2025-01-01',
-                banner: 'banner1.jpg'
+                banner: 'banner1.jpg',
+                soundcloudId: '999'
               },
               fields: {
                 category: 'music',
@@ -452,7 +460,8 @@ describe('useCategorizedPosts', () => {
                 title: 'Music Post',
                 slug: 'music-post',
                 date: '2025-01-01',
-                banner: 'banner1.jpg'
+                banner: 'banner1.jpg',
+                soundcloudId: '999'
               },
               fields: {
                 category: 'music',
@@ -503,7 +512,7 @@ describe('useCategorizedPosts', () => {
     expect(result.posts).toHaveLength(2)
 
     // Verify sections are assigned correctly
-    expect(result.posts[0].section).toBe('music')
+    expect(result.posts[0].section).toBe('musicSoundcloud')
     expect(result.posts[1].section).toBe('photography')
 
     // Verify no duplicate IDs
@@ -522,7 +531,8 @@ describe('useCategorizedPosts', () => {
                 title: 'Duplicate Test Post',
                 slug: 'duplicate-test',
                 date: '2025-01-01',
-                banner: 'banner1.jpg'
+                banner: 'banner1.jpg',
+                soundcloudId: '888'
               },
               fields: {
                 category: 'music',
@@ -560,7 +570,7 @@ describe('useCategorizedPosts', () => {
     expect(result.posts[1].fields.id).toBe('2')
 
     // Verify sections are assigned correctly
-    expect(result.posts[0].section).toBe('music')
+    expect(result.posts[0].section).toBe('musicSoundcloud')
     expect(result.posts[1].section).toBe('photography')
   })
 
@@ -589,7 +599,8 @@ describe('useCategorizedPosts', () => {
                 title: 'Music Post',
                 slug: 'music-post',
                 date: '2025-01-02',
-                banner: 'banner2.jpg'
+                banner: 'banner2.jpg',
+                soundcloudId: '777'
               },
               fields: {
                 category: 'music',
@@ -686,7 +697,7 @@ describe('useCategorizedPosts', () => {
 
     // Verify sections are assigned correctly
     expect(result.posts[0].section).toBe('recaps')
-    expect(result.posts[1].section).toBe('music')
+    expect(result.posts[1].section).toBe('musicSoundcloud')
     expect(result.posts[2].section).toBe('photography')
     expect(result.posts[3].section).toBe('other')
 

--- a/www.chrisvogt.me/package.json
+++ b/www.chrisvogt.me/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "www.chrisvogt.me",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "license": "GPL",
   "scripts": {
     "build": "gatsby build",

--- a/www.chronogrove.com/package.json
+++ b/www.chronogrove.com/package.json
@@ -1,6 +1,6 @@
 {
   "name": "www.chronogrove.com",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Official demo site for gatsby-theme-chronogrove",
   "scripts": {
     "develop": "gatsby develop",


### PR DESCRIPTION
## Summary

This release tightens the home page **Latest Posts** widget so recap cards read like the travel strip (visual-first, no excerpt blurbs) and so music picks up two clear rows of embeds instead of a single mixed grid.

## What changed

- **Recaps** no longer pass `excerpt` into `PostCard`, and they use the same two-column grid pattern as travel on large viewports. Thumbnails, title, and meta stay; the extra paragraph of preview text goes away.
- **Music** is split at the data layer: `useCategorizedPosts` now returns `musicSoundcloud` and `musicYoutube`, each capped at two posts by date. The widget renders one **Music** heading, then a SoundCloud row and a YouTube row, with only the relevant embed props per row so card heights line up. Posts that already appear in the SoundCloud row are skipped for the YouTube row so dual-embed posts are not shown twice. Music entries without `soundcloudId` or `youtubeSrc` are not shown in these rows.

## Versions

- `gatsby-theme-chronogrove` **0.85.0**
- `www.chrisvogt.me` **1.16.0**
- `www.chronogrove.com` **1.3.0**

Changelog and package versions are updated in this branch.

## Testing

- `pnpm --filter gatsby-theme-chronogrove test -- theme/src/hooks/use-categorized-posts.spec.js theme/src/components/widgets/recent-posts/recent-posts-widget.spec.js`

Made with [Cursor](https://cursor.com)