### PR TITLE
Extract shared page layouts into @chronogrove/ui (0.83.1) / theme 0.85.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,46 @@
 # Changelog
 
+## 0.85.6
+
+### `@chronogrove/ui` — Shared page layouts (article column, home dashboard, page shell)
+
+- **New subpaths**: `@chronogrove/ui/article-column-container` (`articleColumnContainerSx`, `ArticleColumnContainer`), `@chronogrove/ui/home-dashboard-layout` (`HomeDashboardGrid`, home dashboard `sx` tokens), `@chronogrove/ui/page-shell-layout` (`ChronogrovePageShell` — skip link, optional header/footer slots, main landmark or bare children).
+- **Tests**: unit specs for the new modules; coverage thresholds unchanged.
+- **Version**: **0.83.1**
+
+### `gatsby-theme-chronogrove`
+
+- **Layout**: `layout.js` composes **`ChronogrovePageShell`** from **`@chronogrove/ui/page-shell-layout`** (nav, footer, audio bar padding unchanged).
+- **Home**: `templates/home.js` uses **`HomeDashboardGrid`** and shared home layout tokens from **`@chronogrove/ui/home-dashboard-layout`**.
+- **Constants**: `constants/article-column-container-sx.js` re-exports **`articleColumnContainerSx`** from **`@chronogrove/ui/article-column-container`** for theme shadowing.
+- **Tests**: `layout.spec.js` snapshots updated for the shell’s `<main>` markup.
+- **Version**: **0.85.6**
+
+### `chronogrove-next` (example)
+
+- **`app/home-showcase.jsx`**: Uses the same **`@chronogrove/ui/home-dashboard-layout`** primitives as the Gatsby home template for the dashboard-style grid and main shell tokens.
+
+### `www.chrisvogt.me`
+
+- **About**: `articleColumnContainerSx` from **`gatsby-theme-chronogrove/src/constants/article-column-container-sx`** instead of duplicating container `sx`.
+- **Version**: **1.16.6** (tracks theme **0.85.6**).
+
+### `www.chronogrove.com` (demo)
+
+- **About**: Same **`articleColumnContainerSx`** import path; **`about.spec.js`** mocks the constants module for Jest.
+- **Version**: **1.3.6** (tracks theme **0.85.6**).
+
+### Files changed
+
+- `packages/ui/package.json` (version **0.83.1**, new **`exports`**), `packages/ui/src/article-column-container.js`, `packages/ui/src/article-column-container.spec.js`, `packages/ui/src/home-dashboard-layout.js`, `packages/ui/src/home-dashboard-layout.spec.js`, `packages/ui/src/page-shell-layout.js`, `packages/ui/src/page-shell-layout.spec.js`
+- `theme/package.json` (version **0.85.6**), `theme/src/components/layout.js`, `theme/src/templates/home.js`, `theme/src/constants/article-column-container-sx.js`, `theme/src/components/__snapshots__/layout.spec.js.snap`
+- `examples/chronogrove-next/app/home-showcase.jsx`
+- `www.chrisvogt.me/package.json` (version **1.16.6**), `www.chrisvogt.me/src/pages/about.js`
+- `www.chronogrove.com/package.json` (version **1.3.6**), `www.chronogrove.com/src/pages/about.js`, `www.chronogrove.com/src/pages/about.spec.js`
+- `CHANGELOG.md`
+
+---
+
 ## 0.85.5
 
 ### `gatsby-theme-chronogrove` — Direct `@chronogrove/ui/theme` imports ([Issue #569](https://github.com/chrisvogt/gatsby-theme-chronogrove/issues/569))

--- a/examples/chronogrove-next/app/home-showcase.jsx
+++ b/examples/chronogrove-next/app/home-showcase.jsx
@@ -30,6 +30,12 @@ import WidgetHeader from '@chronogrove/ui/widget-header'
 import { WidgetCallToAction } from '@chronogrove/ui/widget-call-to-action'
 import ThumbnailStrip from '@chronogrove/ui/thumbnail-strip'
 import ImageThumbnails from '@chronogrove/ui/image-thumbnails'
