### PR TITLE
refactor(theme): import @chronogrove/ui/theme internally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## 0.85.5
+
+### `gatsby-theme-chronogrove` — Direct `@chronogrove/ui/theme` imports ([Issue #569](https://github.com/chrisvogt/gatsby-theme-chronogrove/issues/569))
+
+- **Refactor**: Theme tests, **`testUtils`**, **`media-item-grid`**, and related specs import the design tokens from **`@chronogrove/ui/theme`** instead of the **`src/gatsby-plugin-theme-ui`** shim paths. The shim files remain for Gatsby theme shadowing and backward compatibility.
+- **Version**: **0.85.5**
+
+### `www.chrisvogt.me`
+
+- **Version**: **1.16.5** (tracks theme **0.85.5**).
+
+### `www.chronogrove.com` (demo)
+
+- **Version**: **1.3.5** (tracks theme **0.85.5**).
+
+### Files changed
+
+- `theme/package.json` (version **0.85.5**), `theme/src/testUtils.js`, `theme/src/components/widgets/spotify/media-item-grid.js`, `theme/src/components/category.spec.js`, `theme/src/components/animated-page-background.spec.js`, `theme/src/components/home-navigation.spec.js`, `theme/src/shortcodes/Note.spec.js`, `theme/src/components/widgets/spotify/playlists.spec.js`, `theme/src/components/widgets/spotify/top-tracks.spec.js`, `theme/src/components/widgets/steam/play-time-chart.spec.js`, `theme/src/components/widgets/steam/steam-game-card.spec.js`
+- `www.chrisvogt.me/package.json` (version **1.16.5**), `www.chronogrove.com/package.json` (version **1.3.5**)
+- `CHANGELOG.md`
+
+---
+
 ## 0.85.4
 
 ### `@chronogrove/ui` — `ThumbnailStrip`, `ImageThumbnails`, Next showcase helpers ([Issue #566](https://github.com/chrisvogt/gatsby-theme-chronogrove/issues/566))

--- a/theme/package.json
+++ b/theme/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-theme-chronogrove",
   "description": "A personal website and digital garden theme for GatsbyJS.",
-  "version": "0.85.4",
+  "version": "0.85.5",
   "author": "Chris Vogt <mail@chrisvogt.me> (https://www.chrisvogt.me)",
   "main": "index.js",
   "license": "MIT",

--- a/theme/src/components/animated-page-background.spec.js
+++ b/theme/src/components/animated-page-background.spec.js
@@ -2,7 +2,7 @@ import React from 'react'
 import { render, cleanup, act } from '@testing-library/react'
 import { ThemeUIProvider } from 'theme-ui'
 import AnimatedPageBackground from './animated-page-background'
-import theme from '../gatsby-plugin-theme-ui/theme'
+import theme from '@chronogrove/ui/theme'
 
 // Store original hooks
 let mockColorMode = 'default'

--- a/theme/src/components/category.spec.js
+++ b/theme/src/components/category.spec.js
@@ -4,7 +4,7 @@ import '@testing-library/jest-dom'
 import { ThemeUIProvider } from 'theme-ui'
 
 import Category from './category'
-import theme from '../gatsby-plugin-theme-ui/theme'
+import theme from '@chronogrove/ui/theme'
 
 const renderWithTheme = ui => render(<ThemeUIProvider theme={theme}>{ui}</ThemeUIProvider>)
 

