### PR TITLE
fix(theme): pause Book3D WebGL off-screen (home background context loss)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## 0.85.1
+
+### `gatsby-theme-chronogrove` — Goodreads 3D books and WebGL background
+
+- **Bug fix**: **`Book3D`** no longer **`dispose()`**s its Three.js renderer when it leaves the viewport. It pauses animation, clears the intro timer, resets hover/intro state to the resting pose, and hides the canvas (**`visibility: hidden`**). Scrolling past many Goodreads tiles and back was creating a burst of new WebGL contexts and could exceed the browser limit, **revoking the dark-mode Color Bends background** on the home page. The scene is still fully torn down on component unmount.
+- **Tests**: **`book-3d.spec.js`** expects pause/reuse on viewport exit/re-entry instead of dispose/recreate.
+- **Version**: **0.85.1**
+
+### `www.chrisvogt.me`
+
+- **Version**: **1.16.1** (tracks theme **0.85.1**).
+
+### `www.chronogrove.com` (demo)
+
+- **Version**: **1.3.1** (tracks theme **0.85.1**).
+
+### Files changed
+
+- `theme/package.json` (version **0.85.1**), `theme/src/components/artwork/book-3d.js`, `theme/src/components/artwork/book-3d.spec.js`
+- `www.chrisvogt.me/package.json` (version **1.16.1**)
+- `www.chronogrove.com/package.json` (version **1.3.1**)
+- `CHANGELOG.md`
+
+---
+
 ## 0.85.0
 
 ### `gatsby-theme-chronogrove` — home “Latest Posts” widget layout

--- a/theme/package.json
+++ b/theme/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-theme-chronogrove",
   "description": "A personal website and digital garden theme for GatsbyJS.",
-  "version": "0.85.0",
+  "version": "0.85.1",
   "author": "Chris Vogt <mail@chrisvogt.me> (https://www.chrisvogt.me)",
   "main": "index.js",
   "license": "MIT",

