### PR TITLE
fix: resolve 7 Sonar static-analysis issues (patch 0.87.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,44 @@
 # Changelog
 
+## 0.87.1
+
+### `@chronogrove/ui` — Sonar bug fixes (patch)
+
+- **`action-button.js`**: Replaced redundant `{icon && icon}` expression with `{icon}` (Sonar S1764 — identical sub-expressions).
+- **`pagination-button.js`**: Same fix for the identical `{icon && icon}` expression.
+- **Version**: **0.84.1**
+
+### `gatsby-theme-chronogrove` — Sonar bug fixes (patch)
+
+- **`discogs-modal.js`**: Added `onKeyDown={e => e.stopPropagation()}` to the inner modal panel alongside its existing `onClick` to satisfy `jsx-a11y/click-events-have-key-events`.
+- **`vinyl-pagination.js`**: Collapsed `isCurrentPage ? 'primary' : 'primary'` to the literal `'primary'` (Sonar S3923 — dead conditional).
+- **`recently-read-books.js`**: Prefixed bare `goodreadsElement.offsetHeight` reflow read with `void` to satisfy `no-unused-expressions`.
+- **`steam-game-card.js`**: Replaced root `<div onClick>` with `<Box as='button' type='button'>` plus `aria-label` for full keyboard accessibility (`jsx-a11y/click-events-have-key-events`). Imports `Box` from `theme-ui`.
+- **`steam-game-card.spec.js`**: Added tests asserting the card renders as a `<button>` element with the correct `aria-label`.
+- **Version**: **0.87.1**
+
+### `www.chrisvogt.me` — Sonar bug fix (patch)
+
+- **`CareerPathVisualization.js`**: Collapsed `isSmallScreen ? 'Art In Reality' : 'Art In Reality'` to the literal `'Art In Reality'` (Sonar S3923 — dead conditional).
+- **Version**: **1.18.1**
+
+### Files changed
+
+- `CHANGELOG.md`
+- `packages/ui/package.json` (version **0.84.1**)
+- `packages/ui/src/action-button.js`
+- `packages/ui/src/pagination-button.js`
+- `theme/package.json` (version **0.87.1**)
+- `theme/src/components/widgets/discogs/discogs-modal.js`
+- `theme/src/components/widgets/discogs/vinyl-pagination.js`
+- `theme/src/components/widgets/goodreads/recently-read-books.js`
+- `theme/src/components/widgets/steam/steam-game-card.js`
+- `theme/src/components/widgets/steam/steam-game-card.spec.js`
+- `www.chrisvogt.me/package.json` (version **1.18.1**)
+- `www.chrisvogt.me/components/CareerPathVisualization.js`
+
+---
+
 ## 0.87.0
 
 ### `@chronogrove/ui` — Category index hero chrome & layout tokens

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chronogrove/ui",
-  "version": "0.84.0",
+  "version": "0.84.1",
   "description": "Chronogrove Theme UI theme, color mode helpers, and shared UI primitives",
   "license": "MIT",
   "type": "module",

--- a/packages/ui/src/action-button.js
+++ b/packages/ui/src/action-button.js
@@ -61,7 +61,7 @@ const ActionButton = ({ children, href, onClick, variant = 'primary', size = 'me
   const content = (
     <>
       {children}
-      {icon && icon}
+      {icon}
     </>
   )
 

--- a/packages/ui/src/pagination-button.js
+++ b/packages/ui/src/pagination-button.js
@@ -92,7 +92,7 @@ const PaginationButton = ({
   const content = (
     <>
       {children}
-      {icon && icon}
+      {icon}
     </>
   )
 

--- a/theme/package.json
+++ b/theme/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-theme-chronogrove",
   "description": "A personal website and digital garden theme for GatsbyJS.",
-  "version": "0.87.0",
+  "version": "0.87.1",
   "author": "Chris Vogt <mail@chrisvogt.me> (https://www.chrisvogt.me)",
   "main": "index.js",
   "license": "MIT",

--- a/theme/src/components/widgets/discogs/discogs-modal.js
+++ b/theme/src/components/widgets/discogs/discogs-modal.js
@@ -189,6 +189,7 @@ const DiscogsModal = ({ isOpen, onClose, release, orderedReleases, onSelectRelea
           position: 'relative'
         }}
         onClick={e => e.stopPropagation()}
+        onKeyDown={e => e.stopPropagation()}
       >
         {/* Close button */}
         <button

--- a/theme/src/components/widgets/discogs/discogs-modal.spec.js
+++ b/theme/src/components/widgets/discogs/discogs-modal.spec.js
@@ -371,6 +371,14 @@ describe('DiscogsModal', () => {
     expect(mockOnClose).not.toHaveBeenCalled()
   })
 
+  it('does not call onClose when a key is pressed inside modal content (stopPropagation)', () => {
+    const { container } = render(<DiscogsModal isOpen={true} onClose={mockOnClose} release={mockRelease} />)
+
+    const modalContent = container.querySelector('[role="dialog"]').children[1]
+    fireEvent.keyDown(modalContent, { key: 'Enter', bubbles: true })
+    expect(mockOnClose).not.toHaveBeenCalled()
+  })
+
   it('sets body overflow hidden when modal is open', () => {
     render(<DiscogsModal isOpen={true} onClose={mockOnClose} release={mockRelease} />)
     expect(document.body.style.overflow).toBe('hidden')

--- a/theme/src/components/widgets/discogs/vinyl-pagination.js
+++ b/theme/src/components/widgets/discogs/vinyl-pagination.js
@@ -122,7 +122,7 @@ const VinylPagination = ({ currentPage, totalPages, onPageChange }) => {
                       px: [1, 2],
                       borderRadius: ['14px', '16px'],
                       border: ['1px solid', '2px solid'],
-                      borderColor: isCurrentPage ? 'primary' : 'primary',
+                      borderColor: 'primary',
                       backgroundColor: isCurrentPage ? 'primary' : 'transparent',
                       color: isCurrentPage ? 'white' : 'primary',
                       cursor: 'pointer',

--- a/theme/src/components/widgets/goodreads/recently-read-books.js
+++ b/theme/src/components/widgets/goodreads/recently-read-books.js
@@ -75,7 +75,7 @@ const RecentlyReadBooks = ({ books = [], isLoading }) => {
         const goodreadsElement = document.getElementById('goodreads')
         if (goodreadsElement) {
           // Force a reflow to ensure the element is properly positioned
-          goodreadsElement.offsetHeight
+          void goodreadsElement.offsetHeight
           // Use the browser's native hash navigation
           window.location.hash = 'goodreads'
         }

--- a/theme/src/components/widgets/steam/__snapshots__/play-time-chart.spec.js.snap
+++ b/theme/src/components/widgets/steam/__snapshots__/play-time-chart.spec.js.snap
@@ -8,8 +8,10 @@ exports[`PlayTimeChart Dark Mode Coverage matches snapshot for a game card in da
     <div
       class="css-zxiliy"
     >
-      <div
-        class="css-xsvu8c"
+      <button
+        aria-label="View Cities: Skylines on Steam"
+        class="css-1cffl98"
+        type="button"
       >
         <div
           class="css-w24l45"
@@ -42,9 +44,11 @@ exports[`PlayTimeChart Dark Mode Coverage matches snapshot for a game card in da
             757.35h total • 2h recently
           </div>
         </div>
-      </div>
-      <div
-        class="css-xsvu8c"
+      </button>
+      <button
+        aria-label="View ARK: Survival Evolved on Steam"
+        class="css-1cffl98"
+        type="button"
       >
         <div
           class="css-w24l45"
@@ -77,9 +81,11 @@ exports[`PlayTimeChart Dark Mode Coverage matches snapshot for a game card in da
             277.83h total
           </div>
         </div>
-      </div>
-      <div
-        class="css-xsvu8c"
+      </button>
+      <button
+        aria-label="View PUBG: BATTLEGROUNDS on Steam"
+        class="css-1cffl98"
+        type="button"
       >
         <div
           class="css-w24l45"
@@ -112,7 +118,7 @@ exports[`PlayTimeChart Dark Mode Coverage matches snapshot for a game card in da
             200h total • 1h recently
           </div>
         </div>
-      </div>
+      </button>
     </div>
     <div
       class="css-rcbrnq"
@@ -150,8 +156,10 @@ exports[`PlayTimeChart Dark Mode Coverage matches snapshot for a hovered game ca
     <div
       class="css-zxiliy"
     >
-      <div
-        class="css-xsvu8c"
+      <button
+        aria-label="View Cities: Skylines on Steam"
+        class="css-1cffl98"
+        type="button"
       >
         <div
           class="css-w24l45"
@@ -184,9 +192,11 @@ exports[`PlayTimeChart Dark Mode Coverage matches snapshot for a hovered game ca
             757.35h total • 2h recently
           </div>
         </div>
-      </div>
-      <div
-        class="css-xsvu8c"
+      </button>
+      <button
+        aria-label="View ARK: Survival Evolved on Steam"
+        class="css-1cffl98"
+        type="button"
       >
         <div
           class="css-w24l45"
@@ -219,9 +229,11 @@ exports[`PlayTimeChart Dark Mode Coverage matches snapshot for a hovered game ca
             277.83h total
           </div>
         </div>
-      </div>
-      <div
-        class="css-xsvu8c"
+      </button>
+      <button
+        aria-label="View PUBG: BATTLEGROUNDS on Steam"
+        class="css-1cffl98"
+        type="button"
       >
         <div
           class="css-w24l45"
@@ -254,7 +266,7 @@ exports[`PlayTimeChart Dark Mode Coverage matches snapshot for a hovered game ca
             200h total • 1h recently
           </div>
         </div>
-      </div>
+      </button>
     </div>
     <div
       class="css-rcbrnq"
@@ -292,8 +304,10 @@ exports[`PlayTimeChart Data Processing filters out games with zero playtime 1`] 
     <div
       class="css-zxiliy"
     >
-      <div
-        class="css-xsvu8c"
+      <button
+        aria-label="View Cities: Skylines on Steam"
+        class="css-1cffl98"
+        type="button"
       >
         <div
           class="css-w24l45"
@@ -326,9 +340,11 @@ exports[`PlayTimeChart Data Processing filters out games with zero playtime 1`] 
             757.35h total • 2h recently
           </div>
         </div>
-      </div>
-      <div
-        class="css-xsvu8c"
+      </button>
+      <button
+        aria-label="View ARK: Survival Evolved on Steam"
+        class="css-1cffl98"
+        type="button"
       >
         <div
           class="css-w24l45"
@@ -361,9 +377,11 @@ exports[`PlayTimeChart Data Processing filters out games with zero playtime 1`] 
             277.83h total
           </div>
         </div>
-      </div>
-      <div
-        class="css-xsvu8c"
+      </button>
+      <button
+        aria-label="View PUBG: BATTLEGROUNDS on Steam"
+        class="css-1cffl98"
+        type="button"
       >
         <div
           class="css-w24l45"
@@ -396,7 +414,7 @@ exports[`PlayTimeChart Data Processing filters out games with zero playtime 1`] 
             200h total • 1h recently
           </div>
         </div>
-      </div>
+      </button>
     </div>
     <div
       class="css-rcbrnq"
@@ -434,8 +452,10 @@ exports[`PlayTimeChart Data Processing renders correctly with sample data 1`] = 
     <div
       class="css-zxiliy"
     >
-      <div
-        class="css-xsvu8c"
+      <button
+        aria-label="View Cities: Skylines on Steam"
+        class="css-1cffl98"
+        type="button"
       >
         <div
           class="css-w24l45"
@@ -468,9 +488,11 @@ exports[`PlayTimeChart Data Processing renders correctly with sample data 1`] = 
             757.35h total • 2h recently
           </div>
         </div>
-      </div>
-      <div
-        class="css-xsvu8c"
+      </button>
+      <button
+        aria-label="View ARK: Survival Evolved on Steam"
+        class="css-1cffl98"
+        type="button"
       >
         <div
           class="css-w24l45"
@@ -503,9 +525,11 @@ exports[`PlayTimeChart Data Processing renders correctly with sample data 1`] = 
             277.83h total
           </div>
         </div>
-      </div>
-      <div
-        class="css-xsvu8c"
+      </button>
+      <button
+        aria-label="View PUBG: BATTLEGROUNDS on Steam"
+        class="css-1cffl98"
+        type="button"
       >
         <div
           class="css-w24l45"
@@ -538,7 +562,7 @@ exports[`PlayTimeChart Data Processing renders correctly with sample data 1`] = 
             200h total • 1h recently
           </div>
         </div>
-      </div>
+      </button>
     </div>
     <div
       class="css-rcbrnq"
@@ -576,8 +600,10 @@ exports[`PlayTimeChart Edge Cases handles single game scenario 1`] = `
     <div
       class="css-zxiliy"
     >
-      <div
-        class="css-xsvu8c"
+      <button
+        aria-label="View Cities: Skylines on Steam"
+        class="css-1cffl98"
+        type="button"
       >
         <div
           class="css-w24l45"
@@ -610,7 +636,7 @@ exports[`PlayTimeChart Edge Cases handles single game scenario 1`] = `
             757.35h total • 2h recently
           </div>
         </div>
-      </div>
+      </button>
     </div>
     <div
       class="css-rcbrnq"
@@ -702,8 +728,10 @@ exports[`PlayTimeChart Light Mode Coverage matches snapshot for a game card in l
     <div
       class="css-zxiliy"
     >
-      <div
-        class="css-xsvu8c"
+      <button
+        aria-label="View Cities: Skylines on Steam"
+        class="css-1cffl98"
+        type="button"
       >
         <div
           class="css-w24l45"
@@ -736,9 +764,11 @@ exports[`PlayTimeChart Light Mode Coverage matches snapshot for a game card in l
             757.35h total • 2h recently
           </div>
         </div>
-      </div>
-      <div
-        class="css-xsvu8c"
+      </button>
+      <button
+        aria-label="View ARK: Survival Evolved on Steam"
+        class="css-1cffl98"
+        type="button"
       >
         <div
           class="css-w24l45"
@@ -771,9 +801,11 @@ exports[`PlayTimeChart Light Mode Coverage matches snapshot for a game card in l
             277.83h total
           </div>
         </div>
-      </div>
-      <div
-        class="css-xsvu8c"
+      </button>
+      <button
+        aria-label="View PUBG: BATTLEGROUNDS on Steam"
+        class="css-1cffl98"
+        type="button"
       >
         <div
           class="css-w24l45"
@@ -806,7 +838,7 @@ exports[`PlayTimeChart Light Mode Coverage matches snapshot for a game card in l
             200h total • 1h recently
           </div>
         </div>
-      </div>
+      </button>
     </div>
     <div
       class="css-rcbrnq"
@@ -844,8 +876,10 @@ exports[`PlayTimeChart Light Mode Coverage matches snapshot for a hovered game c
     <div
       class="css-zxiliy"
     >
-      <div
-        class="css-xsvu8c"
+      <button
+        aria-label="View Cities: Skylines on Steam"
+        class="css-1cffl98"
+        type="button"
       >
         <div
           class="css-w24l45"
@@ -878,9 +912,11 @@ exports[`PlayTimeChart Light Mode Coverage matches snapshot for a hovered game c
             757.35h total • 2h recently
           </div>
         </div>
-      </div>
-      <div
-        class="css-xsvu8c"
+      </button>
+      <button
+        aria-label="View ARK: Survival Evolved on Steam"
+        class="css-1cffl98"
+        type="button"
       >
         <div
           class="css-w24l45"
@@ -913,9 +949,11 @@ exports[`PlayTimeChart Light Mode Coverage matches snapshot for a hovered game c
             277.83h total
           </div>
         </div>
-      </div>
-      <div
-        class="css-xsvu8c"
+      </button>
+      <button
+        aria-label="View PUBG: BATTLEGROUNDS on Steam"
+        class="css-1cffl98"
+        type="button"
       >
         <div
           class="css-w24l45"
@@ -948,7 +986,7 @@ exports[`PlayTimeChart Light Mode Coverage matches snapshot for a hovered game c
             200h total • 1h recently
           </div>
         </div>
-      </div>
+      </button>
     </div>
     <div
       class="css-rcbrnq"
@@ -1007,8 +1045,10 @@ exports[`PlayTimeChart Theme Integration adapts to dark mode styling 1`] = `
     <div
       class="css-zxiliy"
     >
-      <div
-        class="css-xsvu8c"
+      <button
+        aria-label="View Cities: Skylines on Steam"
+        class="css-1cffl98"
+        type="button"
       >
         <div
           class="css-w24l45"
@@ -1041,9 +1081,11 @@ exports[`PlayTimeChart Theme Integration adapts to dark mode styling 1`] = `
             757.35h total • 2h recently
           </div>
         </div>
-      </div>
-      <div
-        class="css-xsvu8c"
+      </button>
+      <button
+        aria-label="View ARK: Survival Evolved on Steam"
+        class="css-1cffl98"
+        type="button"
       >
         <div
           class="css-w24l45"
@@ -1076,9 +1118,11 @@ exports[`PlayTimeChart Theme Integration adapts to dark mode styling 1`] = `
             277.83h total
           </div>
         </div>
-      </div>
-      <div
-        class="css-xsvu8c"
+      </button>
+      <button
+        aria-label="View PUBG: BATTLEGROUNDS on Steam"
+        class="css-1cffl98"
+        type="button"
       >
         <div
           class="css-w24l45"
@@ -1111,7 +1155,7 @@ exports[`PlayTimeChart Theme Integration adapts to dark mode styling 1`] = `
             200h total • 1h recently
           </div>
         </div>
-      </div>
+      </button>
     </div>
     <div
       class="css-rcbrnq"
@@ -1149,8 +1193,10 @@ exports[`PlayTimeChart Theme Integration renders correctly in light mode 1`] = `
     <div
       class="css-zxiliy"
     >
-      <div
-        class="css-xsvu8c"
+      <button
+        aria-label="View Cities: Skylines on Steam"
+        class="css-1cffl98"
+        type="button"
       >
         <div
           class="css-w24l45"
@@ -1183,9 +1229,11 @@ exports[`PlayTimeChart Theme Integration renders correctly in light mode 1`] = `
             757.35h total • 2h recently
           </div>
         </div>
-      </div>
-      <div
-        class="css-xsvu8c"
+      </button>
+      <button
+        aria-label="View ARK: Survival Evolved on Steam"
+        class="css-1cffl98"
+        type="button"
       >
         <div
           class="css-w24l45"
@@ -1218,9 +1266,11 @@ exports[`PlayTimeChart Theme Integration renders correctly in light mode 1`] = `
             277.83h total
           </div>
         </div>
-      </div>
-      <div
-        class="css-xsvu8c"
+      </button>
+      <button
+        aria-label="View PUBG: BATTLEGROUNDS on Steam"
+        class="css-1cffl98"
+        type="button"
       >
         <div
           class="css-w24l45"
@@ -1253,7 +1303,7 @@ exports[`PlayTimeChart Theme Integration renders correctly in light mode 1`] = `
             200h total • 1h recently
           </div>
         </div>
-      </div>
+      </button>
     </div>
     <div
       class="css-rcbrnq"

--- a/theme/src/components/widgets/steam/__snapshots__/steam-widget.spec.js.snap
+++ b/theme/src/components/widgets/steam/__snapshots__/steam-widget.spec.js.snap
@@ -27,8 +27,10 @@ exports[`SteamWidget renders AI summary if present 1`] = `
     <div
       class="css-1jvl2a0"
     >
-      <div
-        class="css-xsvu8c"
+      <button
+        aria-label="View Half-Life on Steam"
+        class="css-1cffl98"
+        type="button"
       >
         <div
           class="css-w24l45"
@@ -56,9 +58,11 @@ exports[`SteamWidget renders AI summary if present 1`] = `
             2 hours
           </div>
         </div>
-      </div>
-      <div
-        class="css-xsvu8c"
+      </button>
+      <button
+        aria-label="View Portal on Steam"
+        class="css-1cffl98"
+        type="button"
       >
         <div
           class="css-w24l45"
@@ -86,7 +90,7 @@ exports[`SteamWidget renders AI summary if present 1`] = `
             45 minutes
           </div>
         </div>
-      </div>
+      </button>
     </div>
     <div
       class="css-5abbi3"
@@ -108,8 +112,10 @@ exports[`SteamWidget renders AI summary if present 1`] = `
       <div
         class="css-zxiliy"
       >
-        <div
-          class="css-xsvu8c"
+        <button
+          aria-label="View Cities: Skylines on Steam"
+          class="css-1cffl98"
+          type="button"
         >
           <div
             class="css-w24l45"
@@ -142,9 +148,11 @@ exports[`SteamWidget renders AI summary if present 1`] = `
               757.35h total • 2 hours recently
             </div>
           </div>
-        </div>
-        <div
-          class="css-xsvu8c"
+        </button>
+        <button
+          aria-label="View ARK: Survival Evolved on Steam"
+          class="css-1cffl98"
+          type="button"
         >
           <div
             class="css-w24l45"
@@ -177,7 +185,7 @@ exports[`SteamWidget renders AI summary if present 1`] = `
               277.83h total
             </div>
           </div>
-        </div>
+        </button>
       </div>
       <div
         class="css-rcbrnq"
@@ -319,8 +327,10 @@ exports[`SteamWidget renders correctly with sample data 1`] = `
     <div
       class="css-1jvl2a0"
     >
-      <div
-        class="css-xsvu8c"
+      <button
+        aria-label="View Half-Life on Steam"
+        class="css-1cffl98"
+        type="button"
       >
         <div
           class="css-w24l45"
@@ -348,9 +358,11 @@ exports[`SteamWidget renders correctly with sample data 1`] = `
             2 hours
           </div>
         </div>
-      </div>
-      <div
-        class="css-xsvu8c"
+      </button>
+      <button
+        aria-label="View Portal on Steam"
+        class="css-1cffl98"
+        type="button"
       >
         <div
           class="css-w24l45"
@@ -378,7 +390,7 @@ exports[`SteamWidget renders correctly with sample data 1`] = `
             45 minutes
           </div>
         </div>
-      </div>
+      </button>
     </div>
     <div
       class="css-5abbi3"
@@ -400,8 +412,10 @@ exports[`SteamWidget renders correctly with sample data 1`] = `
       <div
         class="css-zxiliy"
       >
-        <div
-          class="css-xsvu8c"
+        <button
+          aria-label="View Cities: Skylines on Steam"
+          class="css-1cffl98"
+          type="button"
         >
           <div
             class="css-w24l45"
@@ -434,9 +448,11 @@ exports[`SteamWidget renders correctly with sample data 1`] = `
               757.35h total • 2 hours recently
             </div>
           </div>
-        </div>
-        <div
-          class="css-xsvu8c"
+        </button>
+        <button
+          aria-label="View ARK: Survival Evolved on Steam"
+          class="css-1cffl98"
+          type="button"
         >
           <div
             class="css-w24l45"
@@ -469,7 +485,7 @@ exports[`SteamWidget renders correctly with sample data 1`] = `
               277.83h total
             </div>
           </div>
-        </div>
+        </button>
       </div>
       <div
         class="css-rcbrnq"
@@ -839,8 +855,10 @@ exports[`SteamWidget renders with empty metrics 1`] = `
     <div
       class="css-1jvl2a0"
     >
-      <div
-        class="css-xsvu8c"
+      <button
+        aria-label="View Half-Life on Steam"
+        class="css-1cffl98"
+        type="button"
       >
         <div
           class="css-w24l45"
@@ -868,9 +886,11 @@ exports[`SteamWidget renders with empty metrics 1`] = `
             2 hours
           </div>
         </div>
-      </div>
-      <div
-        class="css-xsvu8c"
+      </button>
+      <button
+        aria-label="View Portal on Steam"
+        class="css-1cffl98"
+        type="button"
       >
         <div
           class="css-w24l45"
@@ -898,7 +918,7 @@ exports[`SteamWidget renders with empty metrics 1`] = `
             45 minutes
           </div>
         </div>
-      </div>
+      </button>
     </div>
     <div
       class="css-5abbi3"
@@ -920,8 +940,10 @@ exports[`SteamWidget renders with empty metrics 1`] = `
       <div
         class="css-zxiliy"
       >
-        <div
-          class="css-xsvu8c"
+        <button
+          aria-label="View Cities: Skylines on Steam"
+          class="css-1cffl98"
+          type="button"
         >
           <div
             class="css-w24l45"
@@ -954,9 +976,11 @@ exports[`SteamWidget renders with empty metrics 1`] = `
               757.35h total • 2 hours recently
             </div>
           </div>
-        </div>
-        <div
-          class="css-xsvu8c"
+        </button>
+        <button
+          aria-label="View ARK: Survival Evolved on Steam"
+          class="css-1cffl98"
+          type="button"
         >
           <div
             class="css-w24l45"
@@ -989,7 +1013,7 @@ exports[`SteamWidget renders with empty metrics 1`] = `
               277.83h total
             </div>
           </div>
-        </div>
+        </button>
       </div>
       <div
         class="css-rcbrnq"

--- a/theme/src/components/widgets/steam/steam-game-card.js
+++ b/theme/src/components/widgets/steam/steam-game-card.js
@@ -1,5 +1,5 @@
 /** @jsx jsx */
-import { jsx, useThemeUI } from 'theme-ui'
+import { jsx, Box, useThemeUI } from 'theme-ui'
 import { useState } from 'react'
 import { RectShape } from 'react-placeholder/lib/placeholders'
 import isDarkMode from '../../../helpers/isDarkMode'
@@ -16,7 +16,10 @@ const SteamGameCard = ({ game, showRank = false, rank = null, subtitle = null, o
   const handleClick = onClick || (() => window.open(`https://store.steampowered.com/app/${game.id}`, '_blank'))
 
   return (
-    <div
+    <Box
+      as='button'
+      type='button'
+      aria-label={`View ${game.displayName} on Steam`}
       onMouseEnter={() => setIsHovered(true)}
       onMouseLeave={() => setIsHovered(false)}
       onClick={handleClick}
@@ -166,7 +169,7 @@ const SteamGameCard = ({ game, showRank = false, rank = null, subtitle = null, o
           </div>
         )}
       </div>
-    </div>
+    </Box>
   )
 }
 

--- a/theme/src/components/widgets/steam/steam-game-card.spec.js
+++ b/theme/src/components/widgets/steam/steam-game-card.spec.js
@@ -102,6 +102,19 @@ describe('SteamGameCard', () => {
     expect(global.open).not.toHaveBeenCalled()
   })
 
+  it('renders as a button element for keyboard accessibility', () => {
+    const { container } = renderWithTheme(<SteamGameCard game={mockGame} />)
+    const card = container.firstChild
+    expect(card.tagName).toBe('BUTTON')
+    expect(card.getAttribute('type')).toBe('button')
+  })
+
+  it('has an aria-label describing the game', () => {
+    const { container } = renderWithTheme(<SteamGameCard game={mockGame} />)
+    const card = container.firstChild
+    expect(card.getAttribute('aria-label')).toBe('View Test Game on Steam')
+  })
+
   it('handles hover state correctly', () => {
     const { container } = renderWithTheme(<SteamGameCard game={mockGame} />)
     const card = container.firstChild

--- a/www.chrisvogt.me/components/CareerPathVisualization.js
+++ b/www.chrisvogt.me/components/CareerPathVisualization.js
@@ -28,7 +28,7 @@ const CareerPathVisualization = () => {
       'Encore Discovery Solutions': isSmallScreen ? 'Encore' : 'Encore Discovery',
       'Pan Am Education': 'Pan Am',
       'Salucro Healthcare Solutions': isSmallScreen ? 'Salucro' : 'Salucro Healthcare',
-      'Art In Reality, LLC': isSmallScreen ? 'Art In Reality' : 'Art In Reality'
+      'Art In Reality, LLC': 'Art In Reality'
     }
     return abbreviations[name] || name
   }

--- a/www.chrisvogt.me/package.json
+++ b/www.chrisvogt.me/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "www.chrisvogt.me",
-  "version": "1.18.0",
+  "version": "1.18.1",
   "license": "GPL",
   "scripts": {
     "build": "gatsby build",


### PR DESCRIPTION
## Summary

- Collapse redundant `{icon && icon}` to `{icon}` in `action-button.js` and `pagination-button.js` (`@chronogrove/ui`)
- Add `onKeyDown` to the Discogs modal inner panel for keyboard parity alongside its `onClick` (`jsx-a11y`)
- Remove dead `isCurrentPage ? 'primary' : 'primary'` ternary in `vinyl-pagination.js`
- Prefix bare `goodreadsElement.offsetHeight` reflow read with `void` in `recently-read-books.js`
- Replace root `<div onClick>` with `<Box as='button' type='button'>` + `aria-label` in `steam-game-card.js`; update snapshots and add element-type / aria-label tests
- Collapse dead `'Art In Reality'` ternary in `CareerPathVisualization.js`

## Versions

| Package | Before | After |
|---|---|---|
| `@chronogrove/ui` | 0.84.0 | 0.84.1 |
| `gatsby-theme-chronogrove` | 0.87.0 | 0.87.1 |
| `www.chrisvogt.me` | 1.18.0 | 1.18.1 |

## Test plan

- [x] All 109 test suites pass (1315 tests)
- [x] Project-wide coverage thresholds met (98% statements/functions/lines, 90% branches)
- [x] Snapshots updated to reflect `<button>` root element in Steam card
- [x] New tests assert `SteamGameCard` renders as a `<button>` with the correct `aria-label`

Made with [Cursor](https://cursor.com)