### PR TITLE
fix(theme): cap Goodreads carousel WebGL to the active page (v0.85.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## 0.85.2
+
+### `gatsby-theme-chronogrove` — Goodreads carousel WebGL limits
+
+- **Bug fix**: The Goodreads carousel kept **every page** mounted for swipe layout, so each tile created a **`Book3D` / WebGL context**. That could exceed the browser context cap (**“Too many active WebGL contexts”**), trigger **context loss**, and break covers after pagination (and stress other canvases, e.g. the home background). **Non-active carousel pages** now use **`BookLink`** with **`flatCover`** (static `<img>` plus a title fallback on image error). Only the **current page** mounts **`Book3D`** (~10 contexts instead of dozens).
+- **Tests**: **`book-link.spec.js`** covers **`flatCover`**; **`recently-read-books`** pagination tests unchanged.
+- **Version**: **0.85.2**
+
+### `www.chrisvogt.me`
+
+- **Version**: **1.16.2** (tracks theme **0.85.2**).
+
+### `www.chronogrove.com` (demo)
+
+- **Version**: **1.3.2** (tracks theme **0.85.2**).
+
+### Files changed
+
+- `theme/package.json` (version **0.85.2**), `theme/src/components/widgets/goodreads/book-link.js`, `theme/src/components/widgets/goodreads/book-link.spec.js`, `theme/src/components/widgets/goodreads/recently-read-books.js`
+- `www.chrisvogt.me/package.json` (version **1.16.2**)
+- `www.chronogrove.com/package.json` (version **1.3.2**)
+- `CHANGELOG.md`
+
+---
+
 ## 0.85.1
 
 ### `gatsby-theme-chronogrove` — Goodreads 3D books and WebGL background

--- a/theme/package.json
+++ b/theme/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-theme-chronogrove",
   "description": "A personal website and digital garden theme for GatsbyJS.",
-  "version": "0.85.1",
+  "version": "0.85.2",
   "author": "Chris Vogt <mail@chrisvogt.me> (https://www.chrisvogt.me)",
   "main": "index.js",
   "license": "MIT",

--- a/theme/src/components/widgets/goodreads/book-link.js
+++ b/theme/src/components/widgets/goodreads/book-link.js
@@ -2,9 +2,18 @@
 import { jsx } from 'theme-ui'
 import { Card } from '@theme-ui/components'
 import { navigate as gatsbyNavigate } from 'gatsby'
+import { useEffect, useState } from 'react'
 import Book3D from '../../artwork/book-3d'
 
-const BookLink = ({ id, thumbnailURL, title, suppressNavigation = false, introDelay = 0 }) => {
+const BookLink = ({
+  id,
+  thumbnailURL,
+  title,
+  suppressNavigation = false,
+  introDelay = 0,
+  // When true, use a static image instead of WebGL (limits contexts: one carousel page worth of Book3D).
+  flatCover = false
+}) => {
   // Append compression/format hints for imgix CDN images
   const imageUrl = (() => {
     try {
@@ -15,6 +24,11 @@ const BookLink = ({ id, thumbnailURL, title, suppressNavigation = false, introDe
       return thumbnailURL
     }
   })()
+
+  const [flatImgFailed, setFlatImgFailed] = useState(false)
+  useEffect(() => {
+    setFlatImgFailed(false)
+  }, [imageUrl, flatCover])
 
   const handleClick = e => {
     e.preventDefault()
@@ -71,7 +85,58 @@ const BookLink = ({ id, thumbnailURL, title, suppressNavigation = false, introDe
           }
         }}
       >
-        <Book3D thumbnailURL={imageUrl} title={title} introDelay={introDelay} />
+        {flatCover ? (
+          <div sx={{ width: '100%', paddingBottom: '100%', position: 'relative' }}>
+            <div
+              data-testid='book-preview-flat'
+              role='img'
+              aria-label={title}
+              sx={{
+                position: 'absolute',
+                inset: 0,
+                borderRadius: 2,
+                overflow: 'hidden',
+                bg: 'muted',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center'
+              }}
+            >
+              {!flatImgFailed ? (
+                <img
+                  data-testid='book-preview-thumbnail'
+                  src={imageUrl}
+                  alt=''
+                  loading='lazy'
+                  decoding='async'
+                  onError={() => setFlatImgFailed(true)}
+                  sx={{
+                    position: 'absolute',
+                    inset: 0,
+                    width: '100%',
+                    height: '100%',
+                    objectFit: 'cover'
+                  }}
+                />
+              ) : (
+                <span
+                  sx={{
+                    p: 2,
+                    fontSize: 1,
+                    lineHeight: 'snug',
+                    textAlign: 'center',
+                    color: 'text',
+                    wordBreak: 'break-word'
+                  }}
+                >
+                  {title}
+                </span>
+              )}
+            </div>
+          </div>
+        ) : (
+          <Book3D thumbnailURL={imageUrl} title={title} introDelay={introDelay} />
+        )}
       </button>
     </Card>
   )

--- a/theme/src/components/widgets/goodreads/book-link.js
+++ b/theme/src/components/widgets/goodreads/book-link.js
@@ -25,9 +25,38 @@ const BookLink = ({
     }
   })()
 
-  const [flatImgFailed, setFlatImgFailed] = useState(false)
+  /** Flat cover only: probe URL off the DOM so the visible `<img>` needs no handlers (a11y lint). */
+  const [flatCoverMediaStatus, setFlatCoverMediaStatus] = useState('pending')
+
   useEffect(() => {
-    setFlatImgFailed(false)
+    if (!flatCover) {
+      setFlatCoverMediaStatus('pending')
+      return
+    }
+
+    if (!imageUrl) {
+      setFlatCoverMediaStatus('failed')
+      return
+    }
+
+    setFlatCoverMediaStatus('pending')
+    let cancelled = false
+    const probe = new window.Image()
+    const onLoad = () => {
+      if (!cancelled) setFlatCoverMediaStatus('ready')
+    }
+    const onErr = () => {
+      if (!cancelled) setFlatCoverMediaStatus('failed')
+    }
+    probe.addEventListener('load', onLoad)
+    probe.addEventListener('error', onErr)
+    probe.src = imageUrl
+
+    return () => {
+      cancelled = true
+      probe.removeEventListener('load', onLoad)
+      probe.removeEventListener('error', onErr)
+    }
   }, [imageUrl, flatCover])
 
   const handleClick = e => {
@@ -90,6 +119,7 @@ const BookLink = ({
             <div
               data-testid='book-preview-flat'
               role='img'
+              aria-busy={flatCoverMediaStatus === 'pending'}
               aria-label={title}
               sx={{
                 position: 'absolute',
@@ -102,23 +132,7 @@ const BookLink = ({
                 justifyContent: 'center'
               }}
             >
-              {!flatImgFailed ? (
-                <img
-                  data-testid='book-preview-thumbnail'
-                  src={imageUrl}
-                  alt=''
-                  loading='lazy'
-                  decoding='async'
-                  onError={() => setFlatImgFailed(true)}
-                  sx={{
-                    position: 'absolute',
-                    inset: 0,
-                    width: '100%',
-                    height: '100%',
-                    objectFit: 'cover'
-                  }}
-                />
-              ) : (
+              {flatCoverMediaStatus === 'failed' ? (
                 <span
                   sx={{
                     p: 2,
@@ -131,7 +145,22 @@ const BookLink = ({
                 >
                   {title}
                 </span>
-              )}
+              ) : flatCoverMediaStatus === 'ready' ? (
+                <img
+                  data-testid='book-preview-thumbnail'
+                  src={imageUrl}
+                  alt=''
+                  loading='lazy'
+                  decoding='async'
+                  sx={{
+                    position: 'absolute',
+                    inset: 0,
+                    width: '100%',
+                    height: '100%',
+                    objectFit: 'cover'
+                  }}
+                />
+              ) : null}
             </div>
           </div>
         ) : (

--- a/theme/src/components/widgets/goodreads/book-link.spec.js
+++ b/theme/src/components/widgets/goodreads/book-link.spec.js
@@ -1,9 +1,41 @@
 import React from 'react'
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import '@testing-library/jest-dom'
 import { navigate as gatsbyNavigate } from 'gatsby'
 
 import BookLink from './book-link'
+
+/** jsdom does not reliably complete `Image()` loads for remote URLs; the component probes with `Image()` before rendering `<img>`. */
+const OriginalImage = global.Image
+class MockImage {
+  constructor() {
+    this._onLoad = null
+    this._onErr = null
+  }
+
+  addEventListener(type, fn) {
+    if (type === 'load') this._onLoad = fn
+    if (type === 'error') this._onErr = fn
+  }
+
+  removeEventListener(type, fn) {
+    if (type === 'load' && this._onLoad === fn) this._onLoad = null
+    if (type === 'error' && this._onErr === fn) this._onErr = null
+  }
+
+  set src(value) {
+    this._src = value
+    queueMicrotask(() => {
+      const fail = !value || value === 'not-a-valid-url' || String(value).includes('__IMAGE_PROBE_ERROR__')
+      if (fail) this._onErr?.()
+      else this._onLoad?.()
+    })
+  }
+
+  get src() {
+    return this._src
+  }
+}
 
 // Mock gatsby's navigate function
 jest.mock('gatsby', () => ({
@@ -33,6 +65,11 @@ describe('Widget/Goodreads/BookLink', () => {
   beforeEach(() => {
     jest.clearAllMocks()
     jest.spyOn(console, 'log').mockImplementation(() => {})
+    global.Image = MockImage
+  })
+
+  afterEach(() => {
+    global.Image = OriginalImage
   })
 
   it('renders a book link with the correct attributes', () => {
@@ -89,18 +126,50 @@ describe('Widget/Goodreads/BookLink', () => {
     expect(screen.getByTestId('book-preview-3d')).toBeInTheDocument()
   })
 
-  it('renders a flat image preview when flatCover is true (no WebGL)', () => {
+  it('renders a flat image preview when flatCover is true (no WebGL)', async () => {
     render(<BookLink {...mockProps} flatCover />)
     expect(screen.queryByTestId('book-preview-3d')).not.toBeInTheDocument()
-    expect(screen.getByTestId('book-preview-thumbnail')).toHaveAttribute('src', 'https://example.com/book.jpg')
     expect(screen.getByTestId('book-preview-flat')).toHaveAttribute('aria-label', 'Test Book')
+    await waitFor(() => {
+      expect(screen.getByTestId('book-preview-thumbnail')).toHaveAttribute('src', 'https://example.com/book.jpg')
+    })
   })
 
-  it('shows the title when the flat cover image fails to load', () => {
-    render(<BookLink {...mockProps} flatCover />)
-    const img = screen.getByTestId('book-preview-thumbnail')
-    fireEvent.error(img)
-    expect(screen.queryByTestId('book-preview-thumbnail')).not.toBeInTheDocument()
+  it('shows the title when the flat cover image fails to load', async () => {
+    render(<BookLink {...mockProps} thumbnailURL='not-a-valid-url' flatCover />)
+    await waitFor(() => {
+      expect(screen.queryByTestId('book-preview-thumbnail')).not.toBeInTheDocument()
+      expect(screen.getByText('Test Book')).toBeInTheDocument()
+    })
+  })
+
+  it('shows the title when flatCover has no image URL', () => {
+    render(<BookLink {...mockProps} thumbnailURL='' flatCover />)
     expect(screen.getByText('Test Book')).toBeInTheDocument()
+    expect(screen.queryByTestId('book-preview-thumbnail')).not.toBeInTheDocument()
+  })
+
+  it('ignores flat-cover probe callbacks after unmount', () => {
+    jest.useFakeTimers()
+    global.Image = class DelayedMock {
+      constructor() {
+        this._onLoad = null
+      }
+
+      addEventListener(type, fn) {
+        if (type === 'load') this._onLoad = fn
+      }
+
+      removeEventListener() {}
+
+      set src(_value) {
+        setTimeout(() => this._onLoad?.(), 100)
+      }
+    }
+
+    const { unmount } = render(<BookLink {...mockProps} flatCover />)
+    unmount()
+    jest.advanceTimersByTime(200)
+    jest.useRealTimers()
   })
 })

--- a/theme/src/components/widgets/goodreads/book-link.spec.js
+++ b/theme/src/components/widgets/goodreads/book-link.spec.js
@@ -88,4 +88,11 @@ describe('Widget/Goodreads/BookLink', () => {
     render(<BookLink {...mockProps} introDelay={240} />)
     expect(screen.getByTestId('book-preview-3d')).toBeInTheDocument()
   })
+
+  it('renders a flat image preview when flatCover is true (no WebGL)', () => {
+    render(<BookLink {...mockProps} flatCover />)
+    expect(screen.queryByTestId('book-preview-3d')).not.toBeInTheDocument()
+    expect(screen.getByTestId('book-preview-thumbnail')).toHaveAttribute('src', 'https://example.com/book.jpg')
+    expect(screen.getByTestId('book-preview-flat')).toHaveAttribute('aria-label', 'Test Book')
+  })
 })

--- a/theme/src/components/widgets/goodreads/book-link.spec.js
+++ b/theme/src/components/widgets/goodreads/book-link.spec.js
@@ -95,4 +95,12 @@ describe('Widget/Goodreads/BookLink', () => {
     expect(screen.getByTestId('book-preview-thumbnail')).toHaveAttribute('src', 'https://example.com/book.jpg')
     expect(screen.getByTestId('book-preview-flat')).toHaveAttribute('aria-label', 'Test Book')
   })
+
+  it('shows the title when the flat cover image fails to load', () => {
+    render(<BookLink {...mockProps} flatCover />)
+    const img = screen.getByTestId('book-preview-thumbnail')
+    fireEvent.error(img)
+    expect(screen.queryByTestId('book-preview-thumbnail')).not.toBeInTheDocument()
+    expect(screen.getByText('Test Book')).toBeInTheDocument()
+  })
 })

--- a/theme/src/components/widgets/goodreads/recently-read-books.js
+++ b/theme/src/components/widgets/goodreads/recently-read-books.js
@@ -231,6 +231,7 @@ const RecentlyReadBooks = ({ books = [], isLoading }) => {
                         <BookLink
                           id={book.id}
                           key={book.id}
+                          flatCover={pageIndex !== currentPage - 1}
                           introDelay={bookIndex * 80}
                           suppressNavigation={isDragging || isTransitioning}
                           thumbnailURL={book.cdnMediaURL || book.thumbnail}

--- a/www.chrisvogt.me/package.json
+++ b/www.chrisvogt.me/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "www.chrisvogt.me",
-  "version": "1.16.1",
+  "version": "1.16.2",
   "license": "GPL",
   "scripts": {
     "build": "gatsby build",

--- a/www.chronogrove.com/package.json
+++ b/www.chronogrove.com/package.json
@@ -1,6 +1,6 @@
 {
   "name": "www.chronogrove.com",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Official demo site for gatsby-theme-chronogrove",
   "scripts": {
     "develop": "gatsby develop",


### PR DESCRIPTION
## Summary

The Goodreads carousel keeps every slide in the DOM for swipe layout, but each tile was mounting `Book3D` (a separate WebGL context). That could exceed the browser’s context limit, trigger **“Too many active WebGL contexts”** / **THREE.WebGLRenderer: Context Lost**, and break covers after pagination (and stress other canvases, e.g. the home background).

## Changes

- **Non-active carousel pages** use `BookLink` with `flatCover`: a static `<img>` (same imgix URL rules) plus a **title fallback** when the image fails (e.g. 404).
- **Only the current page** mounts `Book3D` (~10 WebGL contexts instead of dozens).
- **Versions**: `gatsby-theme-chronogrove` **0.85.2**; `www.chrisvogt.me` **1.16.2**; `www.chronogrove.com` **1.3.2**.
- **CHANGELOG**: new **0.85.2** section.

## Testing

- `pnpm --filter gatsby-theme-chronogrove exec jest theme/src/components/widgets/goodreads/book-link.spec.js theme/src/components/widgets/goodreads/recently-read-books.spec.js`

Made with [Cursor](https://cursor.com)