### PR TITLE
fix(theme): avoid WebGL context exhaustion when paging Goodreads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@
 
 - **`Book3D`**: Guards teardown so a late **`IntersectionObserver`** callback cannot **`createScene()`** after **`dispose()`** (disconnect observers and DOM listeners **before** destroying the Three.js scene); animation frame, intro **`setTimeout`**, and **`TextureLoader`** paths respect **`active`**; **`WEBGL_lose_context`** (**`loseContext`**) after **`renderer.dispose()`** where available so contexts are released promptly on drivers that defer until GC if not lost explicitly.
 - **Goodreads / `recently-read-books`**: On **`currentPage`** change (not initial mount), the active slide renders **flat covers** for two **`requestAnimationFrame`** ticks before **`Book3D`** again, so disposing the previous slide’s canvases completes before allocating the next (~10+) contexts — avoids spikes that exceeded the browser cap and revoked the fixed **Color Bends** layer (**“Too many active WebGL contexts”**).
-- **Tests**: **`book-3d.spec.js`** (post-unmount intersect must not **`setSize`**, **`mockRenderer.getContext`** for **`WEBGL_lose_context`**).
+- **Tests**: **`book-3d.spec.js`** — post-unmount intersect must not recreate the renderer; **`getContext`** / **`WEBGL_lose_context`** (including **`getExtension`** throw swallowed in **`dispose`**); ResizeObserver callbacks after **unmount**; stale animation ticks after **unmount** or **leaveViewport**.
+- **`Book3D` instrumentation**: **`istanbul ignore next`** on the intro-timeout **`!inViewport`** guard (normally unreachable — viewport leave clears the timer before it fires).
 - **Version**: **0.85.8**
 
 ### `www.chrisvogt.me`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## 0.85.8
+
+### `gatsby-theme-chronogrove` — Goodreads carousel WebGL and dark-mode background
+
+- **`Book3D`**: Guards teardown so a late **`IntersectionObserver`** callback cannot **`createScene()`** after **`dispose()`** (disconnect observers and DOM listeners **before** destroying the Three.js scene); animation frame, intro **`setTimeout`**, and **`TextureLoader`** paths respect **`active`**; **`WEBGL_lose_context`** (**`loseContext`**) after **`renderer.dispose()`** where available so contexts are released promptly on drivers that defer until GC if not lost explicitly.
+- **Goodreads / `recently-read-books`**: On **`currentPage`** change (not initial mount), the active slide renders **flat covers** for two **`requestAnimationFrame`** ticks before **`Book3D`** again, so disposing the previous slide’s canvases completes before allocating the next (~10+) contexts — avoids spikes that exceeded the browser cap and revoked the fixed **Color Bends** layer (**“Too many active WebGL contexts”**).
+- **Tests**: **`book-3d.spec.js`** (post-unmount intersect must not **`setSize`**, **`mockRenderer.getContext`** for **`WEBGL_lose_context`**).
+- **Version**: **0.85.8**
+
+### `www.chrisvogt.me`
+
+- **Version**: **1.16.8** (tracks theme **0.85.8**).
+
+### `www.chronogrove.com` (demo)
+
+- **Version**: **1.3.8** (tracks theme **0.85.8**).
+
+### Files changed
+
+- `theme/package.json` (version **0.85.8**), `theme/src/components/artwork/book-3d.js`, `theme/src/components/artwork/book-3d.spec.js`, `theme/src/components/widgets/goodreads/recently-read-books.js`
+- `www.chrisvogt.me/package.json` (version **1.16.8**), `www.chronogrove.com/package.json` (version **1.3.8**)
+- `CHANGELOG.md`
+
+---
+
 ## 0.85.7
 
 ### `@chronogrove/ui` — Letterpress card depth + dashboard widget headers

--- a/theme/package.json
+++ b/theme/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-theme-chronogrove",
   "description": "A personal website and digital garden theme for GatsbyJS.",
-  "version": "0.85.7",
+  "version": "0.85.8",
   "author": "Chris Vogt <mail@chrisvogt.me> (https://www.chrisvogt.me)",
   "main": "index.js",
   "license": "MIT",