--- a/theme/src/components/artwork/book-3d.js
+++ b/theme/src/components/artwork/book-3d.js
@@ -137,6 +137,8 @@ const Book3D = ({ thumbnailURL, title, introDelay = 0 }) => {
     let returnStartY = 0
     let returnStartMs = null
     let introTimer = null
+    /** Tracks viewport visibility; kept in sync with IntersectionObserver (or true when IO is unavailable). */
+    let inViewport = false
 
     // ── Helpers defined up front so createScene/destroyScene can reference them
     const doRender = () => {
@@ -146,6 +148,11 @@ const Book3D = ({ thumbnailURL, title, introDelay = 0 }) => {
     const startAnim = () => {
       if (rafId !== null) return
       const tick = () => {
+        if (!inViewport) {
+          rafId = null
+          return
+        }
+
         const now = performance.now()
 
         if (phase === 'INTRO') {
@@ -197,6 +204,30 @@ const Book3D = ({ thumbnailURL, title, introDelay = 0 }) => {
         cancelAnimationFrame(rafId)
         rafId = null
       }
+    }
+
+    const startIntroTimer = () => {
+      clearTimeout(introTimer)
+      introTimer = setTimeout(() => {
+        if (!inViewport) {
+          if (book) {
+            book.rotation.y = REST_Y
+            book.rotation.x = REST_X
+          }
+          phase = 'IDLE'
+          doRender()
+          return
+        }
+        if (hovered) {
+          phase = 'IDLE'
+          book.rotation.y = REST_Y
+          book.rotation.x = REST_X
+          return
+        }
+        phase = 'INTRO'
+        introStartMs = performance.now()
+        startAnim()
+      }, introDelay)
     }
 
     // ── Scene creation ─────────────────────────────────────────────────────
@@ -302,18 +333,7 @@ const Book3D = ({ thumbnailURL, title, introDelay = 0 }) => {
         applyFallback()
       }
 
-      // Start intro after the per-book stagger delay
-      introTimer = setTimeout(() => {
-        if (hovered) {
-          phase = 'IDLE'
-          book.rotation.y = REST_Y
-          book.rotation.x = REST_X
-          return
-        }
-        phase = 'INTRO'
-        introStartMs = performance.now()
-        startAnim()
-      }, introDelay)
+      startIntroTimer()
 
       doRender()
     }
@@ -349,17 +369,40 @@ const Book3D = ({ thumbnailURL, title, introDelay = 0 }) => {
       camera = null
     }
 
-    // ── IntersectionObserver owns the scene lifecycle ──────────────────────
+    // ── IntersectionObserver: defer WebGL creation until visible, but do NOT dispose the
+    // renderer when off-screen. Disposing many book renderers at once and recreating them
+    // on scroll-back can exceed the browser WebGL context limit and revoke other canvases
+    // (e.g. the fixed ColorBends home background).
     let observer
     if ('IntersectionObserver' in window) {
       observer = new window.IntersectionObserver(
         ([entry]) => {
           if (entry.isIntersecting) {
-            if (!renderer) createScene()
-            // else: rapid re-entry before destroyScene ran — book is at resting pose, nothing to do
+            inViewport = true
+            if (!renderer) {
+              createScene()
+            } else {
+              renderer.domElement.style.visibility = 'visible'
+              if (phase === 'PENDING' && !introTimer) {
+                startIntroTimer()
+              }
+              doRender()
+            }
           } else {
+            inViewport = false
+            hovered = false
             stopAnim()
-            destroyScene()
+            clearTimeout(introTimer)
+            introTimer = null
+            if (book && (phase === 'INTRO' || phase === 'RETURN' || phase === 'HOVERED')) {
+              book.rotation.y = REST_Y
+              book.rotation.x = REST_X
+              phase = 'IDLE'
+            }
+            if (renderer) {
+              renderer.domElement.style.visibility = 'hidden'
+              doRender()
+            }
           }
         },
         { threshold: 0.1 }
@@ -367,6 +410,7 @@ const Book3D = ({ thumbnailURL, title, introDelay = 0 }) => {
       observer.observe(container)
     } else {
       // No IntersectionObserver support — create immediately
+      inViewport = true
       createScene()
     }
 

--- a/theme/src/components/artwork/book-3d.spec.js
+++ b/theme/src/components/artwork/book-3d.spec.js
@@ -192,22 +192,24 @@ describe('Artwork/Book3D', () => {
     expect(mockScene.add).toHaveBeenCalledWith(mockMesh)
   })
 
-  it('destroys the scene when the book leaves the viewport', () => {
+  it('pauses WebGL when the book leaves the viewport without disposing the renderer', () => {
     render(<Book3D {...defaultProps} />)
     enterViewport()
     leaveViewport()
-    expect(mockRenderer.dispose).toHaveBeenCalled()
-    expect(mockGeometry.dispose).toHaveBeenCalled()
+    expect(mockRenderer.dispose).not.toHaveBeenCalled()
+    expect(mockGeometry.dispose).not.toHaveBeenCalled()
+    expect(mockRenderer.domElement.style.visibility).toBe('hidden')
   })
 
-  it('recreates the scene when the book re-enters after leaving', () => {
+  it('reuses the existing WebGL scene when the book re-enters after leaving', () => {
     render(<Book3D {...defaultProps} />)
     enterViewport()
     leaveViewport()
     jest.clearAllMocks()
-    mockRenderer.domElement = createMockCanvas()
     enterViewport()
-    expect(mockRenderer.setSize).toHaveBeenCalled()
+    expect(mockRenderer.dispose).not.toHaveBeenCalled()
+    expect(mockRenderer.setSize).not.toHaveBeenCalled()
+    expect(mockRenderer.domElement.style.visibility).toBe('visible')
   })
 
   it('sets up an IntersectionObserver on mount', () => {
@@ -646,13 +648,15 @@ describe('Artwork/Book3D', () => {
     expect(mockRenderer.setSize).toHaveBeenCalledTimes(2)
   })
 
-  it('does nothing in the resize callback when the scene has been destroyed', () => {
+  it('still applies resize when the book is off-screen (renderer kept alive)', () => {
     render(<Book3D {...defaultProps} />)
     enterViewport()
-    leaveViewport() // destroyScene — renderer = null
+    leaveViewport()
 
-    // Should not throw due to the !renderer guard (line 377)
-    expect(() => resizeCallback && resizeCallback([])).not.toThrow()
+    resizeCallback && resizeCallback([])
+
+    expect(mockCamera.updateProjectionMatrix).toHaveBeenCalled()
+    expect(mockRenderer.setSize).toHaveBeenCalled()
   })
 
   // ── Cleanup ────────────────────────────────────────────────────────────────

--- a/www.chrisvogt.me/package.json
+++ b/www.chrisvogt.me/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "www.chrisvogt.me",
-  "version": "1.16.0",
+  "version": "1.16.1",
   "license": "GPL",
   "scripts": {
     "build": "gatsby build",

--- a/www.chronogrove.com/package.json
+++ b/www.chronogrove.com/package.json
@@ -1,6 +1,6 @@
 {
   "name": "www.chronogrove.com",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Official demo site for gatsby-theme-chronogrove",
   "scripts": {
     "develop": "gatsby develop",


### PR DESCRIPTION
## Summary

Goodreads `Book3D` tiles were calling `renderer.dispose()` whenever they scrolled out of view, then allocating new WebGL renderers on the way back. That burst of context creation could exceed the browser WebGL limit and **revoke the dark-mode Color Bends** fixed background on the home page.

## Changes

- **`book-3d.js`**: On viewport exit, pause RAF, clear the intro timer, reset hover/intro motion to the resting pose, and hide the canvas (`visibility: hidden`). On re-enter, show the canvas and reuse the existing renderer. Full teardown still runs on unmount.
- **`book-3d.spec.js`**: Tests updated for pause/reuse instead of dispose/recreate.
- **Versions**: `gatsby-theme-chronogrove` **0.85.1**; `www.chrisvogt.me` **1.16.1**; `www.chronogrove.com` **1.3.1**.
- **`CHANGELOG.md`**: New **0.85.1** section.

## Testing

- `pnpm --filter gatsby-theme-chronogrove exec jest theme/src/components/artwork/book-3d.spec.js`
- Confirmed in local dev by reporter (scroll past Goodreads and back in dark mode).

Made with [Cursor](https://cursor.com)