### PR TITLE
feat(travel): journal index carousel, hero sizing — v0.86.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,39 @@
 # Changelog
 
+## 0.86.0
+
+### `gatsby-theme-chronogrove` — Travel-ready Cloudinary sizing & tests for www travel index
+
+- **Cloudinary helpers** (`cloudinaryThumbnailUrl.js`): **`optimizeCloudinaryFillDimensionsSrc`** resizes/transforms uploads for arbitrary **fill** dimensions (not just square thumbs); **`CLOUDINARY_FEATURED_PORTRAIT_2X`** (~780×1040) supports a sharper travel **featured portrait** crop. Covered in **`cloudinaryThumbnailUrl.spec.js`**.
+- **Jest**: **`jest.config.js`** includes **`www.chrisvogt.me/src/components/**`** in **`collectCoverageFrom`** so site-specific **`travel-journal-index`** stays within diff coverage thresholds. **`theme/src/pages/chrisvogt-me-travel-journal-index.spec.js`** exercises the travel journal UI (featured hero, carousel advance, **`+N`** overflow cue, stamps, **read-more** links, hero without image, **`Untitled`\*\* fallback).
+- **Version**: **0.86.0**
+
+### `www.chrisvogt.me`
+
+- **Travel journal** (`travel.js`): The travel index route uses **`TravelJournalIndex`** — featured **masthead** with **Instagram-style carousel** (interval, crossfade, dots, preload, gallery cue icon as **inline SVG**), timeline **stamp** rhythm, and **`travel-read-more-link`** CTAs with explicit **`aria-label`s**. Implemented in **`www.chrisvogt.me/src/components/travel-journal-index.js`**.
+- **`chrisvogt-me-travel-page.spec.js`**: Assertions updated for the new layout/cue semantics.
+- **Version**: **1.17.0** (tracks theme **0.86.0**).
+
+### `www.chronogrove.com` (demo)
+
+- **Version**: **1.4.0** (tracks theme **0.86.0**).
+
+### Files changed
+
+- `CHANGELOG.md`
+- `theme/package.json` (version **0.86.0**)
+- `theme/jest.config.js`
+- `theme/src/helpers/cloudinaryThumbnailUrl.js`
+- `theme/src/helpers/cloudinaryThumbnailUrl.spec.js`
+- **`theme/src/pages/chrisvogt-me-travel-journal-index.spec.js`**
+- `theme/src/pages/chrisvogt-me-travel-page.spec.js`
+- `www.chrisvogt.me/package.json` (version **1.17.0**)
+- `www.chrisvogt.me/src/pages/travel.js`
+- **`www.chrisvogt.me/src/components/travel-journal-index.js`**
+- `www.chronogrove.com/package.json` (version **1.4.0**)
+
+---
+
 ## 0.85.16
 
 ### `gatsby-theme-chronogrove` — Discogs modal & vinyl sort labeling