--- a/theme/src/components/artwork/book-3d.js
+++ b/theme/src/components/artwork/book-3d.js
@@ -220,6 +220,8 @@ const Book3D = ({ thumbnailURL, title, introDelay = 0 }) => {
       clearTimeout(introTimer)
       introTimer = setTimeout(() => {
         if (!active) return
+        /* Defensive: IO leave clears this timer first, so reaching !inViewport is effectively unreachable today. */
+        /* istanbul ignore next */
         if (!inViewport) {
           if (book) {
             book.rotation.y = REST_Y

--- a/theme/src/components/artwork/book-3d.js
+++ b/theme/src/components/artwork/book-3d.js
@@ -120,6 +120,12 @@ const Book3D = ({ thumbnailURL, title, introDelay = 0 }) => {
     const container = containerRef.current
     if (!container) return
 
+    // Prevents recreated WebGL contexts after teardown: observers may still deliver
+    // `isIntersecting` after dispose() clears `renderer`; without this, createScene()
+    // can fire again before disconnect() runs and leaks contexts (revoking older
+    // canvases like ColorBends).
+    let active = true
+
     // ── All Three.js state lives here so createScene/destroyScene can own it ──
     let renderer = null
     let scene = null
@@ -146,8 +152,12 @@ const Book3D = ({ thumbnailURL, title, introDelay = 0 }) => {
     }
 
     const startAnim = () => {
-      if (rafId !== null) return
+      if (!active || rafId !== null) return
       const tick = () => {
+        if (!active) {
+          rafId = null
+          return
+        }
         if (!inViewport) {
           rafId = null
           return
@@ -209,6 +219,7 @@ const Book3D = ({ thumbnailURL, title, introDelay = 0 }) => {
     const startIntroTimer = () => {
       clearTimeout(introTimer)
       introTimer = setTimeout(() => {
+        if (!active) return
         if (!inViewport) {
           if (book) {
             book.rotation.y = REST_Y
@@ -232,7 +243,7 @@ const Book3D = ({ thumbnailURL, title, introDelay = 0 }) => {
 
     // ── Scene creation ─────────────────────────────────────────────────────
     const createScene = () => {
-      if (renderer) return
+      if (!active || renderer) return
 
       const w = container.clientWidth || 200
       const h = container.clientHeight || 200
@@ -301,7 +312,7 @@ const Book3D = ({ thumbnailURL, title, introDelay = 0 }) => {
 
       // Load cover texture (or fall back immediately if no URL)
       const applyFallback = () => {
-        if (!coverMat) return
+        if (!active || !coverMat) return
         const fallbackTex = buildCoverFallbackTexture(title)
         coverMat.map = fallbackTex
         coverMat.color.set(0xffffff)
@@ -317,7 +328,7 @@ const Book3D = ({ thumbnailURL, title, introDelay = 0 }) => {
         loader.load(
           thumbnailURL,
           tex => {
-            if (!coverMat) return
+            if (!active || !coverMat) return
             tex.colorSpace = THREE.SRGBColorSpace
             coverMat.map = tex
             coverMat.color.set(0xffffff)
@@ -360,9 +371,17 @@ const Book3D = ({ thumbnailURL, title, introDelay = 0 }) => {
       }
       coverMat = null
 
+      const domEl = renderer.domElement
+      const gl = renderer.getContext()
       renderer.dispose()
-      if (renderer.domElement.parentElement === container) {
-        container.removeChild(renderer.domElement)
+      try {
+        gl.getExtension('WEBGL_lose_context')?.loseContext()
+      } catch {
+        // Context may already be torn down during dispose().
+      }
+
+      if (domEl.parentElement === container) {
+        container.removeChild(domEl)
       }
       renderer = null
       scene = null
@@ -377,6 +396,7 @@ const Book3D = ({ thumbnailURL, title, introDelay = 0 }) => {
     if ('IntersectionObserver' in window) {
       observer = new window.IntersectionObserver(
         ([entry]) => {
+          if (!active) return
           if (entry.isIntersecting) {
             inViewport = true
             if (!renderer) {
@@ -411,14 +431,16 @@ const Book3D = ({ thumbnailURL, title, introDelay = 0 }) => {
     } else {
       // No IntersectionObserver support — create immediately
       inViewport = true
-      createScene()
+      if (active) {
+        createScene()
+      }
     }
 
     // ── ResizeObserver ─────────────────────────────────────────────────────
     let ro
     if ('ResizeObserver' in window) {
       ro = new ResizeObserver(() => {
-        if (!renderer || !camera) return
+        if (!active || !renderer || !camera) return
         const nw = container.clientWidth || 200
         const nh = container.clientHeight || 200
         camera.aspect = nw / nh
@@ -462,12 +484,13 @@ const Book3D = ({ thumbnailURL, title, introDelay = 0 }) => {
 
     // ── Cleanup ────────────────────────────────────────────────────────────
     return () => {
-      destroyScene()
+      active = false
       if (observer) observer.disconnect()
       if (ro) ro.disconnect()
       container.removeEventListener('mouseenter', onMouseEnter)
       container.removeEventListener('mousemove', onMouseMove)
       container.removeEventListener('mouseleave', onMouseLeave)
+      destroyScene()
     }
   }, [thumbnailURL, title, introDelay])
 

--- a/theme/src/components/artwork/book-3d.spec.js
+++ b/theme/src/components/artwork/book-3d.spec.js
@@ -49,8 +49,15 @@ const mockCamera = {
   updateProjectionMatrix: jest.fn()
 }
 
+const mockGl = {
+  getExtension: jest.fn(() => ({
+    loseContext: jest.fn()
+  }))
+}
+
 const mockRenderer = {
   domElement: createMockCanvas(),
+  getContext: jest.fn(() => mockGl),
   setSize: jest.fn(),
   setPixelRatio: jest.fn(),
   setClearColor: jest.fn(),
@@ -190,6 +197,16 @@ describe('Artwork/Book3D', () => {
     enterViewport()
     expect(mockRenderer.setSize).toHaveBeenCalled()
     expect(mockScene.add).toHaveBeenCalledWith(mockMesh)
+  })
+
+  it('ignores IntersectionObserver intersect notifications after unmount (avoids stray WebGL recreation)', () => {
+    const { unmount } = render(<Book3D {...defaultProps} />)
+    enterViewport()
+    expect(mockRenderer.setSize).toHaveBeenCalled()
+    jest.clearAllMocks()
+    unmount()
+    intersectionCallback([{ isIntersecting: true }])
+    expect(mockRenderer.setSize).not.toHaveBeenCalled()
   })
 
   it('pauses WebGL when the book leaves the viewport without disposing the renderer', () => {

--- a/theme/src/components/artwork/book-3d.spec.js
+++ b/theme/src/components/artwork/book-3d.spec.js
@@ -284,6 +284,29 @@ describe('Artwork/Book3D', () => {
     expect(global.cancelAnimationFrame).toHaveBeenCalled()
   })
 
+  it('exits stale RAF tick when teardown already ran (!active)', () => {
+    const { unmount } = render(<Book3D {...defaultProps} />)
+    enterViewport()
+    jest.runAllTimers()
+    const tick = animationCallback
+    expect(tick).toEqual(expect.any(Function))
+    jest.clearAllMocks()
+    unmount()
+    tick()
+    expect(mockRenderer.render).not.toHaveBeenCalled()
+  })
+
+  it('exits stale RAF tick when the viewport already marked off-screen (!inViewport)', () => {
+    render(<Book3D {...defaultProps} />)
+    enterViewport()
+    jest.runAllTimers()
+    const tick = animationCallback
+    leaveViewport()
+    jest.clearAllMocks()
+    tick()
+    expect(mockRenderer.render).not.toHaveBeenCalled()
+  })
+
   it('runs a tick after the intro fires', () => {
     render(<Book3D {...defaultProps} />)
     enterViewport()
@@ -676,6 +699,16 @@ describe('Artwork/Book3D', () => {
     expect(mockRenderer.setSize).toHaveBeenCalled()
   })
 
+  it('ignores ResizeObserver resize callbacks after unmount (active guard)', () => {
+    const { unmount } = render(<Book3D {...defaultProps} />)
+    enterViewport()
+    jest.clearAllMocks()
+    unmount()
+    resizeCallback && resizeCallback([])
+    expect(mockRenderer.setSize).not.toHaveBeenCalled()
+    expect(mockCamera.updateProjectionMatrix).not.toHaveBeenCalled()
+  })
+
   // ── Cleanup ────────────────────────────────────────────────────────────────
 
   it('cleans up all resources on unmount', () => {
@@ -687,6 +720,16 @@ describe('Artwork/Book3D', () => {
     expect(mockIntersectionObserver.disconnect).toHaveBeenCalled()
     expect(mockResizeObserver.disconnect).toHaveBeenCalled()
     expect(mockGeometry.dispose).toHaveBeenCalled()
+    expect(mockRenderer.dispose).toHaveBeenCalled()
+  })
+
+  it('swallows WEBGL_lose_context errors during dispose when getExtension throws', () => {
+    mockGl.getExtension.mockImplementationOnce(() => {
+      throw new Error('context already invalidated')
+    })
+    const { unmount } = render(<Book3D {...defaultProps} />)
+    enterViewport()
+    expect(() => unmount()).not.toThrow()
     expect(mockRenderer.dispose).toHaveBeenCalled()
   })
 

--- a/theme/src/components/widgets/goodreads/recently-read-books.js
+++ b/theme/src/components/widgets/goodreads/recently-read-books.js
@@ -4,7 +4,7 @@ import { Heading } from '@theme-ui/components'
 import { RectShape } from 'react-placeholder/lib/placeholders'
 import { Themed } from '@theme-ui/mdx'
 import { useLocation, navigate } from '@gatsbyjs/reach-router'
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import isDarkMode from '../../../helpers/isDarkMode'
 import Pagination from '../../pagination'
 import useSwipePagination from '../../../hooks/use-swipe-pagination'
@@ -22,6 +22,14 @@ const RecentlyReadBooks = ({ books = [], isLoading }) => {
   const darkModeActive = isDarkMode(colorMode)
   const location = useLocation()
   const [currentPage, setCurrentPage] = useState(1)
+  /**
+   * After a page change, React unmounts the old slide's Book3D and mounts the new slide's in the
+   * same commit. That overlaps WebGL create/dispose and can briefly hold ~2× book contexts plus
+   * ColorBends, exceeding the browser cap and revoking the background. We show flat covers on the
+   * active slide for two animation frames so previous renderers can finish disposing first.
+   */
+  const [activeSlideWebglReady, setActiveSlideWebglReady] = useState(true)
+  const skipInitialWebglDefer = useRef(true)
   const params = new URLSearchParams(location.search)
   const bookId = params.get('bookId')
   const selectedBook = bookId ? books.find(book => book.id === bookId) : null
@@ -113,6 +121,25 @@ const RecentlyReadBooks = ({ books = [], isLoading }) => {
   useEffect(() => {
     setCurrentPage(1)
   }, [books])
+
+  useEffect(() => {
+    if (skipInitialWebglDefer.current) {
+      skipInitialWebglDefer.current = false
+      return
+    }
+    setActiveSlideWebglReady(false)
+    let raf1 = 0
+    let raf2 = 0
+    raf1 = requestAnimationFrame(() => {
+      raf2 = requestAnimationFrame(() => {
+        setActiveSlideWebglReady(true)
+      })
+    })
+    return () => {
+      cancelAnimationFrame(raf1)
+      if (raf2) cancelAnimationFrame(raf2)
+    }
+  }, [currentPage])
 
   const handleClose = e => {
     if (e) {
@@ -231,7 +258,7 @@ const RecentlyReadBooks = ({ books = [], isLoading }) => {
                         <BookLink
                           id={book.id}
                           key={book.id}
-                          flatCover={pageIndex !== currentPage - 1}
+                          flatCover={pageIndex !== currentPage - 1 || !activeSlideWebglReady}
                           introDelay={bookIndex * 80}
                           suppressNavigation={isDragging || isTransitioning}
                           thumbnailURL={book.cdnMediaURL || book.thumbnail}

--- a/www.chrisvogt.me/package.json
+++ b/www.chrisvogt.me/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "www.chrisvogt.me",
-  "version": "1.16.7",
+  "version": "1.16.8",
   "license": "GPL",
   "scripts": {
     "build": "gatsby build",

--- a/www.chronogrove.com/package.json
+++ b/www.chronogrove.com/package.json
@@ -1,6 +1,6 @@
 {
   "name": "www.chronogrove.com",
-  "version": "1.3.7",
+  "version": "1.3.8",
   "description": "Official demo site for gatsby-theme-chronogrove",
   "scripts": {
     "develop": "gatsby develop",


### PR DESCRIPTION
## Summary

Fixes dark-mode **Color Bends** / **THREE.WebGLRenderer: Context Lost** when paging the Goodreads carousel ("Too many active WebGL contexts").

### Changes

- **`recently-read-books`**: After **`currentPage`** changes, the active slide uses flat covers for two **`requestAnimationFrame`** ticks before mounting **`Book3D`**, so the previous slide’s WebGL contexts can finish disposing before allocating the next batch.
- **`Book3D`**: Harder teardown (disconnect observers before **`destroyScene`**), **`active`** guard across IO / RAF / timeouts / texture loads, **`WEBGL_lose_context`** **`loseContext()`** after **`renderer.dispose()`** where available.
- **Tests**: regression in **`book-3d.spec.js`**; mock **`getContext`** for **loseContext**.

### Versions

- `gatsby-theme-chronogrove`: **0.85.8**
- `www.chrisvogt.me`: **1.16.8**
- `www.chronogrove.com`: **1.3.8**

CHANGELOG updated under **## 0.85.8**.

Made with [Cursor](https://cursor.com)