### PR TITLE
fix(goodreads): preserve grid page after book detail (#601)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## 0.85.9
+
+### `gatsby-theme-chronogrove` — Goodreads grid pagination after book detail
+
+- **Goodreads / `recently-read-books`**: Reset carousel page to 1 only when the **book list identity** changes (ordered ids), not when the parent passes a new filtered **`books`** array reference on each render. Opening a book (**`?bookId=`**) no longer forces page 1 before returning from detail view ([#601](https://github.com/chrisvogt/gatsby-theme-chronogrove/issues/601)).
+- **Tests**: **`recently-read-books.spec.js`** — page survives rerender with a new array and the same ids.
+- **Version**: **0.85.9**
+
+### `www.chrisvogt.me`
+
+- **Version**: **1.16.9** (tracks theme **0.85.9**).
+
+### `www.chronogrove.com` (demo)
+
+- **Version**: **1.3.9** (tracks theme **0.85.9**).
+
+### Files changed
+
+- `theme/package.json` (version **0.85.9**), `theme/src/components/widgets/goodreads/recently-read-books.js`, `theme/src/components/widgets/goodreads/recently-read-books.spec.js`
+- `www.chrisvogt.me/package.json` (version **1.16.9**), `www.chronogrove.com/package.json` (version **1.3.9**)
+- `CHANGELOG.md`
+
+---
+
 ## 0.85.8
 
 ### `gatsby-theme-chronogrove` — Goodreads carousel WebGL and dark-mode background

--- a/theme/package.json
+++ b/theme/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-theme-chronogrove",
   "description": "A personal website and digital garden theme for GatsbyJS.",
-  "version": "0.85.8",
+  "version": "0.85.9",
   "author": "Chris Vogt <mail@chrisvogt.me> (https://www.chrisvogt.me)",
   "main": "index.js",
   "license": "MIT",

--- a/theme/src/components/widgets/goodreads/recently-read-books.js
+++ b/theme/src/components/widgets/goodreads/recently-read-books.js
@@ -118,9 +118,10 @@ const RecentlyReadBooks = ({ books = [], isLoading }) => {
     }
   }, [currentPage, totalPages])
 
+  const booksIdentityKey = books.map(b => b.id).join(',')
   useEffect(() => {
     setCurrentPage(1)
-  }, [books])
+  }, [booksIdentityKey])
 
   useEffect(() => {
     if (skipInitialWebglDefer.current) {

--- a/theme/src/components/widgets/goodreads/recently-read-books.spec.js
+++ b/theme/src/components/widgets/goodreads/recently-read-books.spec.js
@@ -177,6 +177,46 @@ describe('Widget/Goodreads/RecentlyReadBooks', () => {
         'Book 1'
       )
     })
+
+    it('preserves the current page when the books prop gets a new array reference with identical ids', () => {
+      const paginatedBooks = Array.from({ length: 20 }, (_, idx) => ({
+        ...mockBooks[idx % mockBooks.length],
+        id: `book-${idx + 1}`,
+        title: `Book ${idx + 1}`,
+        thumbnail: `https://example.com/book-${idx + 1}.jpg`
+      }))
+
+      const { rerender } = renderWithRouter(<RecentlyReadBooks books={paginatedBooks} isLoading={false} default />)
+
+      fireEvent.click(screen.getByLabelText('Go to page 2'))
+      expect(screen.getByText('Page 2 of 2')).toBeInTheDocument()
+
+      // Simulate a parent re-render producing a new array reference with the same books
+      const sameBooksNewReference = [...paginatedBooks]
+
+      rerender(
+        <LocationProvider
+          history={{
+            location: { pathname: '/' },
+            listen: () => () => {},
+            navigate: () => {},
+            _onTransitionComplete: () => {}
+          }}
+        >
+          <Router>
+            <div default>
+              <RecentlyReadBooks books={sameBooksNewReference} isLoading={false} default />
+            </div>
+          </Router>
+        </LocationProvider>
+      )
+
+      expect(screen.getByText('Page 2 of 2')).toBeInTheDocument()
+      expect(within(screen.getByTestId('goodreads-page-2')).getAllByTestId('book-link')[0]).toHaveAttribute(
+        'title',
+        'Book 11'
+      )
+    })
   })
 
   describe('navigation and scroll behavior', () => {

--- a/www.chrisvogt.me/package.json
+++ b/www.chrisvogt.me/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "www.chrisvogt.me",
-  "version": "1.16.8",
+  "version": "1.16.9",
   "license": "GPL",
   "scripts": {
     "build": "gatsby build",

--- a/www.chronogrove.com/package.json
+++ b/www.chronogrove.com/package.json
@@ -1,6 +1,6 @@
 {
   "name": "www.chronogrove.com",
-  "version": "1.3.8",
+  "version": "1.3.9",
   "description": "Official demo site for gatsby-theme-chronogrove",
   "scripts": {
     "develop": "gatsby develop",


### PR DESCRIPTION
## Summary

Fixes [#601](https://github.com/chrisvogt/gatsby-theme-chronogrove/issues/601).

The Goodreads carousel reset to page 1 whenever the parent re-rendered with a new `books` array reference (from `.filter()` in `goodreads-widget.js`), including when opening a book (`?bookId=`). Pagination now resets only when the ordered list of book ids changes.

## Changes

- `recently-read-books.js`: derive `booksIdentityKey` from ids; reset page effect depends on that key
- `recently-read-books.spec.js`: regression test for new array reference + same ids
- Version **0.85.9** (theme + tracking site bumps) and `CHANGELOG.md`

Made with [Cursor](https://cursor.com)