### PR TITLE
Reading room: single-column Travel & Music, 98% coverage discipline, Flickr → c1v0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog
 
+## 0.85.10
+
+### `www.chrisvogt.me` — Travel & Music index layout
+
+- **Travel (`/travel/`)**: Uses **`articleColumnContainerSx`** (same reading measure as the blog index and MDX posts), **single-column** post list, **home-widget-style** `PostCard` (vertical thumbnails + title block), and optional **`excerpt`** under the title when set in frontmatter.
+- **Music (`/music/`)**: Same **article column** width and **single-column** cards (stacked embeds) for easier focus than the previous multi-column grid.
+- **Tests**: **`theme/src/pages/chrisvogt-me-travel-page.spec.js`** and **`theme/src/pages/chrisvogt-me-music-page.spec.js`** exercise the site pages (filters, empty states, `Head` SEO props). **`theme/jest.config.js`** collects coverage for **`www.chrisvogt.me/src/pages/travel.js`** and **`music.js`**.
+- **Jest / Babel**: **`theme/babel.config.js`** adds a **`babel-plugin-remove-graphql-queries`** override **only** for `www.chrisvogt.me/**/*.js` so Jest can compile those pages without breaking theme **`useStaticQuery`** JSON extraction. **`theme/jest.config.js`** raises global **`coverageThreshold`** for **statements**, **lines**, and **functions** to **98%** (branches remain **90%**).
+- **Version**: **0.85.10**
+
+### `www.chrisvogt.me`
+
+- **Version**: **1.16.10** (tracks theme **0.85.10**).
+
+### `www.chronogrove.com` (demo)
+
+- **Version**: **1.3.10** (tracks theme **0.85.10**).
+
+### Files changed
+
+- `theme/package.json` (version **0.85.10**), `theme/babel.config.js`, `theme/jest.config.js` (coverage thresholds + collect paths), `theme/src/pages/chrisvogt-me-travel-page.spec.js`, `theme/src/pages/chrisvogt-me-music-page.spec.js`
+- `www.chrisvogt.me/package.json` (version **1.16.10**), `www.chrisvogt.me/src/pages/travel.js`, `www.chrisvogt.me/src/pages/music.js`
+- `www.chronogrove.com/package.json` (version **1.3.10**)
+- `CHANGELOG.md`
+
+---
+
 ## 0.85.9
 
 ### `gatsby-theme-chronogrove` — Goodreads grid pagination after book detail

--- a/theme/babel.config.js
+++ b/theme/babel.config.js
@@ -1,4 +1,24 @@
 // Babel config, used by Jest
+// Strip page queries only from the chrisvogt.me site package when Jest compiles it from theme tests.
+// Applying remove-graphql-queries to the whole repo breaks theme `useStaticQuery` JSON extraction.
+const path = require('path')
+
+const chrisvogtSiteRoot = path.join(__dirname, '..', 'www.chrisvogt.me')
+
 module.exports = {
-  presets: ['babel-preset-gatsby']
+  presets: ['babel-preset-gatsby'],
+  overrides: [
+    {
+      test: /www\.chrisvogt\.me[/\\].*\.jsx?$/,
+      plugins: [
+        [
+          require.resolve('babel-plugin-remove-graphql-queries'),
+          {
+            stage: 'develop',
+            path: chrisvogtSiteRoot
+          }
+        ]
+      ]
+    }
+  ]
 }