--- a/theme/jest.config.js
+++ b/theme/jest.config.js
@@ -13,7 +13,7 @@ module.exports = {
   // An array of glob patterns indicating a set of files for which coverage information should be collected
   collectCoverageFrom: [
     'src/**/*(.js|!(*.spec.js|*.scss|*.json|*.snap))',
-    '../www.chrisvogt.me/components/**/*(.js|!(*.spec.js|*.scss|*.json|*.snap))',
+    '../www.chrisvogt.me/src/components/**/*(.js|!(*.spec.js|*.scss|*.json|*.snap))',
     '../www.chrisvogt.me/src/pages/travel.js',
     '../www.chrisvogt.me/src/pages/music.js',
     'gatsby-browser.js',

--- a/theme/package.json
+++ b/theme/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-theme-chronogrove",
   "description": "A personal website and digital garden theme for GatsbyJS.",
-  "version": "0.85.16",
+  "version": "0.86.0",
   "author": "Chris Vogt <mail@chrisvogt.me> (https://www.chrisvogt.me)",
   "main": "index.js",
   "license": "MIT",

--- a/theme/src/helpers/cloudinaryThumbnailUrl.js
+++ b/theme/src/helpers/cloudinaryThumbnailUrl.js
@@ -2,6 +2,9 @@ import { IMAGE_THUMBNAILS_SIZE_PX } from '@chronogrove/ui/image-thumbnails'
 
 const THUMBNAIL_SIZE_2X = IMAGE_THUMBNAILS_SIZE_PX * 2
 
+/** ~380px portrait column at 3:4, scaled for ~2x DPR — featured travel hero and similar heroes */
+export const CLOUDINARY_FEATURED_PORTRAIT_2X = { height: Math.round((780 * 4) / 3), width: 780 }
+
 /**
  * Check if URL is a valid Cloudinary URL by parsing the hostname
  * (prevents substring attacks like "https://evil.com/?url=res.cloudinary.com").
@@ -26,6 +29,24 @@ export function optimizeCloudinaryThumbnailSrc(src) {
   if (isCloudinaryUrl(src) && src.includes('/upload/')) {
     const transforms = `w_${THUMBNAIL_SIZE_2X},h_${THUMBNAIL_SIZE_2X},c_fill,f_auto,q_auto`
 
+    return src.replace(/\/upload\/(?:[^/]+\/)?v(\d+)/, `/upload/${transforms}/v$1`)
+  }
+
+  return src
+}
+
+/**
+ * Cloudinary resize with crop fill — for heroes / featured cards that need dimensions larger than thumbnails.
+ *
+ * @param {string | null | undefined} src
+ * @param {number} widthPx
+ * @param {number} heightPx
+ */
+export function optimizeCloudinaryFillDimensionsSrc(src, widthPx, heightPx) {
+  if (!src) return src
+
+  if (isCloudinaryUrl(src) && src.includes('/upload/') && Number.isFinite(widthPx) && Number.isFinite(heightPx)) {
+    const transforms = `w_${Math.round(widthPx)},h_${Math.round(heightPx)},c_fill,f_auto,q_auto`
     return src.replace(/\/upload\/(?:[^/]+\/)?v(\d+)/, `/upload/${transforms}/v$1`)
   }
 

--- a/theme/src/helpers/cloudinaryThumbnailUrl.spec.js
+++ b/theme/src/helpers/cloudinaryThumbnailUrl.spec.js
@@ -1,4 +1,8 @@
-import { isCloudinaryUrl, optimizeCloudinaryThumbnailSrc } from './cloudinaryThumbnailUrl'
+import {
+  isCloudinaryUrl,
+  optimizeCloudinaryFillDimensionsSrc,
+  optimizeCloudinaryThumbnailSrc
+} from './cloudinaryThumbnailUrl'
 
 describe('cloudinaryThumbnailUrl', () => {
   const cloudinaryImages = [
@@ -59,5 +63,34 @@ describe('cloudinaryThumbnailUrl', () => {
   it('returns Cloudinary URLs without /upload/ unchanged', () => {
     const u = 'https://res.cloudinary.com/demo/image/simple.jpg'
     expect(optimizeCloudinaryThumbnailSrc(u)).toBe(u)
+  })
+
+  describe('optimizeCloudinaryFillDimensionsSrc', () => {
+    it('applies portrait hero dimensions', () => {
+      const out = optimizeCloudinaryFillDimensionsSrc(cloudinaryImages[0], 780, Math.round((780 * 4) / 3))
+      expect(out).toMatchInlineSnapshot(
+        '"https://res.cloudinary.com/chrisvogt/image/upload/w_780,h_1040,c_fill,f_auto,q_auto/v1234567890/folder/image1.jpg"'
+      )
+    })
+
+    it('replaces prior transforms like thumb helper does', () => {
+      expect(optimizeCloudinaryFillDimensionsSrc(cloudinaryWithTransforms[1], 400, 500)).toMatchInlineSnapshot(
+        '"https://res.cloudinary.com/chrisvogt/image/upload/w_400,h_500,c_fill,f_auto,q_auto/v1750231638/galleries/image2.jpg"'
+      )
+    })
+
+    it('does not rewrite spoof URLs', () => {
+      const maliciousUrls = [
+        'https://evil.com/?redirect=res.cloudinary.com/image/upload/v123/image.jpg',
+        'https://attacker.com/path?url=https://res.cloudinary.com/image/upload/v123/img.jpg'
+      ]
+      maliciousUrls.forEach(url => {
+        expect(optimizeCloudinaryFillDimensionsSrc(url, 780, 1040)).toBe(url)
+      })
+    })
+
+    it('returns unchanged when dimensions are non-finite', () => {
+      expect(optimizeCloudinaryFillDimensionsSrc(cloudinaryImages[0], Number.NaN, 1040)).toBe(cloudinaryImages[0])
+    })
   })
 })

--- a/theme/src/pages/chrisvogt-me-travel-journal-index.spec.js
+++ b/theme/src/pages/chrisvogt-me-travel-journal-index.spec.js
@@ -1,0 +1,199 @@
+import React from 'react'
+import { render, screen, act, waitFor } from '@testing-library/react'
+import '@testing-library/jest-dom'
+
+jest.mock('gatsby', () => ({
+  graphql: jest.fn(),
+  Link: ({ children, to, ...rest }) => (
+    <a href={typeof to === 'string' ? to : '#'} {...rest}>
+      {children}
+    </a>
+  )
+}))
+
+import TravelJournalIndex from '../../../www.chrisvogt.me/src/components/travel-journal-index'
+import { TestProvider } from '../testUtils'
+
+/** Carousel advance ~= interval + crossfade in travel-journal-index */
+const CAROUSEL_STEP_MS = 3000 + 300
+
+const originalIntersectionObserver = global.IntersectionObserver
+
+describe('travel-journal-index (www)', () => {
+  const cloud = n => `https://res.cloudinary.com/chrisvogt/image/upload/v173000000${n}/blog/t${n}.jpg`
+
+  const makePost = (overrides = {}) => ({
+    fields: {
+      category: 'travel',
+      id: 't1',
+      path: '/travel/default/',
+      ...overrides.fields
+    },
+    frontmatter: {
+      date: 'January 1, 2025',
+      excerpt: 'Excerpt text.',
+      thumbnails: [cloud('1')],
+      title: 'Belize',
+      ...overrides.frontmatter
+    }
+  })
+
+  beforeEach(() => {
+    jest.spyOn(global, 'Image').mockImplementation(function MockImage() {
+      this.src = ''
+    })
+    global.IntersectionObserver = jest.fn().mockImplementation(cb => ({
+      disconnect: jest.fn(),
+      observe: jest.fn(el => {
+        cb([{ isIntersecting: true, target: el }])
+      }),
+      unobserve: jest.fn(),
+      root: null,
+      rootMargin: '',
+      thresholds: []
+    }))
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+    global.IntersectionObserver = originalIntersectionObserver
+  })
+
+  it('renders nothing when posts is empty', () => {
+    const { container } = render(
+      <TestProvider>
+        <TravelJournalIndex posts={[]} />
+      </TestProvider>
+    )
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders featured masthead plus read more for a single travel post', () => {
+    render(
+      <TestProvider>
+        <TravelJournalIndex posts={[makePost()]} />
+      </TestProvider>
+    )
+    expect(screen.getByTestId('travel-featured-entry')).toBeInTheDocument()
+    expect(screen.queryAllByTestId('travel-entry')).toHaveLength(0)
+    expect(screen.getByRole('heading', { level: 2, name: 'Belize' })).toBeInTheDocument()
+    expect(screen.getAllByTestId('travel-read-more-link')).toHaveLength(1)
+    expect(screen.queryByTestId('travel-featured-carousel-icon')).not.toBeInTheDocument()
+  })
+
+  it('shows carousel badge when featured has multiple thumbnails and advances slides on timers', async () => {
+    jest.useFakeTimers()
+    try {
+      render(
+        <TestProvider>
+          <TravelJournalIndex
+            posts={[
+              makePost({
+                frontmatter: {
+                  title: 'Multi',
+                  thumbnails: [cloud('91'), cloud('92')]
+                }
+              }),
+              makePost({
+                fields: { id: 't2', path: '/travel/next/' },
+                frontmatter: { title: 'Next', thumbnails: [cloud('3')] }
+              })
+            ]}
+          />
+        </TestProvider>
+      )
+
+      await waitFor(() => {
+        expect(screen.getByTestId('travel-featured-carousel-icon')).toBeInTheDocument()
+      })
+
+      screen.getByAltText(/^Multi: photo 1 of 2$/)
+
+      await act(async () => {
+        jest.advanceTimersByTime(CAROUSEL_STEP_MS)
+      })
+
+      await waitFor(() => {
+        expect(screen.getByAltText(/^Multi: photo 2 of 2$/)).toBeInTheDocument()
+      })
+    } finally {
+      act(() => {
+        jest.runOnlyPendingTimers()
+      })
+      jest.useRealTimers()
+    }
+  })
+
+  it('shows carousel +N cue when truncated to eight slides after cap', () => {
+    jest.useFakeTimers()
+    const thumbs = Array.from({ length: 9 }).map(
+      (_, i) => `https://res.cloudinary.com/chrisvogt/image/upload/v177000010${i}/g/x${i}.jpg`
+    )
+    try {
+      render(
+        <TestProvider>
+          <TravelJournalIndex posts={[makePost({ frontmatter: { title: 'Many', thumbnails: thumbs } })]} />
+        </TestProvider>
+      )
+      expect(screen.getByTestId('travel-featured-carousel-icon')).toBeInTheDocument()
+      expect(screen.getByText('+3')).toBeInTheDocument()
+    } finally {
+      act(() => {
+        jest.runOnlyPendingTimers()
+      })
+      jest.useRealTimers()
+    }
+  })
+
+  it('shows timeline stamps plus read-more on each stamp and featured row', () => {
+    render(
+      <TestProvider>
+        <TravelJournalIndex
+          posts={[
+            makePost(),
+            makePost({
+              fields: { id: 'b', category: 'travel/pnw', path: '/travel/pnw/' },
+              frontmatter: { title: 'PNW', excerpt: 'Mtns', thumbnails: ['https://cdn.example/z.jpg'] }
+            }),
+            makePost({
+              fields: { id: 'c', path: '/travel/tiny/' },
+              frontmatter: { title: 'Tiny', thumbnails: [], date: 'Feb 1', excerpt: null }
+            })
+          ]}
+        />
+      </TestProvider>
+    )
+
+    expect(screen.getAllByTestId('travel-entry')).toHaveLength(2)
+    const readLinks = screen.getAllByTestId('travel-read-more-link')
+    expect(readLinks).toHaveLength(3)
+    expect(readLinks[1]).toHaveAttribute('href', '/travel/pnw/')
+  })
+
+  it('shows hero frame without image when thumbnails are missing', () => {
+    render(
+      <TestProvider>
+        <TravelJournalIndex posts={[makePost({ frontmatter: { thumbnails: null } })]} />
+      </TestProvider>
+    )
+    expect(screen.getByTestId('travel-featured-hero')).toBeInTheDocument()
+    expect(screen.queryAllByRole('img')).toHaveLength(0)
+  })
+
+  it('uses Untitled headline when timeline title is not a string', () => {
+    render(
+      <TestProvider>
+        <TravelJournalIndex
+          posts={[
+            makePost(),
+            makePost({
+              fields: { id: 'unt', path: '/travel/u/' },
+              frontmatter: { title: undefined, thumbnails: [], excerpt: '' }
+            })
+          ]}
+        />
+      </TestProvider>
+    )
+    expect(screen.getByRole('heading', { level: 2, name: 'Untitled' })).toBeInTheDocument()
+  })
+})

--- a/theme/src/pages/chrisvogt-me-travel-page.spec.js
+++ b/theme/src/pages/chrisvogt-me-travel-page.spec.js
@@ -16,21 +16,6 @@ jest.mock('../../../theme/src/components/layout', () => ({ children, transparent
   </div>
 ))
 jest.mock('../../../theme/src/components/blog/page-header', () => ({ children }) => <h1>{children}</h1>)
-jest.mock(
-  '../../../theme/src/components/widgets/recent-posts/post-card',
-  () =>
-    ({ title, category, excerpt, link, thumbnails }) => (
-      <div
-        data-testid='post-card'
-        data-category={category}
-        data-link={link}
-        data-excerpt={excerpt ?? ''}
-        data-thumbnails={thumbnails ? thumbnails.join(',') : ''}
-      >
-        {title}
-      </div>
-    )
-)
 jest.mock('../../../theme/src/components/seo', () => {
   const MockSeo = ({ canonicalPath, title, description, children }) => (
     <div data-testid='seo' data-canonical-path={canonicalPath} data-title={title} data-description={description}>
@@ -71,7 +56,7 @@ describe('www.chrisvogt.me Travel page', () => {
     getPosts.mockReset()
   })
 
-  it('renders travel posts with home-style cards and excerpt', () => {
+  it('renders travel journal featured trip plus timeline stamps with excerpts', () => {
     getPosts.mockReturnValue([
       travelNode(),
       travelNode({
@@ -93,15 +78,43 @@ describe('www.chrisvogt.me Travel page', () => {
 
     expect(screen.getByTestId('layout')).toHaveAttribute('data-transparent', 'true')
     expect(screen.getByTestId('animated-background')).toHaveAttribute('data-overlay-height', 'min(75vh, 1000px)')
-    expect(screen.getByText('Travel')).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Travel' })).toBeInTheDocument()
     expect(screen.getByText('Narrative posts and photo galleries from trips and destinations.')).toBeInTheDocument()
 
-    const cards = screen.getAllByTestId('post-card')
-    expect(cards).toHaveLength(2)
-    expect(cards[0]).toHaveAttribute('data-category', 'travel')
-    expect(cards[0]).toHaveAttribute('data-excerpt', 'Island hopping and reef days.')
-    expect(cards[1]).toHaveAttribute('data-category', 'travel/pnw')
+    expect(screen.getByTestId('travel-featured-entry')).toBeInTheDocument()
+    expect(screen.getByRole('heading', { level: 2, name: 'Belize' })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { level: 2, name: 'Pacific Northwest' })).toBeInTheDocument()
+    expect(screen.getAllByTestId('travel-entry')).toHaveLength(1)
     expect(screen.getByRole('region', { name: 'Travel posts' })).toBeInTheDocument()
+  })
+
+  it('shows a gallery cue on featured trip when thumbnails list has multiple photos', () => {
+    getPosts.mockReturnValue([
+      travelNode({
+        fields: { id: 'travel-multi', path: '/travel/multi/' },
+        frontmatter: {
+          title: 'Multi-photo trip',
+          thumbnails: ['https://example.com/img-a.jpg', 'https://example.com/img-b.jpg']
+        }
+      }),
+      travelNode({
+        fields: { category: 'travel/pnw', id: 't2', path: '/travel/pnw/' },
+        frontmatter: {
+          date: 'February 1, 2025',
+          excerpt: 'Mountains and coast.',
+          thumbnails: ['https://example.com/b.jpg'],
+          title: 'Pacific Northwest'
+        }
+      })
+    ])
+
+    render(
+      <TestProvider>
+        <TravelPage data={mockData} />
+      </TestProvider>
+    )
+
+    expect(screen.getByTestId('travel-featured-carousel-icon')).toBeInTheDocument()
   })
 
   it('filters out non-travel posts', () => {
@@ -119,7 +132,7 @@ describe('www.chrisvogt.me Travel page', () => {
       </TestProvider>
     )
 
-    expect(screen.getAllByTestId('post-card')).toHaveLength(1)
+    expect(screen.queryAllByTestId('travel-entry')).toHaveLength(0)
     expect(screen.getByText('Belize')).toBeInTheDocument()
     expect(screen.queryByText('Tech')).not.toBeInTheDocument()
   })
@@ -138,7 +151,8 @@ describe('www.chrisvogt.me Travel page', () => {
       </TestProvider>
     )
 
-    expect(screen.queryAllByTestId('post-card')).toHaveLength(0)
+    expect(screen.queryByTestId('travel-featured-entry')).not.toBeInTheDocument()
+    expect(screen.queryAllByTestId('travel-entry')).toHaveLength(0)
     expect(screen.getByText('No travel posts yet. Check back soon!')).toBeInTheDocument()
   })
 

--- a/www.chrisvogt.me/package.json
+++ b/www.chrisvogt.me/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "www.chrisvogt.me",
-  "version": "1.16.16",
+  "version": "1.17.0",
   "license": "GPL",
   "scripts": {
     "build": "gatsby build",

--- a/www.chrisvogt.me/src/components/travel-journal-index.js
+++ b/www.chrisvogt.me/src/components/travel-journal-index.js
@@ -1,0 +1,645 @@
+/** @jsx jsx */
+/* global Image, IntersectionObserver */
+import React, { Fragment, useEffect, useMemo, useRef, useState } from 'react'
+import { jsx, Box } from 'theme-ui'
+import { Link } from 'gatsby'
+
+import Category from '../../../theme/src/components/category'
+import {
+  CLOUDINARY_FEATURED_PORTRAIT_2X,
+  optimizeCloudinaryFillDimensionsSrc,
+  optimizeCloudinaryThumbnailSrc
+} from '../../../theme/src/helpers/cloudinaryThumbnailUrl'
+
+function optimizedStampThumbnail(src) {
+  if (typeof src !== 'string' || src.length === 0) return undefined
+  const o = optimizeCloudinaryThumbnailSrc(src)
+  return o || undefined
+}
+
+function optimizedFeaturedPortrait(src) {
+  if (typeof src !== 'string' || src.length === 0) return undefined
+  const o = optimizeCloudinaryFillDimensionsSrc(
+    src,
+    CLOUDINARY_FEATURED_PORTRAIT_2X.width,
+    CLOUDINARY_FEATURED_PORTRAIT_2X.height
+  )
+  return o || undefined
+}
+
+/** Same timing as instagram-widget-item carousel rotation */
+const FEATURED_CAROUSEL_INTERVAL_MS = 3000
+const FEATURED_CAROUSEL_CROSSFADE_MS = 300
+const FEATURED_CAROUSEL_MAX_SLIDES = 8
+
+const preloadFeaturedImage = url => {
+  if (!url || typeof window === 'undefined') return
+  const img = new Image()
+  img.src = url
+}
+
+const Thumb = ({ sizePx, sx, url }) => (
+  <Box
+    aria-hidden
+    sx={{
+      width: `${sizePx}px`,
+      maxWidth: '100%',
+      aspectRatio: '3 / 4',
+      flexShrink: 0,
+      bg: 'muted',
+      ...(url ? { backgroundImage: `url(${url})` } : {}),
+      backgroundSize: 'cover',
+      backgroundPosition: 'center',
+      borderRadius: '11px',
+      borderWidth: '1px',
+      borderStyle: 'solid',
+      borderColor: 'muted',
+      boxShadow: '0 2px 10px rgba(0, 0, 0, 0.1)',
+      ...sx
+    }}
+  />
+)
+
+/** Stacked-frames cue (same role as instagram-widget-item carousel icon) — inline SVG so www has no FontAwesome dependency */
+const FeaturedGalleryCueIcon = () => (
+  <Box as='svg' aria-hidden viewBox='0 0 24 24' sx={{ width: '15px', height: '15px', display: 'block', flexShrink: 0 }}>
+    <rect x='11.5' y='8.5' width='9.5' height='9.5' rx='1.75' fill='white' opacity={0.4} />
+    <rect x='3' y='5' width='12.5' height='12.5' rx='1.75' fill='white' />
+  </Box>
+)
+
+const featuredHeroFrameSx = {
+  width: '100%',
+  maxWidth: ['min(396px, 100%)', null, null, 'none'],
+  mx: ['auto'],
+  aspectRatio: '3 / 4',
+  borderRadius: '11px',
+  overflow: 'hidden',
+  borderWidth: '1px',
+  borderStyle: 'solid',
+  borderColor: 'muted',
+  boxShadow: '0 2px 10px rgba(0, 0, 0, 0.1)',
+  position: 'relative',
+  bg: 'muted'
+}
+
+/**
+ * Carousel behaviour aligned with instagram-widget-item: timed advance, opacity crossfade, preload next,
+ * and dot indicators whenever the carousel is "active." Here, active means in view or hovered.
+ *
+ * @param {{ slideKeys: string[], title: string }} props
+ */
+const FeaturedHeroCarousel = ({ slideKeys, title }) => {
+  const keysLine = (Array.isArray(slideKeys) ? slideKeys : []).join('|')
+  const urls = useMemo(
+    () =>
+      (Array.isArray(slideKeys) ? slideKeys : [])
+        .slice(0, FEATURED_CAROUSEL_MAX_SLIDES)
+        .map(s => optimizedFeaturedPortrait(s))
+        .filter(Boolean),
+    [keysLine]
+  )
+
+  const [currentIndex, setCurrentIndex] = useState(0)
+  const [inView, setInView] = useState(false)
+  const [isMouseOver, setIsMouseOver] = useState(false)
+  const [isTransitioning, setIsTransitioning] = useState(false)
+
+  const rootRef = useRef(null)
+  const intervalRef = useRef(null)
+  const timeoutRef = useRef(null)
+  const slidesLenRef = useRef(0)
+  slidesLenRef.current = urls.length
+
+  const hasCarousel = urls.length > 1
+  const currentSrc = urls[currentIndex] || urls[0]
+  /** Active while in view (IntersectionObserver) or hovered — same crossfade/interval pattern as Instagram carousel items */
+  const isActive = hasCarousel && (inView || isMouseOver)
+
+  useEffect(() => {
+    const el = rootRef.current
+    if (!el || typeof IntersectionObserver === 'undefined') {
+      setInView(true)
+      return undefined
+    }
+    const observer = new IntersectionObserver(([entry]) => setInView(!!entry?.isIntersecting), {
+      threshold: 0.2,
+      rootMargin: '48px'
+    })
+    observer.observe(el)
+    return () => observer.disconnect()
+  }, [])
+
+  useEffect(() => {
+    setCurrentIndex(0)
+    setIsTransitioning(false)
+  }, [keysLine])
+
+  useEffect(() => {
+    if (hasCarousel && isActive && urls.length > 0) {
+      const next = (currentIndex + 1) % urls.length
+      preloadFeaturedImage(urls[next])
+    }
+  }, [currentIndex, hasCarousel, isActive, keysLine, urls])
+
+  useEffect(() => {
+    if (hasCarousel && isActive) {
+      urls.forEach(preloadFeaturedImage)
+    }
+  }, [hasCarousel, isActive, keysLine, urls])
+
+  useEffect(() => {
+    const clearTimers = () => {
+      if (intervalRef.current !== null) {
+        window.clearInterval(intervalRef.current)
+        intervalRef.current = null
+      }
+      if (timeoutRef.current !== null) {
+        window.clearTimeout(timeoutRef.current)
+        timeoutRef.current = null
+      }
+      setIsTransitioning(false)
+    }
+
+    clearTimers()
+    if (!hasCarousel || !isActive) {
+      return clearTimers
+    }
+
+    intervalRef.current = window.setInterval(() => {
+      setIsTransitioning(true)
+      timeoutRef.current = window.setTimeout(() => {
+        const len = slidesLenRef.current
+        setCurrentIndex(prev => (len > 0 ? (prev + 1) % len : 0))
+        setIsTransitioning(false)
+        timeoutRef.current = null
+      }, FEATURED_CAROUSEL_CROSSFADE_MS)
+    }, FEATURED_CAROUSEL_INTERVAL_MS)
+
+    return clearTimers
+  }, [hasCarousel, isActive, keysLine])
+
+  const handleMouseEnter = () => {
+    setIsMouseOver(true)
+  }
+
+  const handleMouseLeave = () => {
+    setIsMouseOver(false)
+  }
+
+  if (urls.length === 0) {
+    return (
+      <Box aria-hidden sx={{ ...featuredHeroFrameSx }} data-testid='travel-featured-hero'>
+        <Box sx={{ position: 'absolute', inset: 0 }} />
+      </Box>
+    )
+  }
+
+  const altPrefix = typeof title === 'string' ? title.trim() || 'Trip' : 'Trip'
+
+  return (
+    <Box
+      ref={rootRef}
+      aria-label={hasCarousel ? `Photo carousel for ${altPrefix}` : undefined}
+      data-testid='travel-featured-hero'
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+      sx={{ ...featuredHeroFrameSx }}
+    >
+      {hasCarousel ? (
+        <Box
+          aria-hidden
+          data-testid='travel-featured-carousel-icon'
+          sx={{
+            position: 'absolute',
+            top: '10px',
+            right: '10px',
+            zIndex: 2,
+            color: 'white',
+            backgroundColor: 'rgba(20, 20, 31, 0.72)',
+            borderRadius: '50%',
+            width: '28px',
+            height: '28px',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center'
+          }}
+        >
+          <FeaturedGalleryCueIcon />
+        </Box>
+      ) : null}
+
+      {hasCarousel && isActive ? (
+        <Box
+          data-testid='travel-featured-carousel-indicators'
+          sx={{
+            position: 'absolute',
+            bottom: 10,
+            left: '50%',
+            transform: 'translateX(-50%)',
+            display: 'flex',
+            gap: '5px',
+            zIndex: 2,
+            alignItems: 'center',
+            px: 2,
+            py: '5px',
+            borderRadius: '999px',
+            backgroundColor: 'rgba(12, 12, 20, 0.45)'
+          }}
+        >
+          {urls.slice(0, 5).map((_, idx) => {
+            const n = urls.length
+            const show = idx === currentIndex % Math.min(5, n)
+            return (
+              <span
+                aria-hidden
+                key={`travel-feature-dot-${idx}`}
+                sx={{
+                  width: '7px',
+                  height: '7px',
+                  borderRadius: '50%',
+                  backgroundColor: show ? 'rgba(255,255,255,1)' : 'rgba(255,255,255,0.42)',
+                  transition: 'background-color 0.2s ease'
+                }}
+              />
+            )
+          })}
+          {urls.length > 5 ? (
+            <Box as='span' sx={{ color: 'white', fontSize: '11px', lineHeight: '7px', pl: '2px', opacity: 0.9 }}>
+              +{urls.length - 5}
+            </Box>
+          ) : null}
+        </Box>
+      ) : null}
+
+      <Box
+        as='img'
+        key={currentIndex}
+        decoding='async'
+        loading='lazy'
+        alt={
+          urls.length === 1 ? `${altPrefix}: cover photo` : `${altPrefix}: photo ${currentIndex + 1} of ${urls.length}`
+        }
+        src={currentSrc}
+        sx={{
+          position: 'absolute',
+          inset: 0,
+          width: '100%',
+          height: '100%',
+          objectFit: 'cover',
+          display: 'block',
+          opacity: isTransitioning ? 0 : 1,
+          transition: 'opacity 0.28s ease-in-out'
+        }}
+      />
+    </Box>
+  )
+}
+
+const MetaFeatured = ({ category, date }) => (
+  <Box sx={{ display: 'flex', flexWrap: 'wrap', alignItems: 'center', columnGap: 2, rowGap: 1, mb: 3 }}>
+    {category ? <Category type={category} /> : null}
+    {category && date ? (
+      <Box aria-hidden sx={{ opacity: 0.45 }}>
+        •
+      </Box>
+    ) : null}
+    {date ? (
+      <Box as='time' sx={{ fontFamily: 'sans', fontSize: 1, color: 'textMuted' }}>
+        {date}
+      </Box>
+    ) : null}
+  </Box>
+)
+
+const Featured = ({ post }) => {
+  const { excerpt, thumbnails, title, date } = post.frontmatter
+  const category = post.fields.category
+  const href = post.fields.path
+
+  const slideKeys = useMemo(
+    () =>
+      [
+        ...new Set(
+          (Array.isArray(thumbnails) ? thumbnails : [])
+            .filter(s => typeof s === 'string')
+            .map(s => s.trim())
+            .filter(Boolean)
+        )
+      ].slice(0, FEATURED_CAROUSEL_MAX_SLIDES),
+    [JSON.stringify(Array.isArray(thumbnails) ? thumbnails : [])]
+  )
+
+  return (
+    <Box
+      as='article'
+      data-testid='travel-featured-entry'
+      sx={{
+        mb: [4, null, null, '2.875rem'],
+        pb: [3, null, null, '3.375rem'],
+        borderBottomWidth: '1px',
+        borderBottomStyle: 'solid',
+        borderBottomColor: 'muted'
+      }}
+    >
+      <Box
+        sx={{
+          display: 'grid',
+          gap: [3, null, null, '2.125rem'],
+          alignItems: 'center',
+          gridTemplateColumns: '1fr',
+          '@media screen and (min-width: 48em)': {
+            gridTemplateColumns: 'minmax(0, clamp(232px, 32vw, 380px)) minmax(0, 1fr)'
+          }
+        }}
+      >
+        <FeaturedHeroCarousel slideKeys={slideKeys} title={typeof title === 'string' ? title : ''} />
+        <Box sx={{ minWidth: 0 }}>
+          <Box
+            data-testid='travel-entry-link-featured'
+            as={Link}
+            sx={{
+              textDecoration: 'none',
+              color: 'inherit',
+              '& h2:hover': { color: 'primary' },
+              '&:focus-visible': {
+                outline: '2px solid',
+                outlineOffset: '3px',
+                borderRadius: 'sm',
+                outlineColor: 'primary'
+              }
+            }}
+            to={href}
+          >
+            <Box
+              as='h2'
+              sx={{
+                fontFamily: 'serif',
+                fontSize: [4, null, null, 'clamp(2.1875rem, 3vw, 2.6875rem)'],
+                mt: 0,
+                mb: 3,
+                lineHeight: 1.22
+              }}
+            >
+              {title}
+            </Box>
+          </Box>
+          <MetaFeatured category={category} date={date} />
+          {excerpt ? (
+            <Box
+              as='p'
+              sx={{
+                m: 0,
+                fontSize: [2, null, null, '1.05rem'],
+                lineHeight: [1.6, null, null, 1.65],
+                maxWidth: '44rem',
+                color: 'text'
+              }}
+            >
+              {excerpt}
+            </Box>
+          ) : null}
+          <TravelReadMoreLink href={href} title={typeof title === 'string' ? title : null} variant='featured' />
+        </Box>
+      </Box>
+    </Box>
+  )
+}
+
+const TravelReadMoreLink = ({ emphasis = false, href, title, variant = 'timeline' }) => {
+  const label = typeof title === 'string' && title.trim().length > 0 ? title.trim() : 'this trip'
+  const featured = variant === 'featured'
+
+  return (
+    <Box
+      as={Link}
+      aria-label={`Read full post: ${label}`}
+      data-testid='travel-read-more-link'
+      sx={{
+        alignItems: 'center',
+        justifyContent: 'center',
+        borderColor: 'primary',
+        borderRadius: '7px',
+        borderStyle: 'solid',
+        borderWidth: '1px',
+        color: 'primary',
+        display: 'inline-flex',
+        fontFamily: 'body',
+        fontSize: featured ? [1] : [0],
+        fontWeight: 600,
+        letterSpacing: featured ? '0.02em' : '0.06em',
+        lineHeight: 1.25,
+        mt: featured
+          ? ['1rem', null, null, '1.125rem']
+          : emphasis
+            ? ['0.875rem', null, null, '0.8125rem']
+            : ['0.6875rem', null, null, '0.75rem'],
+        px: featured ? ['0.875rem', null, null, '1rem'] : ['0.625rem'],
+        py: featured ? ['0.5rem', null, null, '0.5625rem'] : ['0.325rem'],
+        textDecoration: 'none',
+        textTransform: featured ? 'none' : 'uppercase',
+        transition: 'background-color 0.15s ease, color 0.15s ease, border-color 0.15s ease',
+        '&:hover': {
+          bg: 'primary',
+          color: 'background'
+        },
+        '&:focus-visible': {
+          outline: '2px solid',
+          outlineColor: 'primary',
+          outlineOffset: '3px'
+        }
+      }}
+      to={href}
+    >
+      Read more
+    </Box>
+  )
+}
+
+const StampDenseMeta = ({ category, date }) => (
+  <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: [2], alignItems: 'center', mb: '0.675rem', mt: '0.0625rem' }}>
+    {category ? <Category type={category} /> : null}
+    {category && date ? (
+      <Box aria-hidden sx={{ opacity: 0.45 }}>
+        •
+      </Box>
+    ) : null}
+    {date ? (
+      <Box
+        as='time'
+        sx={{
+          fontFamily: 'sans',
+          fontSize: [0],
+          color: 'textMuted',
+          letterSpacing: '0.04em',
+          textTransform: 'uppercase'
+        }}
+      >
+        {date}
+      </Box>
+    ) : null}
+  </Box>
+)
+
+const TimelineStamp = ({ emphasis, excerpt, href, thumbUrl, title, category, date }) => {
+  const thumbPx = emphasis ? 92 : 72
+  /** Theme UI font-size scale indexes – emphasis rows pop like magazine pull-quotes */
+  const titleFont = emphasis ? [3, null, null, 4] : [2]
+
+  return (
+    <Box
+      role='listitem'
+      data-testid='travel-entry'
+      sx={{
+        position: 'relative',
+        pl: ['0rem', null, null, '6.6875rem'],
+        py: [2, null, null, '1.5rem'],
+        borderBottomWidth: '1px',
+        borderBottomStyle: 'solid',
+        borderBottomColor: 'muted',
+        '&:last-of-type': { borderBottom: 'none' },
+        '&::before': {
+          '@media screen and (max-width: 51.9375em)': { display: 'none !important', content: 'none' },
+          '@media screen and (min-width: 52em)': {
+            content: '""',
+            position: 'absolute',
+            left: '54px',
+            top: emphasis ? '1.25rem' : '1rem',
+            width: emphasis ? '13px' : '11px',
+            height: emphasis ? '13px' : '11px',
+            borderRadius: '999px',
+            bg: emphasis ? 'primary' : 'textMuted',
+            opacity: emphasis ? 1 : 0.5,
+            border: theme => `2px solid ${theme.colors.background}`,
+            transform: 'translateX(-50%)',
+            boxShadow: '0 1px 2px rgba(0, 0, 0, 0.1)',
+            zIndex: 3
+          }
+        }
+      }}
+    >
+      <Box sx={{ display: 'flex', flexDirection: 'row', gap: [3, null, null, 4], alignItems: 'flex-start' }}>
+        <Box aria-hidden sx={{ mt: emphasis ? '-0.125rem' : '0.0625rem' }}>
+          <Box as={Link} sx={{ display: 'block', lineHeight: 0 }} tabIndex={-1} to={href}>
+            <Thumb sizePx={thumbPx} url={thumbUrl} />
+          </Box>
+        </Box>
+        <Box sx={{ minWidth: 0, pt: emphasis ? '-0.125rem' : '0rem' }}>
+          <Box
+            data-testid='travel-entry-link'
+            as={Link}
+            sx={{
+              display: 'block',
+              textDecoration: 'none',
+              color: 'inherit',
+              '& h2:hover': { color: 'primary' },
+              '&:focus-visible': {
+                outline: '2px solid',
+                outlineOffset: '2px',
+                borderRadius: 'sm',
+                outlineColor: 'primary'
+              }
+            }}
+            to={href}
+          >
+            <Box
+              as='h2'
+              sx={{
+                m: 0,
+                mb: '0.5rem',
+                fontFamily: 'serif',
+                fontSize: titleFont,
+                lineHeight: emphasis ? [1.3, null, null, 1.32] : 1.36
+              }}
+            >
+              {title}
+            </Box>
+          </Box>
+          {emphasis ? (
+            <MetaFeatured category={category} date={date} />
+          ) : (
+            <StampDenseMeta category={category} date={date} />
+          )}
+          {excerpt ? (
+            <Box
+              as='p'
+              sx={{
+                m: 0,
+                color: 'text',
+                fontSize: emphasis ? [2, null, null, null] : [1, null, null, 2],
+                lineHeight: emphasis ? 1.6 : 1.55,
+                maxWidth: '38rem'
+              }}
+            >
+              {excerpt}
+            </Box>
+          ) : null}
+          <TravelReadMoreLink
+            emphasis={emphasis}
+            href={href}
+            title={typeof title === 'string' ? title : null}
+            variant='timeline'
+          />
+        </Box>
+      </Box>
+    </Box>
+  )
+}
+
+/**
+ * Featured trip + timeline "passport stamps" blending ideas 1, 3, and 4.
+ * @param {{ posts: Array<{ fields: { category?: unknown, path: string }, frontmatter: { title?: unknown, thumbnails?: unknown, excerpt?: unknown, date?: unknown } }> }} props
+ */
+export default function TravelJournalIndex({ posts }) {
+  if (!Array.isArray(posts) || posts.length === 0) return null
+
+  const [first, ...rest] = posts
+
+  return (
+    <Fragment>
+      {first ? <Featured post={first} /> : null}
+      {rest.length > 0 ? (
+        <Box
+          role='list'
+          sx={{
+            position: 'relative',
+            '&::before': {
+              '@media screen and (max-width: 51.9375em)': {
+                display: 'none'
+              },
+              '@media screen and (min-width: 52em)': {
+                content: '""',
+                position: 'absolute',
+                left: '53px',
+                top: '-0.5rem',
+                bottom: '6px',
+                width: '2px',
+                borderRadius: '2px',
+                bg: theme => `${theme.colors.muted}`,
+                opacity: 0.55,
+                transform: 'translateX(-50%)',
+                zIndex: 1,
+                pointerEvents: 'none'
+              }
+            }
+          }}
+        >
+          {rest.map((post, i) => (
+            <TimelineStamp
+              key={`${post.fields.id ?? ''}-${post.fields.path ?? ''}-${String(i)}`}
+              category={typeof post.fields.category === 'string' ? post.fields.category : null}
+              date={typeof post.frontmatter.date === 'string' ? post.frontmatter.date : null}
+              excerpt={typeof post.frontmatter.excerpt === 'string' ? post.frontmatter.excerpt : null}
+              emphasis={i % 2 === 0}
+              href={post.fields.path}
+              thumbUrl={optimizedStampThumbnail(
+                Array.isArray(post.frontmatter.thumbnails) ? post.frontmatter.thumbnails[0] : null
+              )}
+              title={typeof post.frontmatter.title === 'string' ? post.frontmatter.title : 'Untitled'}
+            />
+          ))}
+        </Box>
+      ) : null}
+    </Fragment>
+  )
+}

--- a/www.chrisvogt.me/src/pages/travel.js
+++ b/www.chrisvogt.me/src/pages/travel.js
@@ -10,7 +10,7 @@ import AnimatedPageBackground from '../../../theme/src/components/animated-page-
 import { getPosts } from '../../../theme/src/hooks/use-recent-posts'
 import Layout from '../../../theme/src/components/layout'
 import PageHeader from '../../../theme/src/components/blog/page-header'
-import PostCard from '../../../theme/src/components/widgets/recent-posts/post-card'
+import TravelJournalIndex from '../components/travel-journal-index'
 import Seo from '../../../theme/src/components/seo'
 
 const TravelPage = ({ data }) => {
@@ -42,27 +42,8 @@ const TravelPage = ({ data }) => {
               <Themed.p>Narrative posts and photo galleries from trips and destinations.</Themed.p>
 
               {posts.length > 0 ? (
-                <Box
-                  as='section'
-                  aria-label='Travel posts'
-                  sx={{
-                    display: 'grid',
-                    gridGap: [2, 2, 3, 3],
-                    gridTemplateColumns: '1fr',
-                    mt: 4
-                  }}
-                >
-                  {posts.map(post => (
-                    <PostCard
-                      key={post.fields.id}
-                      category={post.fields.category}
-                      date={post.frontmatter.date}
-                      excerpt={post.frontmatter.excerpt}
-                      link={post.fields.path}
-                      thumbnails={post.frontmatter.thumbnails}
-                      title={post.frontmatter.title}
-                    />
-                  ))}
+                <Box as='section' aria-label='Travel posts' sx={{ mt: 4 }}>
+                  <TravelJournalIndex posts={posts} />
                 </Box>
               ) : (
                 <Box sx={{ textAlign: 'center', py: 6, mt: 4 }}>

--- a/www.chronogrove.com/package.json
+++ b/www.chronogrove.com/package.json
@@ -1,6 +1,6 @@
 {
   "name": "www.chronogrove.com",
-  "version": "1.3.16",
+  "version": "1.4.0",
   "description": "Official demo site for gatsby-theme-chronogrove",
   "scripts": {
     "develop": "gatsby develop",


### PR DESCRIPTION
## Summary

- **Travel journal** (`www`): `/travel` uses `TravelJournalIndex` — featured masthead with Instagram-style carousel (interval, crossfade, dots, preload, inline SVG gallery cue), timeline stamp rhythm, and read-more CTAs with `aria-label`s.
- **Theme**: `optimizeCloudinaryFillDimensionsSrc` + `CLOUDINARY_FEATURED_PORTRAIT_2X` in `cloudinaryThumbnailUrl.js` for sharper featured hero portraits (tests expanded).
- **Tests**: `jest.config.js` collects coverage from `www.chrisvogt.me/src/components/**`; new `chrisvogt-me-travel-journal-index.spec.js`; `chrisvogt-me-travel-page.spec.js` updated.
- **Release**: `gatsby-theme-chronogrove` **0.86.0**, `www.chrisvogt.me` **1.17.0**, `www.chronogrove.com` **1.4.0** — see `CHANGELOG.md` **0.86.0**.

## Test plan

- [x] `pnpm --filter gatsby-theme-chronogrove test:coverage` (meets thresholds)

Made with [Cursor](https://cursor.com)