### PR TITLE
chore(theme): remove unused React refs

### DIFF
--- a/theme/src/components/home-navigation.js
+++ b/theme/src/components/home-navigation.js
@@ -3,7 +3,7 @@ import { jsx, useColorMode, useThemeUI } from 'theme-ui'
 import { Fragment } from 'react'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { scrollToElementWhenReady } from '../helpers/scroll-to-element-when-ready'
-import { useMemo, useState, useEffect, useRef } from 'react'
+import { useMemo, useState, useEffect } from 'react'
 import useNavigationData from '../hooks/use-navigation-data'
 import useSiteMetadata from '../hooks/use-site-metadata'
 import {
@@ -82,7 +82,6 @@ const HomeNavigation = props => {
   const [colorMode] = useColorMode()
   const { theme } = useThemeUI()
   const isDark = colorMode === 'dark'
-  const scrollRef = useRef(null)
 
   const navigation = useNavigationData()
   const metadata = useSiteMetadata()
@@ -179,7 +178,6 @@ const HomeNavigation = props => {
         <nav role='navigation' aria-label='On-page navigation'>
           {/* Outer scroll-wheel rail container */}
           <div
-            ref={scrollRef}
             sx={{
               position: 'relative',
               pl: '28px', // room for rail + badge overflow

--- a/theme/src/components/widgets/github/contribution-graph.js
+++ b/theme/src/components/widgets/github/contribution-graph.js
@@ -35,7 +35,6 @@ const ContributionGraph = ({ isLoading, contributionCalendar }) => {
   const { colorMode } = useThemeUI()
   const darkModeActive = isDarkMode(colorMode)
   const containerRef = useRef(null)
-  const graphRef = useRef(null)
   const [hoveredCell, setHoveredCell] = useState(null)
 
   // Calculate total days for cell size calculation
@@ -220,9 +219,7 @@ const ContributionGraph = ({ isLoading, contributionCalendar }) => {
         <Themed.p sx={{ mb: 3 }}>{totalContributions} contributions in the last year</Themed.p>
 
         {/* Outer wrapper with explicit width constraint - inline styles prevent FOUC */}
-        {/* Attach ref here for intersection observer */}
         <Box
-          ref={graphRef}
           style={{
             width: '100%',
             maxWidth: '100%',

--- a/theme/src/pages/404.js
+++ b/theme/src/pages/404.js
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 import { Box, Container, Flex, Grid, jsx } from 'theme-ui'
-import { useRef, useEffect, useState } from 'react'
+import { useEffect, useState } from 'react'
 import loadable from '@loadable/component'
 import { Themed } from '@theme-ui/mdx'
 
@@ -15,8 +15,6 @@ const options = Object.freeze({
 })
 
 const NotFoundPage = () => {
-  const ref = useRef()
-
   const [isClient, setIsClient] = useState(false)
   useEffect(() => {
     setIsClient(true)
@@ -27,9 +25,7 @@ const NotFoundPage = () => {
       <Flex sx={{ position: 'relative', flex: 1 }}>
         <Container>
           <Grid gap={4} sx={{ gridTemplateColumns: ['auto', 'auto', '1fr 70%'] }}>
-            <Box>
-              {isClient && <LottieClientOnly key='$floatingAstronaut' ref={ref} height='50vh' options={options} />}
-            </Box>
+            <Box>{isClient && <LottieClientOnly key='$floatingAstronaut' height='50vh' options={options} />}</Box>
             <Box
               sx={{
                 display: 'flex',


### PR DESCRIPTION
## Summary
Removes `useRef` hooks and DOM `ref` props where `.current` was never read—dead code left from earlier implementations or copy-paste.

## Changes
- **`home-navigation.js`**: Dropped unused rail container ref (scroll sync uses `window` / `document.getElementById`).
- **`contribution-graph.js`**: Removed `graphRef` on the outer wrapper; `containerRef` already drives resize/cell sizing. Removed stale “intersection observer” comment.
- **`404.js`**: Removed Lottie `ref` that was never consumed.

## Audit
Searched the repo for `useRef(` and checked each call site. Remaining refs are used (e.g. IntersectionObserver, portals, focus trap, LightGallery `onInit`, animation/D3 containers, swipe/timer handles).

## Testing
Theme Jest suites (incl. home-navigation, contribution-graph, 404) pass via pre-push hook / `pnpm test`.

Made with [Cursor](https://cursor.com)