--- a/theme/jest.config.js
+++ b/theme/jest.config.js
@@ -14,6 +14,8 @@ module.exports = {
   collectCoverageFrom: [
     'src/**/*(.js|!(*.spec.js|*.scss|*.json|*.snap))',
     '../www.chrisvogt.me/components/**/*(.js|!(*.spec.js|*.scss|*.json|*.snap))',
+    '../www.chrisvogt.me/src/pages/travel.js',
+    '../www.chrisvogt.me/src/pages/music.js',
     'gatsby-browser.js',
     'gatsby-node.js',
     'gatsby-ssr.js',
@@ -58,10 +60,10 @@ module.exports = {
 
   coverageThreshold: {
     global: {
-      statements: 95,
+      statements: 98,
       branches: 90,
-      functions: 95,
-      lines: 95
+      functions: 98,
+      lines: 98
     }
   },
 

--- a/theme/package.json
+++ b/theme/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-theme-chronogrove",
   "description": "A personal website and digital garden theme for GatsbyJS.",
-  "version": "0.85.9",
+  "version": "0.85.10",
   "author": "Chris Vogt <mail@chrisvogt.me> (https://www.chrisvogt.me)",
   "main": "index.js",
   "license": "MIT",

--- a/theme/src/pages/chrisvogt-me-music-page.spec.js
+++ b/theme/src/pages/chrisvogt-me-music-page.spec.js
@@ -1,0 +1,159 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import '@testing-library/jest-dom'
+
+jest.mock('gatsby', () => ({
+  ...jest.requireActual('gatsby'),
+  graphql: jest.fn()
+}))
+
+jest.mock('../../../theme/src/components/animated-page-background', () => ({ overlayHeight }) => (
+  <div data-testid='animated-background' data-overlay-height={overlayHeight} />
+))
+jest.mock('../../../theme/src/components/layout', () => ({ children, transparentBackground }) => (
+  <div data-testid='layout' data-transparent={transparentBackground ? 'true' : 'false'}>
+    {children}
+  </div>
+))
+jest.mock('../../../theme/src/components/blog/page-header', () => ({ children }) => <h1>{children}</h1>)
+jest.mock(
+  '../../../theme/src/components/widgets/recent-posts/post-card',
+  () =>
+    ({ title, category, link, soundcloudId, youtubeSrc }) => (
+      <div
+        data-testid='post-card'
+        data-category={category}
+        data-link={link}
+        data-soundcloud={soundcloudId ?? ''}
+        data-youtube={youtubeSrc ?? ''}
+      >
+        {title}
+      </div>
+    )
+)
+jest.mock('../../../theme/src/components/seo', () => {
+  const MockSeo = ({ canonicalPath, title, description, children }) => (
+    <div data-testid='seo' data-canonical-path={canonicalPath} data-title={title} data-description={description}>
+      {children}
+    </div>
+  )
+  return { __esModule: true, default: MockSeo }
+})
+
+jest.mock('../../../theme/src/hooks/use-recent-posts', () => ({
+  getPosts: jest.fn()
+}))
+
+import MusicPage, { Head } from '../../../www.chrisvogt.me/src/pages/music'
+import { getPosts } from '../../../theme/src/hooks/use-recent-posts'
+import { TestProvider } from '../testUtils'
+
+describe('www.chrisvogt.me Music page', () => {
+  const mockData = { allMdx: { edges: [] } }
+
+  const musicNode = overrides => ({
+    fields: {
+      category: 'music',
+      id: 'm1',
+      path: '/music/song/',
+      ...overrides?.fields
+    },
+    frontmatter: {
+      date: 'March 1, 2025',
+      title: 'Original',
+      soundcloudId: null,
+      youtubeSrc: null,
+      ...overrides?.frontmatter
+    }
+  })
+
+  beforeEach(() => {
+    getPosts.mockReset()
+  })
+
+  it('renders music posts in a single column', () => {
+    getPosts.mockReturnValue([
+      musicNode(),
+      musicNode({
+        fields: { category: 'music/covers', id: 'm2', path: '/music/cover/' },
+        frontmatter: {
+          date: 'April 1, 2025',
+          title: 'Cover tune',
+          youtubeSrc: 'https://www.youtube.com/embed/abc'
+        }
+      })
+    ])
+
+    render(
+      <TestProvider>
+        <MusicPage data={mockData} />
+      </TestProvider>
+    )
+
+    expect(screen.getByTestId('layout')).toHaveAttribute('data-transparent', 'true')
+    expect(screen.getByText('My Music')).toBeInTheDocument()
+    const cards = screen.getAllByTestId('post-card')
+    expect(cards).toHaveLength(2)
+    expect(cards[0]).toHaveAttribute('data-category', 'music')
+    expect(cards[1]).toHaveAttribute('data-category', 'music/covers')
+    expect(cards[1]).toHaveAttribute('data-youtube', 'https://www.youtube.com/embed/abc')
+    expect(screen.getByRole('region', { name: 'Music posts' })).toBeInTheDocument()
+  })
+
+  it('filters out non-music posts', () => {
+    getPosts.mockReturnValue([
+      musicNode(),
+      {
+        fields: { category: 'travel', id: 't', path: '/travel/x/' },
+        frontmatter: { date: 'Jan 1', title: 'Trip' }
+      }
+    ])
+
+    render(
+      <TestProvider>
+        <MusicPage data={mockData} />
+      </TestProvider>
+    )
+
+    expect(screen.getAllByTestId('post-card')).toHaveLength(1)
+    expect(screen.queryByText('Trip')).not.toBeInTheDocument()
+  })
+
+  it('shows empty state when there are no music posts', () => {
+    getPosts.mockReturnValue([])
+
+    render(
+      <TestProvider>
+        <MusicPage data={mockData} />
+      </TestProvider>
+    )
+
+    expect(screen.queryAllByTestId('post-card')).toHaveLength(0)
+    expect(screen.getByText('No music posts yet. Check back soon!')).toBeInTheDocument()
+  })
+
+  it('treats missing getPosts data as empty', () => {
+    getPosts.mockReturnValue(undefined)
+
+    render(
+      <TestProvider>
+        <MusicPage data={mockData} />
+      </TestProvider>
+    )
+
+    expect(screen.getByText('No music posts yet. Check back soon!')).toBeInTheDocument()
+  })
+
+  it('Head renders SEO for /music/', () => {
+    render(
+      <TestProvider>
+        <Head />
+      </TestProvider>
+    )
+
+    const seo = screen.getByTestId('seo')
+    expect(seo).toHaveAttribute('data-canonical-path', '/music/')
+    expect(seo.getAttribute('data-title')).toContain('Music')
+    expect(seo.getAttribute('data-description')).toContain('chrisvogt.me')
+  })
+})

--- a/theme/src/pages/chrisvogt-me-travel-page.spec.js
+++ b/theme/src/pages/chrisvogt-me-travel-page.spec.js
@@ -1,0 +1,169 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import '@testing-library/jest-dom'
+
+jest.mock('gatsby', () => ({
+  ...jest.requireActual('gatsby'),
+  graphql: jest.fn()
+}))
+
+jest.mock('../../../theme/src/components/animated-page-background', () => ({ overlayHeight }) => (
+  <div data-testid='animated-background' data-overlay-height={overlayHeight} />
+))
+jest.mock('../../../theme/src/components/layout', () => ({ children, transparentBackground }) => (
+  <div data-testid='layout' data-transparent={transparentBackground ? 'true' : 'false'}>
+    {children}
+  </div>
+))
+jest.mock('../../../theme/src/components/blog/page-header', () => ({ children }) => <h1>{children}</h1>)
+jest.mock(
+  '../../../theme/src/components/widgets/recent-posts/post-card',
+  () =>
+    ({ title, category, excerpt, link, thumbnails }) => (
+      <div
+        data-testid='post-card'
+        data-category={category}
+        data-link={link}
+        data-excerpt={excerpt ?? ''}
+        data-thumbnails={thumbnails ? thumbnails.join(',') : ''}
+      >
+        {title}
+      </div>
+    )
+)
+jest.mock('../../../theme/src/components/seo', () => {
+  const MockSeo = ({ canonicalPath, title, description, children }) => (
+    <div data-testid='seo' data-canonical-path={canonicalPath} data-title={title} data-description={description}>
+      {children}
+    </div>
+  )
+  return { __esModule: true, default: MockSeo }
+})
+
+jest.mock('../../../theme/src/hooks/use-recent-posts', () => ({
+  getPosts: jest.fn()
+}))
+
+import TravelPage, { Head } from '../../../www.chrisvogt.me/src/pages/travel'
+import { getPosts } from '../../../theme/src/hooks/use-recent-posts'
+import { TestProvider } from '../testUtils'
+
+describe('www.chrisvogt.me Travel page', () => {
+  const mockData = { allMdx: { edges: [] } }
+
+  const travelNode = overrides => ({
+    fields: {
+      category: 'travel',
+      id: 't1',
+      path: '/travel/belize/',
+      ...overrides?.fields
+    },
+    frontmatter: {
+      date: 'January 1, 2025',
+      excerpt: 'Island hopping and reef days.',
+      thumbnails: ['https://example.com/a.jpg'],
+      title: 'Belize',
+      ...overrides?.frontmatter
+    }
+  })
+
+  beforeEach(() => {
+    getPosts.mockReset()
+  })
+
+  it('renders travel posts with home-style cards and excerpt', () => {
+    getPosts.mockReturnValue([
+      travelNode(),
+      travelNode({
+        fields: { category: 'travel/pnw', id: 't2', path: '/travel/pnw/' },
+        frontmatter: {
+          date: 'February 1, 2025',
+          excerpt: 'Mountains and coast.',
+          thumbnails: ['https://example.com/b.jpg'],
+          title: 'Pacific Northwest'
+        }
+      })
+    ])
+
+    render(
+      <TestProvider>
+        <TravelPage data={mockData} />
+      </TestProvider>
+    )
+
+    expect(screen.getByTestId('layout')).toHaveAttribute('data-transparent', 'true')
+    expect(screen.getByTestId('animated-background')).toHaveAttribute('data-overlay-height', 'min(75vh, 1000px)')
+    expect(screen.getByText('Travel')).toBeInTheDocument()
+    expect(screen.getByText('Narrative posts and photo galleries from trips and destinations.')).toBeInTheDocument()
+
+    const cards = screen.getAllByTestId('post-card')
+    expect(cards).toHaveLength(2)
+    expect(cards[0]).toHaveAttribute('data-category', 'travel')
+    expect(cards[0]).toHaveAttribute('data-excerpt', 'Island hopping and reef days.')
+    expect(cards[1]).toHaveAttribute('data-category', 'travel/pnw')
+    expect(screen.getByRole('region', { name: 'Travel posts' })).toBeInTheDocument()
+  })
+
+  it('filters out non-travel posts', () => {
+    getPosts.mockReturnValue([
+      travelNode(),
+      {
+        fields: { category: 'technology', id: 'x', path: '/blog/tech/' },
+        frontmatter: { date: 'Jan 1', title: 'Tech', excerpt: '', thumbnails: [] }
+      }
+    ])
+
+    render(
+      <TestProvider>
+        <TravelPage data={mockData} />
+      </TestProvider>
+    )
+
+    expect(screen.getAllByTestId('post-card')).toHaveLength(1)
+    expect(screen.getByText('Belize')).toBeInTheDocument()
+    expect(screen.queryByText('Tech')).not.toBeInTheDocument()
+  })
+
+  it('shows empty state when there are no travel posts', () => {
+    getPosts.mockReturnValue([
+      {
+        fields: { category: 'music', id: 'm', path: '/music/x/' },
+        frontmatter: { date: 'Jan 1', title: 'Song', excerpt: '', thumbnails: [] }
+      }
+    ])
+
+    render(
+      <TestProvider>
+        <TravelPage data={mockData} />
+      </TestProvider>
+    )
+
+    expect(screen.queryAllByTestId('post-card')).toHaveLength(0)
+    expect(screen.getByText('No travel posts yet. Check back soon!')).toBeInTheDocument()
+  })
+
+  it('treats missing getPosts data as empty', () => {
+    getPosts.mockReturnValue(undefined)
+
+    render(
+      <TestProvider>
+        <TravelPage data={mockData} />
+      </TestProvider>
+    )
+
+    expect(screen.getByText('No travel posts yet. Check back soon!')).toBeInTheDocument()
+  })
+
+  it('Head renders SEO for /travel/', () => {
+    render(
+      <TestProvider>
+        <Head />
+      </TestProvider>
+    )
+
+    const seo = screen.getByTestId('seo')
+    expect(seo).toHaveAttribute('data-canonical-path', '/travel/')
+    expect(seo).toHaveAttribute('data-title', 'Travel — Chris Vogt')
+    expect(seo.getAttribute('data-description')).toContain('Belize')
+  })
+})

--- a/www.chrisvogt.me/gatsby-config.js
+++ b/www.chrisvogt.me/gatsby-config.js
@@ -43,7 +43,7 @@ module.exports = {
         widgetDataSource: 'https://api.chrisvogt.me/widgets/discogs'
       },
       flickr: {
-        username: 'chrisvogt',
+        username: 'c1v0',
         widgetDataSource: 'https://api.chrisvogt.me/widgets/flickr'
       },
       github: {
@@ -274,7 +274,7 @@ module.exports = {
             widgetDataSource: 'https://api.chrisvogt.me/widgets/discogs'
           },
           flickr: {
-            username: 'chrisvogt',
+            username: 'c1v0',
             widgetDataSource: 'https://api.chrisvogt.me/widgets/flickr'
           },
           github: {

--- a/www.chrisvogt.me/package.json
+++ b/www.chrisvogt.me/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "www.chrisvogt.me",
-  "version": "1.16.9",
+  "version": "1.16.10",
   "license": "GPL",
   "scripts": {
     "build": "gatsby build",

--- a/www.chrisvogt.me/src/pages/music.js
+++ b/www.chrisvogt.me/src/pages/music.js
@@ -1,10 +1,11 @@
 /** @jsx jsx */
-import { Container, jsx } from 'theme-ui'
+import { Container, jsx, Box } from 'theme-ui'
 import { Themed } from '@theme-ui/mdx'
 import { Flex } from '@theme-ui/components'
 import { Fragment } from 'react'
 import { graphql } from 'gatsby'
 
+import { articleColumnContainerSx } from 'gatsby-theme-chronogrove/src/constants/article-column-container-sx'
 import AnimatedPageBackground from '../../../theme/src/components/animated-page-background'
 import { getPosts } from '../../../theme/src/hooks/use-recent-posts'
 import Layout from '../../../theme/src/components/layout'
@@ -13,7 +14,7 @@ import PostCard from '../../../theme/src/components/widgets/recent-posts/post-ca
 import Seo from '../../../theme/src/components/seo'
 
 const MusicPage = ({ data }) => {
-  const posts = getPosts(data)?.filter(post => post.fields.category?.startsWith('music'))
+  const posts = getPosts(data)?.filter(post => post.fields.category?.startsWith('music')) || []
   return (
     <Fragment>
       <AnimatedPageBackground overlayHeight='min(75vh, 1000px)' />
@@ -32,29 +33,37 @@ const MusicPage = ({ data }) => {
               py: 3
             }}
           >
-            <Container sx={{ flexGrow: 1, width: ['', '', 'max(95ch, 75vw)'] }}>
+            <Container sx={{ ...articleColumnContainerSx, flexGrow: 1 }}>
               <PageHeader>My Music</PageHeader>
 
-              <Themed.div
-                sx={{
-                  display: 'grid',
-                  gridGap: [3, 3, 4],
-                  gridTemplateColumns: ['1fr', '1fr 1fr'],
-                  mt: 4
-                }}
-              >
-                {posts.map(post => (
-                  <PostCard
-                    category={post.fields.category}
-                    date={post.frontmatter.date}
-                    key={post.fields.id}
-                    link={post.fields.path}
-                    soundcloudId={post.frontmatter.soundcloudId}
-                    title={post.frontmatter.title}
-                    youtubeSrc={post.frontmatter.youtubeSrc}
-                  />
-                ))}
-              </Themed.div>
+              {posts.length > 0 ? (
+                <Box
+                  as='section'
+                  aria-label='Music posts'
+                  sx={{
+                    display: 'grid',
+                    gridGap: 4,
+                    gridTemplateColumns: '1fr',
+                    mt: 4
+                  }}
+                >
+                  {posts.map(post => (
+                    <PostCard
+                      category={post.fields.category}
+                      date={post.frontmatter.date}
+                      key={post.fields.id}
+                      link={post.fields.path}
+                      soundcloudId={post.frontmatter.soundcloudId}
+                      title={post.frontmatter.title}
+                      youtubeSrc={post.frontmatter.youtubeSrc}
+                    />
+                  ))}
+                </Box>
+              ) : (
+                <Box sx={{ textAlign: 'center', py: 6, mt: 4 }}>
+                  <Themed.p sx={{ fontSize: 3, color: 'textMuted' }}>No music posts yet. Check back soon!</Themed.p>
+                </Box>
+              )}
             </Container>
           </Flex>
         </Layout>

--- a/www.chrisvogt.me/src/pages/travel.js
+++ b/www.chrisvogt.me/src/pages/travel.js
@@ -1,31 +1,17 @@
 /** @jsx jsx */
-import { Container, jsx } from 'theme-ui'
+import { Container, jsx, Box } from 'theme-ui'
 import { Themed } from '@theme-ui/mdx'
 import { Flex } from '@theme-ui/components'
 import { Fragment } from 'react'
 import { graphql } from 'gatsby'
 
+import { articleColumnContainerSx } from 'gatsby-theme-chronogrove/src/constants/article-column-container-sx'
 import AnimatedPageBackground from '../../../theme/src/components/animated-page-background'
 import { getPosts } from '../../../theme/src/hooks/use-recent-posts'
 import Layout from '../../../theme/src/components/layout'
 import PageHeader from '../../../theme/src/components/blog/page-header'
 import PostCard from '../../../theme/src/components/widgets/recent-posts/post-card'
 import Seo from '../../../theme/src/components/seo'
-
-const getColumnCount = postsCount => {
-  let columnCount
-  switch (postsCount) {
-    case 1:
-      columnCount = 1
-      break
-    case 2:
-      columnCount = 2
-      break
-    default:
-      columnCount = 3
-  }
-  return columnCount
-}
 
 const TravelPage = ({ data }) => {
   const posts =
@@ -50,37 +36,39 @@ const TravelPage = ({ data }) => {
               py: 3
             }}
           >
-            <Container sx={{ flexGrow: 1, width: ['', '', 'max(95ch, 75vw)'] }}>
+            <Container sx={{ ...articleColumnContainerSx, flexGrow: 1 }}>
               <PageHeader>Travel</PageHeader>
 
               <Themed.p>Narrative posts and photo galleries from trips and destinations.</Themed.p>
 
-              <Themed.div
-                sx={{
-                  display: 'grid',
-                  gridAutoRows: '1fr',
-                  gridGap: [3, 3, 4],
-                  gridTemplateColumns: [
-                    '',
-                    '1fr 1fr',
-                    '1fr 1fr',
-                    '1fr 1fr',
-                    `repeat(${getColumnCount(posts.length)}, 1fr)`
-                  ],
-                  mt: 4
-                }}
-              >
-                {posts.map(post => (
-                  <PostCard
-                    category={post.fields.category}
-                    date={post.frontmatter.date}
-                    key={post.fields.id}
-                    link={post.fields.path}
-                    thumbnails={post.frontmatter.thumbnails}
-                    title={post.frontmatter.title}
-                  />
-                ))}
-              </Themed.div>
+              {posts.length > 0 ? (
+                <Box
+                  as='section'
+                  aria-label='Travel posts'
+                  sx={{
+                    display: 'grid',
+                    gridGap: [2, 2, 3, 3],
+                    gridTemplateColumns: '1fr',
+                    mt: 4
+                  }}
+                >
+                  {posts.map(post => (
+                    <PostCard
+                      key={post.fields.id}
+                      category={post.fields.category}
+                      date={post.frontmatter.date}
+                      excerpt={post.frontmatter.excerpt}
+                      link={post.fields.path}
+                      thumbnails={post.frontmatter.thumbnails}
+                      title={post.frontmatter.title}
+                    />
+                  ))}
+                </Box>
+              ) : (
+                <Box sx={{ textAlign: 'center', py: 6, mt: 4 }}>
+                  <Themed.p sx={{ fontSize: 3, color: 'textMuted' }}>No travel posts yet. Check back soon!</Themed.p>
+                </Box>
+              )}
             </Container>
           </Flex>
         </Layout>
@@ -111,10 +99,8 @@ export const pageQuery = graphql`
             path
           }
           frontmatter {
-            banner
             date(formatString: "MMMM DD, YYYY")
-            description
-            slug
+            excerpt
             thumbnails
             title
           }

--- a/www.chronogrove.com/package.json
+++ b/www.chronogrove.com/package.json
@@ -1,6 +1,6 @@
 {
   "name": "www.chronogrove.com",
-  "version": "1.3.9",
+  "version": "1.3.10",
   "description": "Official demo site for gatsby-theme-chronogrove",
   "scripts": {
     "develop": "gatsby develop",


### PR DESCRIPTION
# The art of looking at one thing

Most dashboards want your peripheral vision. These two pages wanted the opposite: a **single column**, the same **measure** you already trust when you read a post, and cards that behave like the home widget you already curate—not a wider stage with competing thumbnails.

This PR is a small argument for **serial attention** on the open web.

---

### What changed (without sounding like a changelog)

| Where | Before | After |
| :--- | :--- | :--- |
| **Travel** | Wide canvas, multi-column grid, horizontal “blog index” cards | Article column (`80ch` family), **one card per row**, vertical **Latest Posts–style** cards, optional **excerpt** when you write one |
| **Music** | Same wide feel, 2-up grid on large screens | Same column discipline, **stacked** cards so embeds don’t fight their neighbors |
| **Flickr CTA** | Username drifted from your real profile | **`c1v0`** in both `siteMetadata` and theme `options` so config matches how you actually show up |

---

### A whispered manifesto for the diff

- *“Three columns is a party. One column is a conversation.”*
- *“If the blog index has a line length, the satellite indexes should inherit that politeness.”*
- *“Coverage is not a badge; it is a promise that the next person who touches this path will get feedback before production.”*

---

### The machinery (for reviewers who like receipts)

- **Jest** now collects **`www.chrisvogt.me/src/pages/travel.js`** and **`music.js`**, with **`chrisvogt-me-*-page.spec.js`** living in the theme so CI stays one command.
- **Babel**: `babel-plugin-remove-graphql-queries` runs **only** under `www.chrisvogt.me/**` so we don’t accidentally amputate theme `useStaticQuery` JSON in tests.
- **Thresholds**: global **98%** statements / lines / functions (branches stay at **90%**), because you asked the merge bar to mean something.
- **Versions**: theme **0.85.10**, **www.chrisvogt.me** **1.16.10**, demo **www.chronogrove.com** **1.3.10** — **CHANGELOG** tells the rest.

```mermaid
flowchart LR
  subgraph inputs [What the reader brings]
    A[Attention]
  end
  subgraph layout [What we give back]
    B[Article measure]
    C[One column]
    D[Home-style travel cards]
  end
  A --> B --> C --> D
```

---

### Deliberately *not* solved here (honesty as elegance)

Using the metrics API’s **`payload.profile`** for Flickr (and siblings) is tracked separately — see **#606**. This PR keeps that idea on the issue, not in the diff, so you can merge narrative and infrastructure without mixing the two stories.

---

### How to read this PR in sixty seconds

1. Skim **`www.chrisvogt.me/src/pages/travel.js`** and **`music.js`** for layout + query shape.
2. Open the two **`chrisvogt-me-*-page.spec.js`** files — they’re the contract.
3. Glance **`theme/babel.config.js`** overrides — that’s the guardrail that makes (1) testable without breaking the rest of the theme.

If this ships, the Travel and Music indexes should feel less like “another grid” and more like **rooms off the same hallway** as the blog.