--- a/theme/src/components/home-navigation.spec.js
+++ b/theme/src/components/home-navigation.spec.js
@@ -708,7 +708,7 @@ describe('HomeNavigation', () => {
       // Theme UI warns when initialColorModeName matches a `colors.modes` key; we only need dark styles for this assertion.
       const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
       try {
-        const theme = require('../gatsby-plugin-theme-ui/theme').default
+        const theme = require('@chronogrove/ui/theme').default
         const darkTheme = {
           ...theme,
           config: {

--- a/theme/src/components/widgets/spotify/media-item-grid.js
+++ b/theme/src/components/widgets/spotify/media-item-grid.js
@@ -6,7 +6,7 @@ import { RectShape } from 'react-placeholder/lib/placeholders'
 import { useState } from 'react'
 import isDarkMode from '../../../helpers/isDarkMode'
 
-import { glassmorhismPanel } from '../../../gatsby-plugin-theme-ui/theme'
+import { glassmorhismPanel } from '@chronogrove/ui/theme'
 
 const MediaItemGrid = ({ isLoading, items = [], onTrackClick }) => {
   const { colorMode } = useThemeUI()

--- a/theme/src/components/widgets/spotify/playlists.spec.js
+++ b/theme/src/components/widgets/spotify/playlists.spec.js
@@ -7,7 +7,7 @@ import spotifyResponseFixture from '../../../../__mocks__/spotify.mock.json'
 import { TestProviderWithState } from '../../../testUtils'
 import { useAudioPlayerStore, resetAudioPlayerStore } from '../../../stores/audio-player-store'
 import { ThemeUIProvider } from 'theme-ui'
-import theme from '../../../gatsby-plugin-theme-ui/theme'
+import theme from '@chronogrove/ui/theme'
 
 jest.mock('./media-item-grid', () => jest.fn(() => <div data-testid='media-item-grid' />))
 

--- a/theme/src/components/widgets/spotify/top-tracks.spec.js
+++ b/theme/src/components/widgets/spotify/top-tracks.spec.js
@@ -7,7 +7,7 @@ import TopTracks from './top-tracks'
 import { TestProviderWithState } from '../../../testUtils'
 import { useAudioPlayerStore, resetAudioPlayerStore } from '../../../stores/audio-player-store'
 import { ThemeUIProvider } from 'theme-ui'
-import theme from '../../../gatsby-plugin-theme-ui/theme'
+import theme from '@chronogrove/ui/theme'
 
 jest.mock('./media-item-grid', () => jest.fn(() => <div data-testid='media-item-grid' />))
 import MediaItemGrid from './media-item-grid'

--- a/theme/src/components/widgets/steam/play-time-chart.spec.js
+++ b/theme/src/components/widgets/steam/play-time-chart.spec.js
@@ -2,7 +2,7 @@ import React from 'react'
 import { render, fireEvent } from '@testing-library/react'
 import '@testing-library/jest-dom'
 import { ThemeUIProvider } from 'theme-ui'
-import theme from '../../../gatsby-plugin-theme-ui'
+import theme from '@chronogrove/ui/theme'
 import PlayTimeChart from './play-time-chart'
 
 const renderWithTheme = (component, customTheme = null) => {

--- a/theme/src/components/widgets/steam/steam-game-card.spec.js
+++ b/theme/src/components/widgets/steam/steam-game-card.spec.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { render, fireEvent } from '@testing-library/react'
 import { ThemeUIProvider } from 'theme-ui'
-import theme from '../../../gatsby-plugin-theme-ui'
+import theme from '@chronogrove/ui/theme'
 import SteamGameCard from './steam-game-card'
 
 // Mock LazyLoad component

--- a/theme/src/shortcodes/Note.spec.js
+++ b/theme/src/shortcodes/Note.spec.js
@@ -2,7 +2,7 @@ import React from 'react'
 import { render, screen } from '@testing-library/react'
 import '@testing-library/jest-dom'
 import { ThemeUIProvider } from 'theme-ui'
-import theme from '../gatsby-plugin-theme-ui'
+import theme from '@chronogrove/ui/theme'
 
 // Mock useColorMode to control light/dark mode
 const mockUseColorMode = jest.fn()

--- a/theme/src/testUtils.js
+++ b/theme/src/testUtils.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { ThemeUIProvider } from 'theme-ui'
-import theme from './gatsby-plugin-theme-ui'
+import theme from '@chronogrove/ui/theme'
 
 export { resetAudioPlayerStore } from './stores/audio-player-store'
 

--- a/www.chrisvogt.me/package.json
+++ b/www.chrisvogt.me/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "www.chrisvogt.me",
-  "version": "1.16.4",
+  "version": "1.16.5",
   "license": "GPL",
   "scripts": {
     "build": "gatsby build",

--- a/www.chronogrove.com/package.json
+++ b/www.chronogrove.com/package.json
@@ -1,6 +1,6 @@
 {
   "name": "www.chronogrove.com",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "description": "Official demo site for gatsby-theme-chronogrove",
   "scripts": {
     "develop": "gatsby develop",


### PR DESCRIPTION
## Summary

Theme internals (including Jest `testUtils`, `media-item-grid`, and affected specs) now import design tokens from `@chronogrove/ui/theme` instead of relative paths under `src/gatsby-plugin-theme-ui`. The shim files (`theme.js` / `index.js`) stay in place for Gatsby [theme shadowing](https://www.gatsbyjs.com/docs/how-to/plugins-and-themes/theme-shadowing/).

## Versions

- `gatsby-theme-chronogrove` **0.85.5**
- `www.chrisvogt.me` **1.16.5**, `www.chronogrove.com` **1.3.5** (track theme)

## Issue

Refs https://github.com/chrisvogt/gatsby-theme-chronogrove/issues/569

**Closing #569:** This PR covers the *normalize internal imports to `@chronogrove`* slice of that issue. The issue text also mentions *remove or shrink* the `gatsby-plugin-theme-ui` shims, which is **not** done here (by design, for shadowing). Recommend **leaving #569 open** until shim removal is scoped and shipped, **or** closing it manually after merge with a short comment and a follow-up issue for any remaining shim work.

Made with [Cursor](https://cursor.com)