+import {
+  HomeDashboardGrid,
+  homeDashboardMainInnerMaxWidthSx,
+  homeDashboardMainShellSx,
+  homeDashboardPageOuterSx
+} from '@chronogrove/ui/home-dashboard-layout'
 
 /** Stable demo assets for thumbnail components (no Cloudinary; pass-through `optimizeSrc` in the UI package). */
 const DEMO_THUMB_IMAGES = [
@@ -73,22 +79,6 @@ const demoLabelSx = {
   color: 'text',
   mb: 2,
   display: 'block'
-}
-
-const homeGridColumns = [
-  null,
-  null,
-  'minmax(200px, 0.375fr) minmax(0, 1.625fr)',
-  'minmax(200px, 0.4fr) minmax(0, 1.6fr)'
-]
-
-const homeMainShellSx = {
-  position: 'relative',
-  borderTopRightRadius: '3em',
-  borderTopLeftRadius: '.5em',
-  px: [3, 4],
-  pt: [2, 3],
-  pb: [4, 5]
 }
 
 const widgetHeadingSx = {
@@ -369,7 +359,7 @@ export default function HomeShowcase() {
           </Container>
         </Box>
 
-        <Box sx={{ minHeight: '500px', pt: [3, 4], px: 0, pb: [4, 5] }}>
+        <Box sx={{ ...homeDashboardPageOuterSx, pt: [3, 4], pb: [4, 5] }}>
           <Container>
             <Flex
               sx={{
@@ -391,344 +381,354 @@ export default function HomeShowcase() {
               ))}
             </Flex>
 
-            <Grid columns={homeGridColumns} gap={[null, 4]}>
-              <Box
-                as='aside'
-                sx={{ mb: [4, null], display: ['none', null, 'block'], position: 'sticky', top: '1.5em' }}
-              >
-                <Text sx={{ fontSize: [2, 3], fontFamily: 'heading', fontWeight: 'bold', color: 'text', mb: 2 }}>
-                  On this page
-                </Text>
-                <Box as='nav' aria-label='Section navigation' sx={{ display: 'flex', flexDirection: 'column', gap: 0 }}>
-                  {NAV.map(({ label, href }) => (
-                    <Link key={href} href={href} sx={navLinkSx}>
-                      {label}
-                    </Link>
-                  ))}
-                </Box>
-                <Text sx={{ color: 'textMuted', fontSize: 0, mt: 3, lineHeight: 1.6 }}>
-                  Skip target:{' '}
-                  <Text as='span' sx={{ fontFamily: 'monospace' }}>
-                    SkipNavContent
+            <HomeDashboardGrid
+              asideSx={{ display: ['none', null, 'block'], position: 'sticky', top: '1.5em' }}
+              aside={
+                <>
+                  <Text sx={{ fontSize: [2, 3], fontFamily: 'heading', fontWeight: 'bold', color: 'text', mb: 2 }}>
+                    On this page
                   </Text>
-                </Text>
-              </Box>
+                  <Box
+                    as='nav'
+                    aria-label='Section navigation'
+                    sx={{ display: 'flex', flexDirection: 'column', gap: 0 }}
+                  >
+                    {NAV.map(({ label, href }) => (
+                      <Link key={href} href={href} sx={navLinkSx}>
+                        {label}
+                      </Link>
+                    ))}
+                  </Box>
+                  <Text sx={{ color: 'textMuted', fontSize: 0, mt: 3, lineHeight: 1.6 }}>
+                    Skip target:{' '}
+                    <Text as='span' sx={{ fontFamily: 'monospace' }}>
+                      SkipNavContent
+                    </Text>
+                  </Text>
+                </>
+              }
+              main={
+                <Box>
+                  <Box sx={{ ...homeDashboardMainShellSx, pb: [4, 5] }}>
+                    <Box sx={homeDashboardMainInnerMaxWidthSx}>
+                      <Box id='overview' sx={{ scrollMarginTop: '5rem', mb: [4, 5] }}>
+                        <Heading
+                          as='h1'
+                          sx={{
+                            mb: 2,
+                            fontSize: 'clamp(1.75rem, 4vw, 2.25rem)',
+                            fontFamily: 'heading',
+                            color: 'text',
+                            lineHeight: 1.2
+                          }}
+                        >
+                          What this page is for
+                        </Heading>
+                        <Text
+                          as='p'
+                          sx={{
+                            fontSize: [2, 3],
+                            color: 'textMuted',
+                            lineHeight: 1.7,
+                            maxWidth: '40rem',
+                            m: 0
+                          }}
+                        >
+                          It is a compact, realistic slice of the Gatsby home dashboard: shared WidgetHeader, metric
+                          tiles, and pinned-style cards — not a flat list of disconnected controls. See{' '}
+                          <Text as='span' sx={{ fontFamily: 'monospace', fontSize: '0.92em' }}>
+                            packages/ui/README.md
+                          </Text>{' '}
+                          for package entry points.
+                        </Text>
+                      </Box>
 
-              <Box>
-                <Box sx={homeMainShellSx}>
-                  <Box sx={{ maxWidth: '960px' }}>
-                    <Box id='overview' sx={{ scrollMarginTop: '5rem', mb: [4, 5] }}>
-                      <Heading
-                        as='h1'
-                        sx={{
-                          mb: 2,
-                          fontSize: 'clamp(1.75rem, 4vw, 2.25rem)',
-                          fontFamily: 'heading',
-                          color: 'text',
-                          lineHeight: 1.2
-                        }}
+                      <Section
+                        id='widget-demo'
+                        title='Widget composition'
+                        description='Uses WidgetHeader from @chronogrove/ui (same module as gatsby-theme-chronogrove): optional icon, title, WidgetCallToAction aside, and ProfileMetricsBadge metrics — then MetricCard (including showPlaceholder), StatusCard, WidgetSection, and actionCard.'
                       >
-                        What this page is for
-                      </Heading>
-                      <Text
-                        as='p'
-                        sx={{
-                          fontSize: [2, 3],
-                          color: 'textMuted',
-                          lineHeight: 1.7,
-                          maxWidth: '40rem',
-                          m: 0
-                        }}
+                        <DemoPreview title='Composite widget (read-only demo)'>
+                          <WidgetCompositionDemo />
+                        </DemoPreview>
+
+                        <Box sx={{ mt: 3 }}>
+                          <DemoPreview title='Router CTA vs external link'>
+                            <DemoBlock label={null}>
+                              <Text sx={{ color: 'textMuted', fontSize: 1, mb: 2, lineHeight: 1.6 }}>
+                                Internal routes use your framework link so soft navigation stays client-side; outbound
+                                links stay plain anchors.
+                              </Text>
+                              <Flex sx={{ flexDirection: 'column', gap: 2, alignItems: 'flex-start' }}>
+                                <WidgetCallToAction href='https://github.com/chrisvogt/gatsby-theme-chronogrove'>
+                                  External
+                                  <span className='read-more-icon'>&rarr;</span>
+                                </WidgetCallToAction>
+                                <WidgetCallToAction linkComponent={NextLink} href='/'>
+                                  App Router home
+                                  <span className='read-more-icon'>&rarr;</span>
+                                </WidgetCallToAction>
+                              </Flex>
+                            </DemoBlock>
+                          </DemoPreview>
+                        </Box>
+                      </Section>
+
+                      <Section
+                        id='controls'
+                        title='Buttons & pagination'
+                        description='Filled Theme UI buttons, outline ActionButtons for dense toolbars, and the pagination bar used in media and long lists.'
                       >
-                        It is a compact, realistic slice of the Gatsby home dashboard: shared WidgetHeader, metric
-                        tiles, and pinned-style cards — not a flat list of disconnected controls. See{' '}
-                        <Text as='span' sx={{ fontFamily: 'monospace', fontSize: '0.92em' }}>
-                          packages/ui/README.md
-                        </Text>{' '}
-                        for package entry points.
-                      </Text>
-                    </Box>
-
-                    <Section
-                      id='widget-demo'
-                      title='Widget composition'
-                      description='Uses WidgetHeader from @chronogrove/ui (same module as gatsby-theme-chronogrove): optional icon, title, WidgetCallToAction aside, and ProfileMetricsBadge metrics — then MetricCard (including showPlaceholder), StatusCard, WidgetSection, and actionCard.'
-                    >
-                      <DemoPreview title='Composite widget (read-only demo)'>
-                        <WidgetCompositionDemo />
-                      </DemoPreview>
-
-                      <Box sx={{ mt: 3 }}>
-                        <DemoPreview title='Router CTA vs external link'>
-                          <DemoBlock label={null}>
-                            <Text sx={{ color: 'textMuted', fontSize: 1, mb: 2, lineHeight: 1.6 }}>
-                              Internal routes use your framework link so soft navigation stays client-side; outbound
-                              links stay plain anchors.
+                        <DemoPreview title='Controls'>
+                          <DemoBlock label='Button'>
+                            <Flex sx={{ flexWrap: 'wrap', gap: 2 }}>
+                              <Button type='button'>Publish</Button>
+                              <Button type='button' variant='secondary'>
+                                Back
+                              </Button>
+                            </Flex>
+                          </DemoBlock>
+                          <Box as='hr' sx={previewDividerSx} />
+                          <DemoBlock label='ActionButton'>
+                            <Flex sx={{ flexWrap: 'wrap', gap: 2, alignItems: 'center' }}>
+                              <ActionButton type='button' size='large'>
+                                Show more
+                              </ActionButton>
+                              <ActionButton type='button' variant='secondary' size='small'>
+                                Filter
+                              </ActionButton>
+                            </Flex>
+                          </DemoBlock>
+                          <Box as='hr' sx={previewDividerSx} />
+                          <DemoBlock label='Pagination'>
+                            <Pagination
+                              currentPage={paginationBarPage}
+                              totalPages={10}
+                              onPageChange={setPaginationBarPage}
+                              maxVisiblePages={5}
+                            />
+                          </DemoBlock>
+                          <Box as='hr' sx={previewDividerSx} />
+                          <DemoBlock label='PaginationButton (building block)'>
+                            <Text sx={{ color: 'textMuted', fontSize: 1, mb: 2, lineHeight: 1.6, m: 0 }}>
+                              Used inside Pagination for page numbers and prev/next; primary tint follows theme
+                              colors.primary.
                             </Text>
-                            <Flex sx={{ flexDirection: 'column', gap: 2, alignItems: 'flex-start' }}>
-                              <WidgetCallToAction href='https://github.com/chrisvogt/gatsby-theme-chronogrove'>
-                                External
-                                <span className='read-more-icon'>&rarr;</span>
-                              </WidgetCallToAction>
-                              <WidgetCallToAction linkComponent={NextLink} href='/'>
-                                App Router home
-                                <span className='read-more-icon'>&rarr;</span>
-                              </WidgetCallToAction>
+                            <Flex sx={{ flexWrap: 'wrap', gap: 2, alignItems: 'center' }}>
+                              <PaginationButton active variant='primary'>
+                                3
+                              </PaginationButton>
+                              <PaginationButton variant='primary'>4</PaginationButton>
+                              <PaginationButton variant='secondary' size='small'>
+                                5
+                              </PaginationButton>
+                              <PaginationButton disabled variant='primary'>
+                                …
+                              </PaginationButton>
                             </Flex>
                           </DemoBlock>
                         </DemoPreview>
-                      </Box>
-                    </Section>
+                      </Section>
 
-                    <Section
-                      id='controls'
-                      title='Buttons & pagination'
-                      description='Filled Theme UI buttons, outline ActionButtons for dense toolbars, and the pagination bar used in media and long lists.'
-                    >
-                      <DemoPreview title='Controls'>
-                        <DemoBlock label='Button'>
-                          <Flex sx={{ flexWrap: 'wrap', gap: 2 }}>
-                            <Button type='button'>Publish</Button>
-                            <Button type='button' variant='secondary'>
-                              Back
-                            </Button>
-                          </Flex>
-                        </DemoBlock>
-                        <Box as='hr' sx={previewDividerSx} />
-                        <DemoBlock label='ActionButton'>
-                          <Flex sx={{ flexWrap: 'wrap', gap: 2, alignItems: 'center' }}>
-                            <ActionButton type='button' size='large'>
-                              Show more
-                            </ActionButton>
-                            <ActionButton type='button' variant='secondary' size='small'>
-                              Filter
-                            </ActionButton>
-                          </Flex>
-                        </DemoBlock>
-                        <Box as='hr' sx={previewDividerSx} />
-                        <DemoBlock label='Pagination'>
-                          <Pagination
-                            currentPage={paginationBarPage}
-                            totalPages={10}
-                            onPageChange={setPaginationBarPage}
-                            maxVisiblePages={5}
-                          />
-                        </DemoBlock>
-                        <Box as='hr' sx={previewDividerSx} />
-                        <DemoBlock label='PaginationButton (building block)'>
-                          <Text sx={{ color: 'textMuted', fontSize: 1, mb: 2, lineHeight: 1.6, m: 0 }}>
-                            Used inside Pagination for page numbers and prev/next; primary tint follows theme
-                            colors.primary.
-                          </Text>
-                          <Flex sx={{ flexWrap: 'wrap', gap: 2, alignItems: 'center' }}>
-                            <PaginationButton active variant='primary'>
-                              3
-                            </PaginationButton>
-                            <PaginationButton variant='primary'>4</PaginationButton>
-                            <PaginationButton variant='secondary' size='small'>
-                              5
-                            </PaginationButton>
-                            <PaginationButton disabled variant='primary'>
-                              …
-                            </PaginationButton>
-                          </Flex>
-                        </DemoBlock>
-                      </DemoPreview>
-                    </Section>
-
-                    <Section
-                      id='layout'
-                      title='Layout primitives'
-                      description='Blog-style post title (PageHeader) and decorative masthead shell (Header) — same exports the Gatsby theme uses for MDX/blog and layout chrome.'
-                    >
-                      <DemoPreview title='PageHeader · Header'>
-                        <DemoBlock label='PageHeader (h1 · p-name)'>
-                          <PageHeader>October in the Bay Area</PageHeader>
-                          <Text sx={{ color: 'textMuted', fontSize: 1, m: 0, mt: 2, lineHeight: 1.6 }}>
-                            Microformats{' '}
-                            <Text as='span' sx={{ fontFamily: 'monospace', fontSize: '0.92em' }}>
-                              p-name
-                            </Text>{' '}
-                            on the title for posts.
-                          </Text>
-                        </DemoBlock>
-                        <Box as='hr' sx={previewDividerSx} />
-                        <DemoBlock label='Header (variant: styles.Header)'>
-                          <Header>
-                            <Text sx={{ m: 0, color: 'text', fontFamily: 'heading', fontSize: 2 }}>Masthead slot</Text>
-                          </Header>
-                        </DemoBlock>
-                      </DemoPreview>
-                    </Section>
-
-                    <Section
-                      id='thumbnails'
-                      title='Post thumbnails'
-                      description='ThumbnailStrip (vertical stacked strip beside card copy) and ImageThumbnails (circular row above the title) — same exports as gatsby-theme-chronogrove recent-post cards. This page uses pass-through URLs; the Gatsby site wires ImageThumbnails with a Cloudinary optimizeSrc helper.'
-                    >
-                      <DemoPreview title='ThumbnailStrip · ImageThumbnails'>
-                        <DemoBlock label='ThumbnailStrip'>
-                          <Text sx={{ color: 'textMuted', fontSize: 1, mb: 3, lineHeight: 1.65, m: 0 }}>
-                            Compact vertical strip with staggered overlap — useful as a side rail next to a headline
-                            (horizontal post cards on the theme).
-                          </Text>
-                          <Flex sx={{ gap: [3, 4], alignItems: 'flex-start', flexWrap: 'wrap' }}>
-                            <ThumbnailStrip images={DEMO_THUMB_IMAGES} maxImages={4} />
-                            <Box sx={{ flex: '1 1 12rem', minWidth: 0 }}>
-                              <Text
-                                sx={{
-                                  fontFamily: 'heading',
-                                  fontSize: 3,
-                                  color: 'text',
-                                  m: 0,
-                                  mb: 2,
-                                  lineHeight: 1.35
-                                }}
-                              >
-                                Sample headline row
+                      <Section
+                        id='layout'
+                        title='Layout primitives'
+                        description='Blog-style post title (PageHeader) and decorative masthead shell (Header) — same exports the Gatsby theme uses for MDX/blog and layout chrome.'
+                      >
+                        <DemoPreview title='PageHeader · Header'>
+                          <DemoBlock label='PageHeader (h1 · p-name)'>
+                            <PageHeader>October in the Bay Area</PageHeader>
+                            <Text sx={{ color: 'textMuted', fontSize: 1, m: 0, mt: 2, lineHeight: 1.6 }}>
+                              Microformats{' '}
+                              <Text as='span' sx={{ fontFamily: 'monospace', fontSize: '0.92em' }}>
+                                p-name
+                              </Text>{' '}
+                              on the title for posts.
+                            </Text>
+                          </DemoBlock>
+                          <Box as='hr' sx={previewDividerSx} />
+                          <DemoBlock label='Header (variant: styles.Header)'>
+                            <Header>
+                              <Text sx={{ m: 0, color: 'text', fontFamily: 'heading', fontSize: 2 }}>
+                                Masthead slot
                               </Text>
-                              <Text sx={{ color: 'textMuted', fontSize: 1, lineHeight: 1.6, m: 0 }}>
-                                Second row uses{' '}
-                                <Text as='span' sx={{ fontFamily: 'monospace', fontSize: '0.92em' }}>
-                                  size=48
-                                </Text>{' '}
-                                for a larger strip.
-                              </Text>
-                              <Box sx={{ mt: 3 }}>
-                                <ThumbnailStrip images={DEMO_THUMB_IMAGES} maxImages={3} size={48} />
+                            </Header>
+                          </DemoBlock>
+                        </DemoPreview>
+                      </Section>
+
+                      <Section
+                        id='thumbnails'
+                        title='Post thumbnails'
+                        description='ThumbnailStrip (vertical stacked strip beside card copy) and ImageThumbnails (circular row above the title) — same exports as gatsby-theme-chronogrove recent-post cards. This page uses pass-through URLs; the Gatsby site wires ImageThumbnails with a Cloudinary optimizeSrc helper.'
+                      >
+                        <DemoPreview title='ThumbnailStrip · ImageThumbnails'>
+                          <DemoBlock label='ThumbnailStrip'>
+                            <Text sx={{ color: 'textMuted', fontSize: 1, mb: 3, lineHeight: 1.65, m: 0 }}>
+                              Compact vertical strip with staggered overlap — useful as a side rail next to a headline
+                              (horizontal post cards on the theme).
+                            </Text>
+                            <Flex sx={{ gap: [3, 4], alignItems: 'flex-start', flexWrap: 'wrap' }}>
+                              <ThumbnailStrip images={DEMO_THUMB_IMAGES} maxImages={4} />
+                              <Box sx={{ flex: '1 1 12rem', minWidth: 0 }}>
+                                <Text
+                                  sx={{
+                                    fontFamily: 'heading',
+                                    fontSize: 3,
+                                    color: 'text',
+                                    m: 0,
+                                    mb: 2,
+                                    lineHeight: 1.35
+                                  }}
+                                >
+                                  Sample headline row
+                                </Text>
+                                <Text sx={{ color: 'textMuted', fontSize: 1, lineHeight: 1.6, m: 0 }}>
+                                  Second row uses{' '}
+                                  <Text as='span' sx={{ fontFamily: 'monospace', fontSize: '0.92em' }}>
+                                    size=48
+                                  </Text>{' '}
+                                  for a larger strip.
+                                </Text>
+                                <Box sx={{ mt: 3 }}>
+                                  <ThumbnailStrip images={DEMO_THUMB_IMAGES} maxImages={3} size={48} />
+                                </Box>
                               </Box>
-                            </Box>
-                          </Flex>
-                        </DemoBlock>
-                        <Box as='hr' sx={previewDividerSx} />
-                        <DemoBlock label='ImageThumbnails'>
-                          <Text sx={{ color: 'textMuted', fontSize: 1, mb: 2, lineHeight: 1.65, m: 0 }}>
-                            Circular row used on vertical recap cards when a post exposes multiple thumbnails.
-                          </Text>
-                          <ImageThumbnails images={DEMO_THUMB_IMAGES} maxImages={4} />
-                          <Heading
-                            as='h3'
-                            sx={{ fontFamily: 'serif', fontSize: 3, color: 'text', m: 0, mt: 2, lineHeight: 1.35 }}
-                          >
-                            Title after thumbnail row
-                          </Heading>
-                        </DemoBlock>
-                      </DemoPreview>
-                    </Section>
+                            </Flex>
+                          </DemoBlock>
+                          <Box as='hr' sx={previewDividerSx} />
+                          <DemoBlock label='ImageThumbnails'>
+                            <Text sx={{ color: 'textMuted', fontSize: 1, mb: 2, lineHeight: 1.65, m: 0 }}>
+                              Circular row used on vertical recap cards when a post exposes multiple thumbnails.
+                            </Text>
+                            <ImageThumbnails images={DEMO_THUMB_IMAGES} maxImages={4} />
+                            <Heading
+                              as='h3'
+                              sx={{ fontFamily: 'serif', fontSize: 3, color: 'text', m: 0, mt: 2, lineHeight: 1.35 }}
+                            >
+                              Title after thumbnail row
+                            </Heading>
+                          </DemoBlock>
+                        </DemoPreview>
+                      </Section>
 
-                    <Section
-                      id='tokens'
-                      title='Labels, cards, links'
-                      description='Small patterns used inside widgets: category label, muted footer, MetricBadge, outbound-link icon, typography tokens, and badges.'
-                    >
-                      <DemoPreview title='Patterns'>
-                        <DemoBlock label='CategoryLabel · card with MutedCardFooter'>
-                          <CategoryLabel>Travel Photography</CategoryLabel>
-                          <Card variant='primary' sx={{ mt: 2, p: 3, maxWidth: '22rem' }}>
-                            <Text sx={{ fontFamily: 'heading', fontSize: 2, color: 'text', m: 0, mb: 2 }}>
-                              Album notes
+                      <Section
+                        id='tokens'
+                        title='Labels, cards, links'
+                        description='Small patterns used inside widgets: category label, muted footer, MetricBadge, outbound-link icon, typography tokens, and badges.'
+                      >
+                        <DemoPreview title='Patterns'>
+                          <DemoBlock label='CategoryLabel · card with MutedCardFooter'>
+                            <CategoryLabel>Travel Photography</CategoryLabel>
+                            <Card variant='primary' sx={{ mt: 2, p: 3, maxWidth: '22rem' }}>
+                              <Text sx={{ fontFamily: 'heading', fontSize: 2, color: 'text', m: 0, mb: 2 }}>
+                                Album notes
+                              </Text>
+                              <Text sx={{ color: 'textMuted', fontSize: 1, lineHeight: 1.6, m: 0, mb: 2 }}>
+                                Short description body.
+                              </Text>
+                              <MutedCardFooter>Updated this week</MutedCardFooter>
+                            </Card>
+                          </DemoBlock>
+                          <Box as='hr' sx={previewDividerSx} />
+                          <DemoBlock label='Outbound glyph'>
+                            <Text sx={{ display: 'flex', alignItems: 'center', gap: 2, color: 'textMuted', m: 0 }}>
+                              Documentation <ExternalLinkIcon aria-hidden />
                             </Text>
-                            <Text sx={{ color: 'textMuted', fontSize: 1, lineHeight: 1.6, m: 0, mb: 2 }}>
-                              Short description body.
+                          </DemoBlock>
+                          <Box as='hr' sx={previewDividerSx} />
+                          <DemoBlock label='Headings · dense label · badges'>
+                            <Heading
+                              as='h3'
+                              sx={{ fontSize: [4, 5], fontFamily: 'heading', color: 'text', m: 0, mb: 2 }}
+                            >
+                              Widget title
+                            </Heading>
+                            <Text
+                              variant='text.title'
+                              sx={{ display: 'inline-block', fontSize: 1, color: 'textMuted', mb: 2 }}
+                            >
+                              theme.text.title
                             </Text>
-                            <MutedCardFooter>Updated this week</MutedCardFooter>
-                          </Card>
-                        </DemoBlock>
-                        <Box as='hr' sx={previewDividerSx} />
-                        <DemoBlock label='Outbound glyph'>
-                          <Text sx={{ display: 'flex', alignItems: 'center', gap: 2, color: 'textMuted', m: 0 }}>
-                            Documentation <ExternalLinkIcon aria-hidden />
-                          </Text>
-                        </DemoBlock>
-                        <Box as='hr' sx={previewDividerSx} />
-                        <DemoBlock label='Headings · dense label · badges'>
-                          <Heading as='h3' sx={{ fontSize: [4, 5], fontFamily: 'heading', color: 'text', m: 0, mb: 2 }}>
-                            Widget title
-                          </Heading>
-                          <Text
-                            variant='text.title'
-                            sx={{ display: 'inline-block', fontSize: 1, color: 'textMuted', mb: 2 }}
-                          >
-                            theme.text.title
-                          </Text>
-                          <Flex sx={{ flexWrap: 'wrap', gap: 2, alignItems: 'center' }}>
-                            <Badge variant='primary'>primary</Badge>
-                            <Badge variant='outline'>outline</Badge>
-                            <MetricBadge variant='metrics'>metrics (MetricBadge)</MetricBadge>
-                          </Flex>
-                        </DemoBlock>
-                        <Box as='hr' sx={previewDividerSx} />
-                        <DemoBlock label='Widget CTA link style'>
+                            <Flex sx={{ flexWrap: 'wrap', gap: 2, alignItems: 'center' }}>
+                              <Badge variant='primary'>primary</Badge>
+                              <Badge variant='outline'>outline</Badge>
+                              <MetricBadge variant='metrics'>metrics (MetricBadge)</MetricBadge>
+                            </Flex>
+                          </DemoBlock>
+                          <Box as='hr' sx={previewDividerSx} />
+                          <DemoBlock label='Widget CTA link style'>
+                            <Link
+                              href='https://github.com/chrisvogt/gatsby-theme-chronogrove'
+                              sx={{ variant: 'links.widgetCta' }}
+                            >
+                              links.widgetCta →
+                            </Link>
+                          </DemoBlock>
+                        </DemoPreview>
+                      </Section>
+
+                      <Section
+                        id='lazy'
+                        title='Lazy load'
+                        description='Content below the fold can wait until the block intersects the viewport (same helper as pinned repos and Steam cards). Scroll here to hydrate the placeholder.'
+                      >
+                        <DemoPreview title='IntersectionObserver'>
+                          <DemoBlock label={null}>
+                            <Text sx={{ color: 'textMuted', fontSize: 1, mb: 3, lineHeight: 1.65, m: 0 }}>
+                              Skeleton uses{' '}
+                              <Text as='span' sx={{ fontFamily: 'monospace', fontSize: '0.92em' }}>
+                                react-placeholder
+                              </Text>{' '}
+                              with{' '}
+                              <Text as='span' sx={{ fontFamily: 'monospace', fontSize: '0.92em' }}>
+                                show-loading-animation
+                              </Text>
+                              .
+                            </Text>
+                            <LazyLoad
+                              placeholder={<LazyPlaceholder />}
+                              useInViewOptions={{
+                                initialInView: false,
+                                rootMargin: '0px 0px -240px 0px',
+                                threshold: 0
+                              }}
+                            >
+                              <LazyLoadedContent />
+                            </LazyLoad>
+                          </DemoBlock>
+                        </DemoPreview>
+                      </Section>
+
+                      <Box
+                        as='footer'
+                        sx={{
+                          mt: 5,
+                          pt: 4,
+                          borderTop: '1px solid',
+                          borderColor: 'panel-divider',
+                          color: 'textMuted',
+                          fontSize: 1
+                        }}
+                      >
+                        <Text sx={{ m: 0 }}>
                           <Link
                             href='https://github.com/chrisvogt/gatsby-theme-chronogrove'
                             sx={{ variant: 'links.widgetCta' }}
                           >
-                            links.widgetCta →
+                            gatsby-theme-chronogrove
                           </Link>
-                        </DemoBlock>
-                      </DemoPreview>
-                    </Section>
-
-                    <Section
-                      id='lazy'
-                      title='Lazy load'
-                      description='Content below the fold can wait until the block intersects the viewport (same helper as pinned repos and Steam cards). Scroll here to hydrate the placeholder.'
-                    >
-                      <DemoPreview title='IntersectionObserver'>
-                        <DemoBlock label={null}>
-                          <Text sx={{ color: 'textMuted', fontSize: 1, mb: 3, lineHeight: 1.65, m: 0 }}>
-                            Skeleton uses{' '}
-                            <Text as='span' sx={{ fontFamily: 'monospace', fontSize: '0.92em' }}>
-                              react-placeholder
-                            </Text>{' '}
-                            with{' '}
-                            <Text as='span' sx={{ fontFamily: 'monospace', fontSize: '0.92em' }}>
-                              show-loading-animation
-                            </Text>
-                            .
+                          {' · '}
+                          <Text as='span' sx={{ fontFamily: 'monospace' }}>
+                            packages/ui/README.md
                           </Text>
-                          <LazyLoad
-                            placeholder={<LazyPlaceholder />}
-                            useInViewOptions={{
-                              initialInView: false,
-                              rootMargin: '0px 0px -240px 0px',
-                              threshold: 0
-                            }}
-                          >
-                            <LazyLoadedContent />
-                          </LazyLoad>
-                        </DemoBlock>
-                      </DemoPreview>
-                    </Section>
-
-                    <Box
-                      as='footer'
-                      sx={{
-                        mt: 5,
-                        pt: 4,
-                        borderTop: '1px solid',
-                        borderColor: 'panel-divider',
-                        color: 'textMuted',
-                        fontSize: 1
-                      }}
-                    >
-                      <Text sx={{ m: 0 }}>
-                        <Link
-                          href='https://github.com/chrisvogt/gatsby-theme-chronogrove'
-                          sx={{ variant: 'links.widgetCta' }}
-                        >
-                          gatsby-theme-chronogrove
-                        </Link>
-                        {' · '}
-                        <Text as='span' sx={{ fontFamily: 'monospace' }}>
-                          packages/ui/README.md
                         </Text>
-                      </Text>
+                      </Box>
                     </Box>
                   </Box>
                 </Box>
-              </Box>
-            </Grid>
+              }
+            />
           </Container>
         </Box>
       </SkipNavContent>

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chronogrove/ui",
-  "version": "0.83.0",
+  "version": "0.83.1",
   "description": "Chronogrove Theme UI theme, color mode helpers, and shared UI primitives",
   "license": "MIT",
   "type": "module",
@@ -137,6 +137,18 @@
     "./action-card-layout": {
       "import": "./src/action-card-layout.js",
       "default": "./src/action-card-layout.js"
+    },
+    "./article-column-container": {
+      "import": "./src/article-column-container.js",
+      "default": "./src/article-column-container.js"
+    },
+    "./home-dashboard-layout": {
+      "import": "./src/home-dashboard-layout.js",
+      "default": "./src/home-dashboard-layout.js"
+    },
+    "./page-shell-layout": {
+      "import": "./src/page-shell-layout.js",
+      "default": "./src/page-shell-layout.js"
     },
     "./thumbnail-strip": {
       "import": "./src/thumbnail-strip.js",

--- a/packages/ui/src/article-column-container.js
+++ b/packages/ui/src/article-column-container.js
@@ -1,0 +1,23 @@
+import React from 'react'
+import { Container } from '@theme-ui/components'
+
+/**
+ * Primary text column width for MDX posts, blog index, and about-style pages.
+ * Keep in sync wherever the article measure must match (Gatsby post template, blog index, etc.).
+ */
+export const articleColumnContainerSx = {
+  position: 'relative',
+  width: ['', '', 'max(80ch, 50vw)'],
+  lineHeight: 1.7
+}
+
+/**
+ * Theme UI `Container` with {@link articleColumnContainerSx}. Pass `sx` to merge (e.g. `flexGrow: 1` on the blog index).
+ */
+export function ArticleColumnContainer({ children, sx = {}, ...rest }) {
+  return (
+    <Container sx={{ ...articleColumnContainerSx, ...sx }} {...rest}>
+      {children}
+    </Container>
+  )
+}

--- a/packages/ui/src/article-column-container.spec.js
+++ b/packages/ui/src/article-column-container.spec.js
@@ -1,0 +1,40 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import { ChronogroveThemeProvider } from './provider.js'
+import chronogroveTheme from './theme.js'
+
+import { ArticleColumnContainer, articleColumnContainerSx } from './article-column-container.js'
+
+describe('articleColumnContainerSx', () => {
+  it('defines the shared article measure', () => {
+    expect(articleColumnContainerSx).toMatchObject({
+      position: 'relative',
+      width: ['', '', 'max(80ch, 50vw)'],
+      lineHeight: 1.7
+    })
+  })
+})
+
+describe('ArticleColumnContainer', () => {
+  it('renders children with merged sx', () => {
+    render(
+      <ChronogroveThemeProvider theme={chronogroveTheme}>
+        <ArticleColumnContainer sx={{ flexGrow: 1 }} data-testid='ac'>
+          <span>body</span>
+        </ArticleColumnContainer>
+      </ChronogroveThemeProvider>
+    )
+    expect(screen.getByTestId('ac')).toContainElement(screen.getByText('body'))
+  })
+
+  it('renders with base article sx when sx is omitted', () => {
+    render(
+      <ChronogroveThemeProvider theme={chronogroveTheme}>
+        <ArticleColumnContainer data-testid='ac-base'>
+          <span>only-base</span>
+        </ArticleColumnContainer>
+      </ChronogroveThemeProvider>
+    )
+    expect(screen.getByTestId('ac-base')).toContainElement(screen.getByText('only-base'))
+  })
+})

--- a/packages/ui/src/home-dashboard-layout.js
+++ b/packages/ui/src/home-dashboard-layout.js
@@ -1,0 +1,58 @@
+import React from 'react'
+import { Box, Grid } from '@theme-ui/components'
+
+/** Theme UI `Grid` `columns` for the home dashboard: single column until `md`, then sidebar + main. */
+export const homeDashboardGridColumns = [
+  null,
+  null,
+  'minmax(200px, 0.375fr) minmax(0, 1.625fr)',
+  'minmax(200px, 0.4fr) minmax(0, 1.6fr)'
+]
+
+export const homeDashboardGridGap = [null, 4]
+
+/** Default aside spacing; merge with site-specific `sx` (e.g. sticky side nav in demos). */
+export const homeDashboardAsideSx = {
+  mb: [4, null]
+}
+
+/** Rounded “glass” panel shell around the main home column (matches gatsby-theme-chronogrove home). */
+export const homeDashboardMainShellSx = {
+  position: 'relative',
+  borderTopRightRadius: '3em',
+  borderTopLeftRadius: '.5em',
+  px: [3, 4],
+  pt: [2, 3]
+}
+
+export const homeDashboardMainInnerMaxWidthSx = {
+  maxWidth: '1200px'
+}
+
+/** Outer stack below the page chrome on the home template (`minHeight`, top padding). */
+export const homeDashboardPageOuterSx = {
+  minHeight: '500px',
+  pt: 3,
+  px: 0
+}
+
+/**
+ * Two-column home dashboard grid (sidebar + main). Pass full `main` node so callers can set
+ * `role="main"`, skip-nav targets, footer, and microformats in one place.
+ *
+ * @param {object} props
+ * @param {React.ReactNode} props.aside
+ * @param {React.ReactNode} props.main
+ * @param {import('theme-ui').ThemeUIStyleObject} [props.asideSx] merged after {@link homeDashboardAsideSx}
+ * @param {React.ComponentProps<typeof Grid>} [props.gridProps] forwarded to `Grid`
+ */
+export function HomeDashboardGrid({ aside, main, asideSx = {}, gridProps = {}, ...gridRest }) {
+  return (
+    <Grid columns={homeDashboardGridColumns} gap={homeDashboardGridGap} {...gridProps} {...gridRest}>
+      <Box as='aside' sx={{ ...homeDashboardAsideSx, ...asideSx }}>
+        {aside}
+      </Box>
+      {main}
+    </Grid>
+  )
+}

--- a/packages/ui/src/home-dashboard-layout.spec.js
+++ b/packages/ui/src/home-dashboard-layout.spec.js
@@ -1,0 +1,60 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import { ChronogroveThemeProvider } from './provider.js'
+import chronogroveTheme from './theme.js'
+
+import {
+  HomeDashboardGrid,
+  homeDashboardAsideSx,
+  homeDashboardGridColumns,
+  homeDashboardGridGap,
+  homeDashboardMainInnerMaxWidthSx,
+  homeDashboardMainShellSx,
+  homeDashboardPageOuterSx
+} from './home-dashboard-layout.js'
+
+describe('home dashboard layout tokens', () => {
+  it('exports grid columns and gap used by the Gatsby home template', () => {
+    expect(homeDashboardGridColumns[2]).toContain('minmax(200px')
+    expect(homeDashboardGridGap).toEqual([null, 4])
+    expect(homeDashboardAsideSx).toEqual({ mb: [4, null] })
+    expect(homeDashboardMainShellSx.borderTopRightRadius).toBe('3em')
+    expect(homeDashboardMainInnerMaxWidthSx.maxWidth).toBe('1200px')
+    expect(homeDashboardPageOuterSx.minHeight).toBe('500px')
+  })
+})
+
+describe('HomeDashboardGrid', () => {
+  it('renders aside and main slots', () => {
+    render(
+      <ChronogroveThemeProvider theme={chronogroveTheme}>
+        <HomeDashboardGrid aside={<span>nav</span>} main={<div data-testid='main'>content</div>} />
+      </ChronogroveThemeProvider>
+    )
+    expect(screen.getByText('nav')).toBeInTheDocument()
+    expect(screen.getByTestId('main')).toHaveTextContent('content')
+  })
+
+  it('merges asideSx onto the aside', () => {
+    const { container } = render(
+      <ChronogroveThemeProvider theme={chronogroveTheme}>
+        <HomeDashboardGrid aside={<span>a</span>} main={<span>b</span>} asideSx={{ position: 'sticky' }} />
+      </ChronogroveThemeProvider>
+    )
+    const aside = container.querySelector('aside')
+    expect(aside).toBeTruthy()
+  })
+
+  it('forwards gridProps to Grid', () => {
+    const { container } = render(
+      <ChronogroveThemeProvider theme={chronogroveTheme}>
+        <HomeDashboardGrid
+          aside={<span>l</span>}
+          main={<span>r</span>}
+          gridProps={{ 'data-testid': 'hdg', id: 'home-dash-grid' }}
+        />
+      </ChronogroveThemeProvider>
+    )
+    expect(container.querySelector('#home-dash-grid')).toBeTruthy()
+  })
+})

--- a/packages/ui/src/page-shell-layout.js
+++ b/packages/ui/src/page-shell-layout.js
@@ -1,0 +1,57 @@
+import React from 'react'
+import { Box } from '@theme-ui/components'
+
+import { SkipNavContent, SkipNavLink } from './skip-nav/index.js'
+
+/**
+ * Default page chrome: skip link, optional header and footer slots, and a main landmark (unless disabled).
+ * Wire Gatsby-specific nav/footer and Zustand-driven `paddingBottom` from the site package.
+ *
+ * @param {object} props
+ * @param {React.ReactNode} props.children
+ * @param {boolean} [props.disableMainWrapper]
+ * @param {boolean} [props.hideHeader] when true, `header` is not rendered
+ * @param {boolean} [props.hideFooter] when true, `footer` is not rendered
+ * @param {boolean} [props.transparentBackground]
+ * @param {number|string} [props.paddingBottom] bottom padding (e.g. room for a fixed audio bar)
+ * @param {React.ReactNode} [props.header] placed inside `<header role="banner">` when not hidden
+ * @param {React.ReactNode} [props.footer]
+ */
+export function ChronogrovePageShell({
+  children,
+  disableMainWrapper = false,
+  hideHeader = false,
+  hideFooter = false,
+  transparentBackground = false,
+  paddingBottom = 0,
+  header = null,
+  footer = null
+}) {
+  return (
+    <Box
+      sx={{
+        backgroundColor: transparentBackground ? 'transparent' : 'background',
+        display: 'flex',
+        flexDirection: 'column',
+        flexGrow: 1,
+        color: theme => theme?.colors?.text,
+        pb: paddingBottom
+      }}
+    >
+      <SkipNavLink />
+
+      {!hideHeader && header ? <header role='banner'>{header}</header> : null}
+
+      {disableMainWrapper ? (
+        children
+      ) : (
+        <Box as='main' role='main'>
+          <SkipNavContent />
+          {children}
+        </Box>
+      )}
+
+      {!hideFooter && footer ? footer : null}
+    </Box>
+  )
+}

--- a/packages/ui/src/page-shell-layout.spec.js
+++ b/packages/ui/src/page-shell-layout.spec.js
@@ -1,0 +1,71 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import { ChronogroveThemeProvider } from './provider.js'
+import chronogroveTheme from './theme.js'
+
+import { ChronogrovePageShell } from './page-shell-layout.js'
+
+function shellRender(ui) {
+  return render(<ChronogroveThemeProvider theme={chronogroveTheme}>{ui}</ChronogroveThemeProvider>)
+}
+
+describe('ChronogrovePageShell', () => {
+  it('renders skip link, header, main with skip target, children, and footer', () => {
+    shellRender(
+      <ChronogrovePageShell header={<span>hdr</span>} footer={<span>ftr</span>} paddingBottom='12px'>
+        <span>inner</span>
+      </ChronogrovePageShell>
+    )
+    expect(screen.getByText('inner')).toBeInTheDocument()
+    expect(screen.getByText('hdr')).toBeInTheDocument()
+    expect(screen.getByText('ftr')).toBeInTheDocument()
+    expect(document.querySelector('main[role="main"]')).toBeTruthy()
+  })
+
+  it('omits header when hideHeader', () => {
+    shellRender(
+      <ChronogrovePageShell hideHeader header={<span>no</span>} footer={null}>
+        <span>x</span>
+      </ChronogrovePageShell>
+    )
+    expect(screen.queryByText('no')).not.toBeInTheDocument()
+  })
+
+  it('omits footer when hideFooter', () => {
+    shellRender(
+      <ChronogrovePageShell hideFooter footer={<span>no</span>}>
+        <span>x</span>
+      </ChronogrovePageShell>
+    )
+    expect(screen.queryByText('no')).not.toBeInTheDocument()
+  })
+
+  it('renders children without main wrapper when disableMainWrapper', () => {
+    shellRender(
+      <ChronogrovePageShell disableMainWrapper>
+        <span data-testid='bare'>bare</span>
+      </ChronogrovePageShell>
+    )
+    expect(screen.getByTestId('bare')).toBeInTheDocument()
+    expect(document.querySelector('main[role="main"]')).toBeFalsy()
+  })
+
+  it('uses transparent background when requested', () => {
+    const { container } = shellRender(
+      <ChronogrovePageShell transparentBackground>
+        <span>t</span>
+      </ChronogrovePageShell>
+    )
+    expect(container.firstChild).toBeTruthy()
+  })
+
+  it('does not render a banner when header is null', () => {
+    shellRender(
+      <ChronogrovePageShell header={null}>
+        <span>no-banner</span>
+      </ChronogrovePageShell>
+    )
+    expect(screen.getByText('no-banner')).toBeInTheDocument()
+    expect(document.querySelector('header[role="banner"]')).toBeFalsy()
+  })
+})

--- a/theme/package.json
+++ b/theme/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-theme-chronogrove",
   "description": "A personal website and digital garden theme for GatsbyJS.",
-  "version": "0.85.5",
+  "version": "0.85.6",
   "author": "Chris Vogt <mail@chrisvogt.me> (https://www.chrisvogt.me)",
   "main": "index.js",
   "license": "MIT",

--- a/theme/src/components/__snapshots__/layout.spec.js.snap
+++ b/theme/src/components/__snapshots__/layout.spec.js.snap
@@ -3,7 +3,7 @@
 exports[`Layout matches the snapshot 1`] = `
 <DocumentFragment>
   <div
-    class="css-e2rbjw"
+    class="css-s6ltgc"
   >
     <a
       class="css-821g5p"
@@ -54,6 +54,7 @@ exports[`Layout matches the snapshot 1`] = `
       </div>
     </header>
     <main
+      class="css-1yz7e9k"
       role="main"
     >
       <div
@@ -120,7 +121,7 @@ exports[`Layout matches the snapshot 1`] = `
 exports[`Layout renders with audio player hidden state 1`] = `
 <DocumentFragment>
   <div
-    class="css-e2rbjw"
+    class="css-s6ltgc"
   >
     <a
       class="css-821g5p"
@@ -171,6 +172,7 @@ exports[`Layout renders with audio player hidden state 1`] = `
       </div>
     </header>
     <main
+      class="css-1yz7e9k"
       role="main"
     >
       <div
@@ -237,7 +239,7 @@ exports[`Layout renders with audio player hidden state 1`] = `
 exports[`Layout renders with audio player visible state 1`] = `
 <DocumentFragment>
   <div
-    class="css-1uj8esv"
+    class="css-1hezyaw"
   >
     <a
       class="css-821g5p"
@@ -288,6 +290,7 @@ exports[`Layout renders with audio player visible state 1`] = `
       </div>
     </header>
     <main
+      class="css-1yz7e9k"
       role="main"
     >
       <div
@@ -354,7 +357,7 @@ exports[`Layout renders with audio player visible state 1`] = `
 exports[`Layout renders with disableMainWrapper prop 1`] = `
 <DocumentFragment>
   <div
-    class="css-e2rbjw"
+    class="css-s6ltgc"
   >
     <a
       class="css-821g5p"
@@ -461,7 +464,7 @@ exports[`Layout renders with disableMainWrapper prop 1`] = `
 exports[`Layout renders with hideFooter prop 1`] = `
 <DocumentFragment>
   <div
-    class="css-e2rbjw"
+    class="css-s6ltgc"
   >
     <a
       class="css-821g5p"
@@ -512,6 +515,7 @@ exports[`Layout renders with hideFooter prop 1`] = `
       </div>
     </header>
     <main
+      class="css-1yz7e9k"
       role="main"
     >
       <div
@@ -531,7 +535,7 @@ exports[`Layout renders with hideFooter prop 1`] = `
 exports[`Layout renders with hideHeader prop 1`] = `
 <DocumentFragment>
   <div
-    class="css-e2rbjw"
+    class="css-s6ltgc"
   >
     <a
       class="css-821g5p"
@@ -542,6 +546,7 @@ exports[`Layout renders with hideHeader prop 1`] = `
       Skip to content
     </a>
     <main
+      class="css-1yz7e9k"
       role="main"
     >
       <div

--- a/theme/src/components/layout.js
+++ b/theme/src/components/layout.js
@@ -1,8 +1,8 @@
 /** @jsx jsx */
 import { jsx } from 'theme-ui'
+import { ChronogrovePageShell } from '@chronogrove/ui/page-shell-layout'
 import { useAudioPlayerStore } from '../stores/audio-player-store'
 import React from 'react'
-import { SkipNavLink, SkipNavContent } from './skip-nav'
 
 import Footer from './footer'
 import TopNavigation from './top-navigation'
@@ -18,39 +18,17 @@ const Layout = ({ children, disableMainWrapper, hideHeader, hideFooter, transpar
   const isVisible = useAudioPlayerStore(state => state.isVisible)
 
   return (
-    <div
-      sx={{
-        backgroundColor: transparentBackground ? 'transparent' : 'background',
-        display: 'flex',
-        flexDirection: 'column',
-        flexGrow: 1,
-        color: theme => theme?.colors?.text,
-        // Add padding when audio player is visible
-        // 100px for player height + 24px (padding) + 16px (extra space)
-        pb: isVisible ? '140px' : 0
-      }}
+    <ChronogrovePageShell
+      disableMainWrapper={disableMainWrapper}
+      hideFooter={hideFooter}
+      hideHeader={hideHeader}
+      transparentBackground={transparentBackground}
+      paddingBottom={isVisible ? '140px' : 0}
+      header={<TopNavigation />}
+      footer={<Footer />}
     >
-      {/* Skip to content link - first in DOM for tab order, visually appears in header when focused */}
-      <SkipNavLink />
-
-      {/* NOTE(chrisvogt): hide the top navigation on the home and 404 pages */}
-      {!hideHeader && (
-        <header role='banner'>
-          <TopNavigation />
-        </header>
-      )}
-
-      {disableMainWrapper ? (
-        children
-      ) : (
-        <main role='main'>
-          <SkipNavContent />
-          {children}
-        </main>
-      )}
-
-      {!hideFooter && <Footer />}
-    </div>
+      {children}
+    </ChronogrovePageShell>
   )
 }
 

--- a/theme/src/constants/article-column-container-sx.js
+++ b/theme/src/constants/article-column-container-sx.js
@@ -1,9 +1,1 @@
-/**
- * Primary text column width for MDX posts and the blog index.
- * Keep in sync with post template so index and articles share the same measure.
- */
-export const articleColumnContainerSx = {
-  position: 'relative',
-  width: ['', '', 'max(80ch, 50vw)'],
-  lineHeight: 1.7
-}
+export { articleColumnContainerSx } from '@chronogrove/ui/article-column-container'

--- a/theme/src/templates/home.js
+++ b/theme/src/templates/home.js
@@ -1,8 +1,14 @@
 /** @jsx jsx */
-import { jsx, Container, Grid } from 'theme-ui'
+import { jsx, Container } from 'theme-ui'
 import { graphql } from 'gatsby'
 import { Fragment } from 'react'
 import { SkipNavContent } from '../components/skip-nav'
+import {
+  HomeDashboardGrid,
+  homeDashboardMainInnerMaxWidthSx,
+  homeDashboardMainShellSx,
+  homeDashboardPageOuterSx
+} from '@chronogrove/ui/home-dashboard-layout'
 
 import AnimatedPageBackground from '../components/animated-page-background'
 import Footer from '../components/footer'
@@ -26,52 +32,26 @@ const HomeTemplate = () => {
         }}
       >
         <Layout hideFooter disableMainWrapper transparentBackground>
-          <div
-            sx={{
-              minHeight: '500px',
-              pt: 3,
-              px: 0
-            }}
-          >
+          <div sx={homeDashboardPageOuterSx}>
             <Container>
-              <Grid
-                columns={[
-                  null,
-                  null,
-                  'minmax(200px, 0.375fr) minmax(0, 1.625fr)' /* Sidebar min 200px, Content flexible */,
-                  'minmax(200px, 0.4fr) minmax(0, 1.6fr)' /* Sidebar min 200px, Content flexible */
-                ]}
-                gap={[null, 4]}
-              >
-                <aside sx={{ mb: [4, null] }}>
-                  <HomeNavigation />
-                </aside>
-                <main role='main'>
-                  <SkipNavContent />
-                  <div
-                    sx={{
-                      position: 'relative',
-                      borderTopRightRadius: '3em',
-                      borderTopLeftRadius: '.5em',
-                      px: [3, 4],
-                      pt: [2, 3]
-                    }}
-                  >
-                    <div
-                      sx={{
-                        maxWidth: '1200px'
-                      }}
-                    >
-                      <section id='top'>
-                        <HomeHeaderContent />
-                      </section>
-                      <HomeWidgets />
+              <HomeDashboardGrid
+                aside={<HomeNavigation />}
+                main={
+                  <main role='main'>
+                    <SkipNavContent />
+                    <div sx={homeDashboardMainShellSx}>
+                      <div sx={homeDashboardMainInnerMaxWidthSx}>
+                        <section id='top'>
+                          <HomeHeaderContent />
+                        </section>
+                        <HomeWidgets />
+                      </div>
                     </div>
-                  </div>
-                  <Footer />
-                  <HCard />
-                </main>
-              </Grid>
+                    <Footer />
+                    <HCard />
+                  </main>
+                }
+              />
             </Container>
           </div>
         </Layout>

--- a/www.chrisvogt.me/package.json
+++ b/www.chrisvogt.me/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "www.chrisvogt.me",
-  "version": "1.16.5",
+  "version": "1.16.6",
   "license": "GPL",
   "scripts": {
     "build": "gatsby build",

--- a/www.chrisvogt.me/src/pages/about.js
+++ b/www.chrisvogt.me/src/pages/about.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import { Container, Flex } from 'theme-ui'
 import { Themed } from '@theme-ui/mdx'
+import { articleColumnContainerSx } from 'gatsby-theme-chronogrove/src/constants/article-column-container-sx'
 import Layout from 'gatsby-theme-chronogrove/src/components/layout'
 import Seo from 'gatsby-theme-chronogrove/src/components/seo'
 import CareerPathCurve from '../../components/CareerPathCurve'
@@ -16,7 +17,7 @@ const AboutPage = () => {
           py: 3
         }}
       >
-        <Container sx={{ width: ['', '', 'max(80ch, 50vw)'], lineHeight: 1.7 }}>
+        <Container sx={articleColumnContainerSx}>
           <Themed.h1>About Me</Themed.h1>
 
           <Themed.p>

--- a/www.chronogrove.com/package.json
+++ b/www.chronogrove.com/package.json
@@ -1,6 +1,6 @@
 {
   "name": "www.chronogrove.com",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "description": "Official demo site for gatsby-theme-chronogrove",
   "scripts": {
     "develop": "gatsby develop",

--- a/www.chronogrove.com/src/pages/about.js
+++ b/www.chronogrove.com/src/pages/about.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import { Container, Flex } from 'theme-ui'
 import { Themed } from '@theme-ui/mdx'
+import { articleColumnContainerSx } from 'gatsby-theme-chronogrove/src/constants/article-column-container-sx'
 import Layout from 'gatsby-theme-chronogrove/src/components/layout'
 import Seo from 'gatsby-theme-chronogrove/src/components/seo'
 
@@ -15,7 +16,7 @@ const AboutPage = () => {
           py: 3
         }}
       >
-        <Container sx={{ width: ['', '', 'max(80ch, 50vw)'], lineHeight: 1.7 }}>
+        <Container sx={articleColumnContainerSx}>
           <Themed.h1>About Chronogrove</Themed.h1>
 
           <Themed.p>

--- a/www.chronogrove.com/src/pages/about.spec.js
+++ b/www.chronogrove.com/src/pages/about.spec.js
@@ -4,6 +4,14 @@ import '@testing-library/jest-dom'
 import AboutPage, { Head } from './about'
 import { ThemeUIProvider } from 'theme-ui'
 
+jest.mock('gatsby-theme-chronogrove/src/constants/article-column-container-sx', () => ({
+  articleColumnContainerSx: {
+    position: 'relative',
+    width: ['', '', 'max(80ch, 50vw)'],
+    lineHeight: 1.7
+  }
+}))
+
 // Mock Layout component
 jest.mock('gatsby-theme-chronogrove/src/components/layout', () => ({ children }) => (
   <div data-testid='layout'>{children}</div>


### PR DESCRIPTION
## Summary

This change moves the article column measure, home dashboard two-column grid tokens + `HomeDashboardGrid`, and the default page chrome (`ChronogrovePageShell`) into `@chronogrove/ui`, then wires `gatsby-theme-chronogrove` through those exports. The Next reference app and both www sites consume the shared patterns where appropriate.

## Packages

- **`@chronogrove/ui` 0.83.1** — new subpaths: `article-column-container`, `home-dashboard-layout`, `page-shell-layout` (+ tests).
- **`gatsby-theme-chronogrove` 0.85.6** — `Layout`, home template, and `article-column-container-sx` shim.
- **`www.chrisvogt.me` 1.16.6** / **`www.chronogrove.com` 1.3.6** — About pages use the theme constants path; demo spec mocks the module.

## Docs

- **`CHANGELOG.md`** — `## 0.85.6` release notes.

## Tracking

Part of **#561** (Epic: Decouple Chronogrove UX into `@chronogrove/ui` for Next.js + Gatsby). Complements the closed Next.js proof in **#563** by making home/article/page-shell layout primitives consumable outside the theme.

_No other open issues specifically filed for “layout exports”; performance/docs items in the issue list are unrelated._

Made with [Cursor](https://cursor.com)