### PR TITLE
fix(theme): Steam empty recently-played + GitHub contribution graph (v0.85.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## 0.85.3
+
+### `gatsby-theme-chronogrove` — Steam widget & GitHub contribution graph
+
+- **Steam**: The **Recently-Played Games** block (heading, copy, and grid) is shown only while **loading** or when the API returns **at least one** recently played game. If the last-two-weeks list is empty after load, the section is omitted so the widget does not show a bare headline.
+- **GitHub contribution graph**: Uses an explicit **4px** gap constant for the heatmap, skeleton, legend, and day-label row math so month labels line up with cells (Theme UI **`gap: 1`** is not guaranteed to be 4px). **Month labels** match GitHub when the year view does not start on the 1st: skip the cramped first partial month and omit the trailing partial month. **Tests**: **`contribution-graph.spec.js`** covers partial-range month labeling.
+- **Version**: **0.85.3**
+
+### `www.chrisvogt.me`
+
+- **Version**: **1.16.3** (tracks theme **0.85.3**).
+
+### `www.chronogrove.com` (demo)
+
+- **Version**: **1.3.3** (tracks theme **0.85.3**).
+
+### Files changed
+
+- `theme/package.json` (version **0.85.3**), `theme/src/components/widgets/steam/steam-widget.js`, `theme/src/components/widgets/steam/README.md`, `theme/src/components/widgets/steam/__snapshots__/steam-widget.spec.js.snap`, `theme/src/components/widgets/github/contribution-graph.js`, `theme/src/components/widgets/github/contribution-graph.spec.js`, `theme/src/components/widgets/github/__snapshots__/contribution-graph.spec.js.snap`, `theme/src/components/widgets/github/__snapshots__/github-widget.spec.js.snap`
+- `www.chrisvogt.me/package.json` (version **1.16.3**)
+- `www.chronogrove.com/package.json` (version **1.3.3**)
+- `CHANGELOG.md`
+
+---
+
 ## 0.85.2
 
 ### `gatsby-theme-chronogrove` — Goodreads carousel WebGL limits

--- a/theme/package.json
+++ b/theme/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-theme-chronogrove",
   "description": "A personal website and digital garden theme for GatsbyJS.",
-  "version": "0.85.2",
+  "version": "0.85.3",
   "author": "Chris Vogt <mail@chrisvogt.me> (https://www.chrisvogt.me)",
   "main": "index.js",
   "license": "MIT",

--- a/theme/src/components/widgets/github/__snapshots__/contribution-graph.spec.js.snap
+++ b/theme/src/components/widgets/github/__snapshots__/contribution-graph.spec.js.snap
@@ -19,7 +19,7 @@ exports[`ContributionGraph Component matches the empty state snapshot 1`] = `
         Loading contribution data...
       </p>
       <div
-        class="css-1oal0qm"
+        class="css-8j9u6e"
       >
         <div
           class="css-1oe1md6"
@@ -1141,7 +1141,7 @@ exports[`ContributionGraph Component matches the loading state snapshot 1`] = `
         Loading contribution data...
       </p>
       <div
-        class="css-1oal0qm"
+        class="css-8j9u6e"
       >
         <div
           class="css-1oe1md6"
@@ -2294,10 +2294,10 @@ exports[`ContributionGraph Component matches the successful state snapshot 1`] =
             style="overflow-x: auto; overflow-y: visible; min-width: 0; max-width: 100%; flex: 1 1 0%; -webkit-overflow-scrolling: touch; contain: inline-size;"
           >
             <div
-              class="css-1zugrk"
+              class="css-1n4gjdj"
             />
             <div
-              class="css-xn8io8"
+              class="css-j6uk15"
             >
               <div
                 class="cell-visible css-1j55t5o"
@@ -2332,7 +2332,7 @@ exports[`ContributionGraph Component matches the successful state snapshot 1`] =
         </div>
       </div>
       <div
-        class="css-1ts1diq"
+        class="css-gasiwb"
       >
         <div
           class="css-1yz7e9k"
@@ -2341,7 +2341,7 @@ exports[`ContributionGraph Component matches the successful state snapshot 1`] =
           Less
         </div>
         <div
-          class="css-1amotyw"
+          class="css-zi44v3"
         >
           <div
             class="css-mfiemg"

--- a/theme/src/components/widgets/github/__snapshots__/github-widget.spec.js.snap
+++ b/theme/src/components/widgets/github/__snapshots__/github-widget.spec.js.snap
@@ -479,7 +479,7 @@ exports[`GitHub Widget matches the error state snapshot 1`] = `
           Loading contribution data...
         </p>
         <div
-          class="css-1oal0qm"
+          class="css-8j9u6e"
         >
           <div
             class="css-1oe1md6"
@@ -1785,7 +1785,7 @@ exports[`GitHub Widget matches the loaded state snapshot 1`] = `
           Loading contribution data...
         </p>
         <div
-          class="css-1oal0qm"
+          class="css-8j9u6e"
         >
           <div
             class="css-1oe1md6"
@@ -3362,7 +3362,7 @@ exports[`GitHub Widget matches the loading state snapshot 1`] = `
           Loading contribution data...
         </p>
         <div
-          class="css-1oal0qm"
+          class="css-8j9u6e"
         >
           <div
             class="css-1oe1md6"

--- a/theme/src/components/widgets/github/contribution-graph.js
+++ b/theme/src/components/widgets/github/contribution-graph.js
@@ -6,6 +6,19 @@ import React, { useMemo, useRef, useEffect, useState } from 'react'
 import { createPortal } from 'react-dom'
 import isDarkMode from '../../../helpers/isDarkMode'
 
+/** Must match grid / legend gap so month labels and row math align with cells (Theme UI `gap: 1` is not guaranteed to be 4px). */
+const CONTRIBUTION_CELL_GAP_PX = 4
+
+function earliestContributionDate(weeks) {
+  let min = null
+  for (const week of weeks) {
+    for (const day of week.contributionDays) {
+      if (!min || day.date < min) min = day.date
+    }
+  }
+  return min
+}
+
 /**
  * ContributionGraph Component
  *
@@ -59,6 +72,20 @@ const ContributionGraph = ({ isLoading, contributionCalendar }) => {
 
     return months
   }, [contributionCalendar])
+
+  // GitHub omits the first month headline when the range doesn't start on the 1st (avoids a cramped first label).
+  // Still omit the last month (partial final month), matching GitHub's right edge.
+  const monthLabelsForDisplay = useMemo(() => {
+    if (!monthLabels.length || !contributionCalendar?.weeks) return []
+
+    const earliest = earliestContributionDate(contributionCalendar.weeks)
+    if (!earliest) return monthLabels.slice(0, -1)
+
+    const dayOfMonth = Number(earliest.slice(8, 10))
+    const skipFirstPartialMonth = dayOfMonth !== 1
+    const withoutEnds = skipFirstPartialMonth ? monthLabels.slice(1) : monthLabels
+    return withoutEnds.length ? withoutEnds.slice(0, -1) : []
+  }, [monthLabels, contributionCalendar?.weeks])
 
   // Calculate responsive cell size
   const [cellSize, setCellSize] = useState(10)
@@ -120,7 +147,7 @@ const ContributionGraph = ({ isLoading, contributionCalendar }) => {
     const updateCellSize = () => {
       const containerWidth = containerRef.current?.offsetWidth || 800
       const weeksCount = contributionCalendar.weeks.length
-      const gap = 4 // Gap between cells in pixels
+      const gap = CONTRIBUTION_CELL_GAP_PX
       const availableWidth = containerWidth - 16 // Small padding for scrollbar/margins
       const calculatedSize = Math.floor((availableWidth - (weeksCount - 1) * gap) / weeksCount)
 
@@ -152,7 +179,7 @@ const ContributionGraph = ({ isLoading, contributionCalendar }) => {
             sx={{
               display: 'grid',
               gridTemplateColumns: 'repeat(53, 1fr)',
-              gap: 1,
+              gap: `${CONTRIBUTION_CELL_GAP_PX}px`,
               opacity: 0.5,
               p: 3
             }}
@@ -237,8 +264,8 @@ const ContributionGraph = ({ isLoading, contributionCalendar }) => {
                 color: 'textMuted',
                 width: '40px',
                 flexShrink: 0,
-                pt: '24px', // Offset for month labels height (20px) + gap (4px)
-                height: `${7 * cellSize + 6 * 4}px` // Align container height with grid rows
+                pt: `${20 + CONTRIBUTION_CELL_GAP_PX}px`, // Month label row (20px) + gap under labels
+                height: `${7 * cellSize + 6 * CONTRIBUTION_CELL_GAP_PX}px` // Align with grid rows
               }}
             >
               {[2, 4, 6].map(dayOfWeek => (
@@ -246,7 +273,7 @@ const ContributionGraph = ({ isLoading, contributionCalendar }) => {
                   key={dayOfWeek}
                   sx={{
                     position: 'absolute',
-                    top: `${dayOfWeek * (cellSize + 4)}px`,
+                    top: `${dayOfWeek * (cellSize + CONTRIBUTION_CELL_GAP_PX)}px`,
                     height: `${cellSize}px`,
                     lineHeight: `${cellSize}px`,
                     textAlign: 'right',
@@ -286,16 +313,16 @@ const ContributionGraph = ({ isLoading, contributionCalendar }) => {
                 sx={{
                   position: 'relative',
                   height: '20px',
-                  mb: 1,
+                  mb: `${CONTRIBUTION_CELL_GAP_PX}px`,
                   minWidth: 0
                 }}
               >
-                {monthLabels.slice(0, -1).map((month, idx) => (
+                {monthLabelsForDisplay.map((month, idx) => (
                   <Box
                     key={`${month.date}-${idx}`}
                     sx={{
                       position: 'absolute',
-                      left: `${month.weekIndex * (cellSize + 4)}px`,
+                      left: `${month.weekIndex * (cellSize + CONTRIBUTION_CELL_GAP_PX)}px`,
                       fontSize: 0,
                       color: 'textMuted',
                       fontWeight: 'normal',
@@ -313,7 +340,7 @@ const ContributionGraph = ({ isLoading, contributionCalendar }) => {
                   display: 'grid',
                   gridTemplateColumns: `repeat(${weeksCount}, ${cellSize}px)`,
                   gridTemplateRows: `repeat(7, ${cellSize}px)`,
-                  gap: 1,
+                  gap: `${CONTRIBUTION_CELL_GAP_PX}px`,
                   minWidth: 'max-content',
                   alignItems: 'start'
                 }}
@@ -426,7 +453,7 @@ const ContributionGraph = ({ isLoading, contributionCalendar }) => {
           sx={{
             display: 'flex',
             alignItems: 'center',
-            gap: 1,
+            gap: `${CONTRIBUTION_CELL_GAP_PX}px`,
             mt: 3,
             ml: '40px', // Match day labels width
             fontSize: 0,
@@ -437,7 +464,7 @@ const ContributionGraph = ({ isLoading, contributionCalendar }) => {
           <Box
             sx={{
               display: 'flex',
-              gap: 1
+              gap: `${CONTRIBUTION_CELL_GAP_PX}px`
             }}
           >
             {[0, 1, 2, 3, 4].map(level => (

--- a/theme/src/components/widgets/github/contribution-graph.spec.js
+++ b/theme/src/components/widgets/github/contribution-graph.spec.js
@@ -163,6 +163,31 @@ describe('ContributionGraph Component', () => {
     expect(document.body.querySelector('[role="tooltip"]')).not.toBeInTheDocument()
   })
 
+  it('omits the first month label when the range does not start on the 1st (GitHub-style)', () => {
+    const day = (date, n) => ({
+      date,
+      contributionCount: n,
+      color: n > 0 ? '#9be9a8' : '#ebedf0'
+    })
+    // One contribution day per week (Saturdays): starts 2025-04-26 so April is partial at the left edge
+    const weeks = Array.from({ length: 12 }, (_, i) => {
+      const d = new Date(2025, 3, 26 + i * 7)
+      const yyyy = d.getFullYear()
+      const mm = String(d.getMonth() + 1).padStart(2, '0')
+      const dd = String(d.getDate()).padStart(2, '0')
+      return { contributionDays: [day(`${yyyy}-${mm}-${dd}`, 0)] }
+    })
+
+    render(
+      <TestProviderWithState>
+        <ContributionGraph isLoading={false} contributionCalendar={{ totalContributions: 0, weeks }} />
+      </TestProviderWithState>
+    )
+
+    expect(screen.queryByText('Apr')).not.toBeInTheDocument()
+    expect(screen.getByText('May')).toBeInTheDocument()
+  })
+
   it('memo prevents re-render when props are unchanged', () => {
     const { rerender } = render(
       <TestProviderWithState>

--- a/theme/src/components/widgets/steam/README.md
+++ b/theme/src/components/widgets/steam/README.md
@@ -13,7 +13,7 @@ The Steam widget displays information from a Steam profile, including recently p
 
 ### Recently-Played Games Section
 
-- Shows games played in the last two weeks
+- Rendered only when data is still loading or the API returns at least one game from the last two weeks (no empty headline when there is nothing to show)
 - Displays game cards with headers and play time
 - Grid layout for responsive design
 
@@ -29,7 +29,7 @@ Main widget component that orchestrates the display of Steam data.
 
 - Fetches Steam data from configured data source
 - Displays profile metrics
-- Shows both owned games table and recently played games
+- Shows the leaderboard (owned games) and recently played games when present
 - Handles loading states
 
 ### OwnedGamesTable

--- a/theme/src/components/widgets/steam/__snapshots__/steam-widget.spec.js.snap
+++ b/theme/src/components/widgets/steam/__snapshots__/steam-widget.spec.js.snap
@@ -541,23 +541,6 @@ exports[`SteamWidget renders error state (hasFatalError) 1`] = `
       <h3
         class="css-9nh3l5"
       >
-        Recently-Played Games
-      </h3>
-    </div>
-    <p
-      class="css-zxnhh7"
-    >
-      Games I've played in the last two weeks.
-    </p>
-    <div
-      class="css-1jvl2a0"
-    />
-    <div
-      class="css-5abbi3"
-    >
-      <h3
-        class="css-9nh3l5"
-      >
         Leaderboard
       </h3>
     </div>
@@ -1072,23 +1055,6 @@ exports[`SteamWidget renders with empty recentlyPlayedGames and ownedGames 1`] =
     >
       Steam
     </div>
-    <div
-      class="css-5abbi3"
-    >
-      <h3
-        class="css-9nh3l5"
-      >
-        Recently-Played Games
-      </h3>
-    </div>
-    <p
-      class="css-zxnhh7"
-    >
-      Games I've played in the last two weeks.
-    </p>
-    <div
-      class="css-1jvl2a0"
-    />
     <div
       class="css-5abbi3"
     >

--- a/theme/src/components/widgets/steam/steam-widget.js
+++ b/theme/src/components/widgets/steam/steam-widget.js
@@ -39,6 +39,7 @@ const SteamWidget = React.memo(() => {
   const profileDisplayName = data?.profile?.displayName
   const profileURL = data?.profile?.profileURL
   const recentlyPlayedGames = data?.collections?.recentlyPlayedGames || []
+  const showRecentlyPlayedSection = isLoading || recentlyPlayedGames.length > 0
 
   const callToAction = (
     <CallToAction title={`${profileDisplayName} on Steam`} url={profileURL} isLoading={isLoading}>
@@ -53,52 +54,56 @@ const SteamWidget = React.memo(() => {
         Steam
       </WidgetHeader>
 
-      <div sx={{ display: 'flex', flex: 1, alignItems: 'center', mb: 3 }}>
-        <Heading as='h3' sx={{ fontSize: [3, 4] }}>
-          Recently-Played Games
-        </Heading>
-      </div>
+      {showRecentlyPlayedSection ? (
+        <>
+          <div sx={{ display: 'flex', flex: 1, alignItems: 'center', mb: 3 }}>
+            <Heading as='h3' sx={{ fontSize: [3, 4] }}>
+              Recently-Played Games
+            </Heading>
+          </div>
 
-      <Themed.p sx={{ mb: 4 }}>Games I've played in the last two weeks.</Themed.p>
+          <Themed.p sx={{ mb: 4 }}>Games I've played in the last two weeks.</Themed.p>
 
-      <div
-        sx={{
-          display: 'grid',
-          gridGap: [3, 2, 2, 3],
-          gridTemplateColumns: ['repeat(2, 1fr)', 'repeat(3, 1fr)', 'repeat(4, 1fr)'],
-          mb: 4
-        }}
-      >
-        {isLoading
-          ? Array.from({ length: RECENTLY_PLAYED_PLACEHOLDER_COUNT }).map((_, i) => (
-              <div
-                key={i}
-                aria-hidden
-                sx={{
-                  variant: 'styles.InstagramItem',
-                  borderRadius: '8px',
-                  boxShadow: 'md',
-                  overflow: 'hidden'
-                }}
-              >
-                <div className='show-loading-animation' style={{ width: '100%', height: '200px' }}>
-                  <RectShape
-                    color={darkModeActive ? '#3a3a4a' : '#efefef'}
-                    style={{ width: '100%', height: '200px', borderRadius: '8px' }}
+          <div
+            sx={{
+              display: 'grid',
+              gridGap: [3, 2, 2, 3],
+              gridTemplateColumns: ['repeat(2, 1fr)', 'repeat(3, 1fr)', 'repeat(4, 1fr)'],
+              mb: 4
+            }}
+          >
+            {isLoading
+              ? Array.from({ length: RECENTLY_PLAYED_PLACEHOLDER_COUNT }).map((_, i) => (
+                  <div
+                    key={i}
+                    aria-hidden
+                    sx={{
+                      variant: 'styles.InstagramItem',
+                      borderRadius: '8px',
+                      boxShadow: 'md',
+                      overflow: 'hidden'
+                    }}
+                  >
+                    <div className='show-loading-animation' style={{ width: '100%', height: '200px' }}>
+                      <RectShape
+                        color={darkModeActive ? '#3a3a4a' : '#efefef'}
+                        style={{ width: '100%', height: '200px', borderRadius: '8px' }}
+                      />
+                    </div>
+                    <div sx={{ height: '72px', p: 3 }} />
+                  </div>
+                ))
+              : recentlyPlayedGames.map(game => (
+                  <SteamGameCard
+                    key={game.id}
+                    game={game}
+                    showRank={false}
+                    subtitle={getTimeSpent(game.playTime2Weeks * 60 * 1000)}
                   />
-                </div>
-                <div sx={{ height: '72px', p: 3 }} />
-              </div>
-            ))
-          : recentlyPlayedGames.map(game => (
-              <SteamGameCard
-                key={game.id}
-                game={game}
-                showRank={false}
-                subtitle={getTimeSpent(game.playTime2Weeks * 60 * 1000)}
-              />
-            ))}
-      </div>
+                ))}
+          </div>
+        </>
+      ) : null}
 
       <div sx={{ display: 'flex', flex: 1, alignItems: 'center', mb: 3 }}>
         <Heading as='h3' sx={{ fontSize: [3, 4] }}>

--- a/www.chrisvogt.me/package.json
+++ b/www.chrisvogt.me/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "www.chrisvogt.me",
-  "version": "1.16.2",
+  "version": "1.16.3",
   "license": "GPL",
   "scripts": {
     "build": "gatsby build",

--- a/www.chronogrove.com/package.json
+++ b/www.chronogrove.com/package.json
@@ -1,6 +1,6 @@
 {
   "name": "www.chronogrove.com",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "Official demo site for gatsby-theme-chronogrove",
   "scripts": {
     "develop": "gatsby develop",


### PR DESCRIPTION
## Summary

Releases **gatsby-theme-chronogrove v0.85.3** (www.chrisvogt.me **1.16.3**, demo **1.3.3**).

### Steam widget
- Hide the **Recently-Played Games** block (heading, copy, grid) when data has loaded and the last-two-weeks list is **empty**, so the widget is not just a headline.
- Still show the section (with skeletons) while **loading**.

### GitHub contribution graph
- Use an explicit **4px** gap constant everywhere the grid spacing matters so **month labels align** with cells (Theme UI `gap: 1` is not guaranteed to be 4px).
- **Month labels** follow GitHub when the year range does not start on the 1st: omit the cramped first partial month and the trailing partial month.
- Add a **regression test** for partial-start ranges; update snapshots.

### Changelog
- See `CHANGELOG.md` § **0.85.3** for the full file list.

Made with [Cursor](https://cursor.com)