### PR TITLE
feat(music): repertoire promo + PostTimelineIndex afterFeatured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,40 @@
 # Changelog
 
+## 0.88.0
+
+### `gatsby-theme-chronogrove` — Music index repertoire promo & timeline slot
+
+- **`PostTimelineIndex`** (`post-timeline-index.js`): Optional **`afterFeatured`** slot rendered between the featured row and stamp list; featured row exposes **`data-bottom-rule`** (`true` | `false`) for whether the muted bottom border is shown (omitted when **`afterFeatured`** is present).
+- **Tests**: **`post-timeline-index.spec.js`** (slot placement + **`data-bottom-rule`**); **`chrisvogt-me-music-repertoire-promo.spec.js`** (**`MusicRepertoirePromo`** / **`ColorModeImage`** light vs dark **`src`**); **`chrisvogt-me-music-page.spec.js`** mock forwards **`afterFeatured`**; **`gatsby-browser.spec.js`** (**`shouldUpdateScroll`** same-pathname branch, **`onClientEntry`** cross-domain color mode); **`flickr-widget.spec.js`** (missing LightGallery instance **`console.error`** path).
+- **Jest**: Global **`coverageThreshold.lines`** raised to **99%**.
+- **Version**: **0.88.0**
+
+### `www.chrisvogt.me`
+
+- **`music.js`**: Repertoire promo card (**`MusicRepertoirePromo`**) below the featured music post, linking to **https://repertoire.chrisvogt.me/** with color-mode screenshots; compact horizontal layout on narrow viewports; named export **`MusicRepertoirePromo`** for tests.
+- **Version**: **1.19.0**
+
+### `www.chronogrove.com` (demo)
+
+- **Version**: **1.6.0** (tracks theme **0.88.0**).
+
+### Files changed
+
+- `CHANGELOG.md`
+- `theme/jest.config.js`
+- `theme/package.json` (version **0.88.0**)
+- `theme/gatsby-browser.spec.js`
+- `theme/src/components/blog/post-timeline-index.js`
+- `theme/src/components/blog/post-timeline-index.spec.js`
+- `theme/src/components/widgets/flickr/flickr-widget.spec.js`
+- `theme/src/pages/chrisvogt-me-music-page.spec.js`
+- `theme/src/pages/chrisvogt-me-music-repertoire-promo.spec.js`
+- `www.chrisvogt.me/package.json` (version **1.19.0**)
+- `www.chrisvogt.me/src/pages/music.js`
+- `www.chronogrove.com/package.json` (version **1.6.0**)
+
+---
+
 ## 0.87.1
 
 ### `@chronogrove/ui` — Sonar bug fixes (patch)

--- a/theme/gatsby-browser.spec.js
+++ b/theme/gatsby-browser.spec.js
@@ -1,8 +1,9 @@
 import React from 'react'
 import { render } from '@testing-library/react'
 import '@testing-library/jest-dom'
-import { shouldUpdateScroll, onRouteUpdate, wrapRootElement } from './gatsby-browser'
+import { onClientEntry, onRouteUpdate, shouldUpdateScroll, wrapRootElement } from './gatsby-browser'
 import { onRouteUpdateChronogroveNavigation } from './src/helpers/on-route-update-chronogrove-navigation'
+import * as chronogroveColorMode from '@chronogrove/ui/color-mode'
 
 jest.mock('@gatsbyjs/reach-router', () => ({
   ...jest.requireActual('@gatsbyjs/reach-router'),
@@ -139,6 +140,52 @@ describe('gatsby-browser', () => {
       }
       const result = shouldUpdateScroll({ routerProps, prevRouterProps: undefined })
       expect(result).toBe(false)
+    })
+
+    it('returns false when pathname matches previous pathname', () => {
+      expect(
+        shouldUpdateScroll({
+          routerProps: { location: { pathname: '/blog' } },
+          prevRouterProps: { location: { pathname: '/blog' } }
+        })
+      ).toBe(false)
+    })
+  })
+
+  describe('onClientEntry', () => {
+    let originalRegistrableDomain
+
+    beforeEach(() => {
+      originalRegistrableDomain = process.env.GATSBY_COLOR_MODE_REGISTRABLE_DOMAIN
+    })
+
+    afterEach(() => {
+      if (originalRegistrableDomain === undefined) {
+        delete process.env.GATSBY_COLOR_MODE_REGISTRABLE_DOMAIN
+      } else {
+        process.env.GATSBY_COLOR_MODE_REGISTRABLE_DOMAIN = originalRegistrableDomain
+      }
+    })
+
+    it('configures cross-domain color mode when GATSBY_COLOR_MODE_REGISTRABLE_DOMAIN is set', () => {
+      const spy = jest.spyOn(chronogroveColorMode, 'setChronogroveCrossDomainColorModeClientConfig')
+      process.env.GATSBY_COLOR_MODE_REGISTRABLE_DOMAIN = '  example.test  '
+      onClientEntry()
+      expect(spy).toHaveBeenCalledWith({ registrableDomain: 'example.test' })
+      spy.mockRestore()
+    })
+
+    it('clears cross-domain color mode client config when env domain is absent or whitespace', () => {
+      const spy = jest.spyOn(chronogroveColorMode, 'setChronogroveCrossDomainColorModeClientConfig')
+      delete process.env.GATSBY_COLOR_MODE_REGISTRABLE_DOMAIN
+      onClientEntry()
+      expect(spy).toHaveBeenCalledWith(null)
+
+      spy.mockClear()
+      process.env.GATSBY_COLOR_MODE_REGISTRABLE_DOMAIN = '   \t'
+      onClientEntry()
+      expect(spy).toHaveBeenCalledWith(null)
+      spy.mockRestore()
     })
   })
 

--- a/theme/jest.config.js
+++ b/theme/jest.config.js
@@ -63,7 +63,7 @@ module.exports = {
       statements: 98,
       branches: 90,
       functions: 98,
-      lines: 98
+      lines: 99
     }
   },
 

--- a/theme/package.json
+++ b/theme/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-theme-chronogrove",
   "description": "A personal website and digital garden theme for GatsbyJS.",
-  "version": "0.87.1",
+  "version": "0.88.0",
   "author": "Chris Vogt <mail@chrisvogt.me> (https://www.chrisvogt.me)",
   "main": "index.js",
   "license": "MIT",

--- a/theme/src/components/blog/post-timeline-index.js
+++ b/theme/src/components/blog/post-timeline-index.js
@@ -390,7 +390,14 @@ const MetaFeatured = ({ category, date }) => (
   </Box>
 )
 
-const Featured = ({ featuredImageAltFallback, post, readMoreAriaFallback, tid, timelineAsideMedia = false }) => {
+const Featured = ({
+  featuredImageAltFallback,
+  post,
+  readMoreAriaFallback,
+  showBottomSeparator = true,
+  tid,
+  timelineAsideMedia = false
+}) => {
   const fm = post.frontmatter
   const { banner, excerpt, thumbnails, title, date, soundcloudId, youtubeSrc } = fm
   const category = post.fields.category
@@ -423,13 +430,18 @@ const Featured = ({ featuredImageAltFallback, post, readMoreAriaFallback, tid, t
   return (
     <Box
       as='article'
+      data-bottom-rule={showBottomSeparator ? 'true' : 'false'}
       data-testid={tid('featured-entry')}
       sx={{
         mb: [4, null, null, '2.875rem'],
         pb: [3, null, null, '3.375rem'],
-        borderBottomWidth: '1px',
-        borderBottomStyle: 'solid',
-        borderBottomColor: 'muted'
+        ...(showBottomSeparator
+          ? {
+              borderBottomWidth: '1px',
+              borderBottomStyle: 'solid',
+              borderBottomColor: 'muted'
+            }
+          : {})
       }}
     >
       <Box
@@ -731,7 +743,8 @@ const TimelineStamp = ({
  *   dataTestIdPrefix?: string,
  *   featuredImageAltFallback?: string,
  *   readMoreAriaFallback?: string,
- *   timelineAsideMedia?: boolean
+ *   timelineAsideMedia?: boolean,
+ *   afterFeatured?: import('react').ReactNode
  * }} props
  */
 export default function PostTimelineIndex({
@@ -739,7 +752,8 @@ export default function PostTimelineIndex({
   dataTestIdPrefix = 'post-timeline',
   featuredImageAltFallback = 'Post',
   readMoreAriaFallback = 'this post',
-  timelineAsideMedia = false
+  timelineAsideMedia = false,
+  afterFeatured = null
 }) {
   if (!Array.isArray(posts) || posts.length === 0) return null
 
@@ -753,10 +767,12 @@ export default function PostTimelineIndex({
           featuredImageAltFallback={featuredImageAltFallback}
           post={first}
           readMoreAriaFallback={readMoreAriaFallback}
+          showBottomSeparator={!afterFeatured}
           tid={tid}
           timelineAsideMedia={timelineAsideMedia}
         />
       ) : null}
+      {afterFeatured}
       {rest.length > 0 ? (
         <Box
           role='list'

--- a/theme/src/components/blog/post-timeline-index.spec.js
+++ b/theme/src/components/blog/post-timeline-index.spec.js
@@ -84,6 +84,28 @@ describe('PostTimelineIndex', () => {
     expect(screen.getAllByTestId('post-timeline-entry')).toHaveLength(1)
     expect(screen.getByRole('heading', { level: 2, name: 'First Post' })).toBeInTheDocument()
     expect(screen.getByRole('heading', { level: 2, name: 'Second' })).toBeInTheDocument()
+    expect(screen.getByTestId('post-timeline-featured-entry')).toHaveAttribute('data-bottom-rule', 'true')
+  })
+
+  it('renders afterFeatured between featured row and stamp list', () => {
+    render(
+      <TestProvider>
+        <PostTimelineIndex
+          afterFeatured={<div data-testid='after-featured-slot'>Between</div>}
+          posts={[
+            makePost(),
+            makePost({
+              fields: { id: 'p2', path: '/blog/second/' },
+              frontmatter: { title: 'Second', thumbnails: [cloud('2')] }
+            })
+          ]}
+        />
+      </TestProvider>
+    )
+
+    expect(screen.getByTestId('after-featured-slot')).toHaveTextContent('Between')
+    expect(screen.getByTestId('post-timeline-featured-entry')).toHaveAttribute('data-bottom-rule', 'false')
+    expect(screen.getAllByTestId('post-timeline-entry')).toHaveLength(1)
   })
 
   it('featured carousel hero receives hover handlers when multiple slides exist', () => {

--- a/theme/src/components/widgets/flickr/flickr-widget.spec.js
+++ b/theme/src/components/widgets/flickr/flickr-widget.spec.js
@@ -19,17 +19,20 @@ jest.mock('../../../hooks/use-site-metadata', () => () => ({
 jest.mock('../../../hooks/use-widget-data')
 import useWidgetData from '../../../hooks/use-widget-data'
 
-// Mock LightGallery at the top
-const mockLightGalleryInstance = {
-  openGallery: jest.fn()
-}
-
-jest.mock('lightgallery/react', () =>
-  jest.fn(({ onInit }) => {
-    onInit({ instance: mockLightGalleryInstance })
-    return <div data-testid='lightgallery-mock' />
+// Mock LightGallery at the top — instance lives on globalThis so tests can clear it without TDZ/hoist issues.
+jest.mock('lightgallery/react', () => {
+  globalThis.__chronogroveFlickrLightGalleryTest ??= {
+    instance: { openGallery: jest.fn() }
+  }
+  const state = globalThis.__chronogroveFlickrLightGalleryTest
+  const React = require('react')
+  return jest.fn(({ onInit }) => {
+    onInit({ instance: state.instance })
+    return React.createElement('div', { 'data-testid': 'lightgallery-mock' })
   })
-)
+})
+
+const mockLightGalleryInstance = () => globalThis.__chronogroveFlickrLightGalleryTest.instance
 
 jest.mock('lightgallery/plugins/thumbnail', () => jest.fn())
 jest.mock('lightgallery/plugins/zoom', () => jest.fn())
@@ -85,6 +88,7 @@ describe('FlickrWidget', () => {
   afterEach(() => {
     jest.clearAllMocks()
     console.error.mockRestore()
+    globalThis.__chronogroveFlickrLightGalleryTest.instance = { openGallery: jest.fn() }
   })
 
   it('renders without crashing', () => {
@@ -155,7 +159,22 @@ describe('FlickrWidget', () => {
     const thumbnails = screen.getAllByAltText(/Flickr photo:/i)
     fireEvent.click(thumbnails[0])
 
-    expect(mockLightGalleryInstance.openGallery).toHaveBeenCalledWith(0)
+    expect(mockLightGalleryInstance().openGallery).toHaveBeenCalledWith(0)
+  })
+
+  it('logs when LightGallery instance is not initialized on photo click', () => {
+    globalThis.__chronogroveFlickrLightGalleryTest.instance = undefined
+    useWidgetData.mockReturnValue(mockSuccessState)
+
+    render(
+      <TestProviderWithQuery>
+        <FlickrWidget />
+      </TestProviderWithQuery>
+    )
+
+    fireEvent.click(screen.getAllByAltText(/Flickr photo:/i)[0])
+
+    expect(console.error).toHaveBeenCalledWith('LightGallery instance is not initialized')
   })
 
   it('calls VanillaTilt.init when isShowingMore or !isLoading is true', () => {
@@ -192,7 +211,7 @@ describe('FlickrWidget', () => {
     )
 
     expect(screen.getByTestId('lightgallery-mock')).toBeInTheDocument()
-    expect(mockLightGalleryInstance.openGallery).not.toHaveBeenCalled()
+    expect(mockLightGalleryInstance().openGallery).not.toHaveBeenCalled()
   })
 
   it('handles fatal error state correctly', () => {

--- a/theme/src/pages/chrisvogt-me-music-page.spec.js
+++ b/theme/src/pages/chrisvogt-me-music-page.spec.js
@@ -26,23 +26,29 @@ jest.mock('../../../theme/src/components/layout', () => ({ children, transparent
   </div>
 ))
 jest.mock('../../../theme/src/components/blog/page-header', () => ({ children }) => <h1>{children}</h1>)
-jest.mock(
-  '../../../theme/src/components/blog/post-timeline-index',
-  () =>
-    ({ posts }) =>
-      (Array.isArray(posts) ? posts : []).map(p => (
-        <div
-          data-testid='post-timeline-slot'
-          key={p.fields.id}
-          data-category={p.fields.category}
-          data-link={p.fields.path}
-          data-soundcloud={p.frontmatter.soundcloudId ?? ''}
-          data-youtube={p.frontmatter.youtubeSrc ?? ''}
-        >
-          {p.frontmatter.title}
-        </div>
-      ))
-)
+jest.mock('../../../theme/src/components/blog/post-timeline-index', () => {
+  const React = require('react')
+  return ({ afterFeatured, posts }) =>
+    React.createElement(
+      React.Fragment,
+      null,
+      (Array.isArray(posts) ? posts : []).map(p =>
+        React.createElement(
+          'div',
+          {
+            'data-testid': 'post-timeline-slot',
+            key: p.fields.id,
+            'data-category': p.fields.category,
+            'data-link': p.fields.path,
+            'data-soundcloud': p.frontmatter.soundcloudId ?? '',
+            'data-youtube': p.frontmatter.youtubeSrc ?? ''
+          },
+          p.frontmatter.title
+        )
+      ),
+      afterFeatured ?? null
+    )
+})
 jest.mock('../../../theme/src/components/seo', () => {
   const MockSeo = ({ canonicalPath, title, description, children }) => (
     <div data-testid='seo' data-canonical-path={canonicalPath} data-title={title} data-description={description}>
@@ -120,6 +126,11 @@ describe('www.chrisvogt.me Music page', () => {
     expect(cards[1]).toHaveAttribute('data-category', 'music/covers')
     expect(cards[1]).toHaveAttribute('data-youtube', 'https://www.youtube.com/embed/abc')
     expect(screen.getByRole('region', { name: 'Music posts' })).toBeInTheDocument()
+    expect(screen.getByTestId('music-repertoire-promo')).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /My piano repertoire/i })).toHaveAttribute(
+      'href',
+      'https://repertoire.chrisvogt.me/'
+    )
   })
 
   it('uses the default music lead when musicIndexLead is blank', () => {
@@ -133,6 +144,7 @@ describe('www.chrisvogt.me Music page', () => {
     )
 
     expect(screen.getByText('Original songs, covers, and audio posts.')).toBeInTheDocument()
+    expect(screen.getByTestId('music-repertoire-promo')).toBeInTheDocument()
   })
 
   it('filters out non-music posts', () => {
@@ -152,6 +164,7 @@ describe('www.chrisvogt.me Music page', () => {
 
     expect(screen.getAllByTestId('post-timeline-slot')).toHaveLength(1)
     expect(screen.queryByText('Trip')).not.toBeInTheDocument()
+    expect(screen.getByTestId('music-repertoire-promo')).toBeInTheDocument()
   })
 
   it('shows empty state when there are no music posts', () => {
@@ -164,6 +177,7 @@ describe('www.chrisvogt.me Music page', () => {
     )
 
     expect(screen.queryAllByTestId('post-timeline-slot')).toHaveLength(0)
+    expect(screen.queryByTestId('music-repertoire-promo')).not.toBeInTheDocument()
     expect(screen.getByText('No music posts yet. Check back soon!')).toBeInTheDocument()
   })
 
@@ -177,6 +191,7 @@ describe('www.chrisvogt.me Music page', () => {
     )
 
     expect(screen.getByText('No music posts yet. Check back soon!')).toBeInTheDocument()
+    expect(screen.queryByTestId('music-repertoire-promo')).not.toBeInTheDocument()
   })
 
   it('Head renders SEO for /music/', () => {

--- a/theme/src/pages/chrisvogt-me-music-repertoire-promo.spec.js
+++ b/theme/src/pages/chrisvogt-me-music-repertoire-promo.spec.js
@@ -1,0 +1,58 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import '@testing-library/jest-dom'
+
+const mockUseColorMode = jest.fn()
+jest.mock('theme-ui', () => ({
+  ...jest.requireActual('theme-ui'),
+  useColorMode: () => mockUseColorMode()
+}))
+
+import { MusicRepertoirePromo } from '../../../www.chrisvogt.me/src/pages/music'
+import { TestProvider } from '../testUtils'
+
+describe('MusicRepertoirePromo', () => {
+  beforeEach(() => {
+    mockUseColorMode.mockReturnValue(['default'])
+  })
+
+  it('links to repertoire.chrisvogt.me with expected copy', () => {
+    render(
+      <TestProvider>
+        <MusicRepertoirePromo />
+      </TestProvider>
+    )
+
+    const link = screen.getByRole('link', { name: /My piano repertoire/i })
+    expect(link).toHaveAttribute('href', 'https://repertoire.chrisvogt.me/')
+    expect(screen.getByRole('heading', { level: 2, name: 'My piano repertoire' })).toBeInTheDocument()
+    expect(screen.getByText(/Browse the full list online/)).toBeInTheDocument()
+    expect(screen.getByText('Visit repertoire.chrisvogt.me')).toBeInTheDocument()
+    expect(screen.getByTestId('music-repertoire-promo')).toBeInTheDocument()
+  })
+
+  it('uses light screenshot URL in default color mode', () => {
+    mockUseColorMode.mockReturnValue(['default'])
+    const { container } = render(
+      <TestProvider>
+        <MusicRepertoirePromo />
+      </TestProvider>
+    )
+    const img = container.querySelector('img')
+    expect(img).toBeTruthy()
+    expect(img.getAttribute('src')).toContain('repertoire-screenshot-light')
+    expect(img).toHaveAttribute('alt', '')
+  })
+
+  it('uses dark screenshot URL in dark color mode', () => {
+    mockUseColorMode.mockReturnValue(['dark'])
+    const { container } = render(
+      <TestProvider>
+        <MusicRepertoirePromo />
+      </TestProvider>
+    )
+    const img = container.querySelector('img')
+    expect(img).toBeTruthy()
+    expect(img.getAttribute('src')).toContain('repertoire-screenshot-dark')
+  })
+})

--- a/www.chrisvogt.me/package.json
+++ b/www.chrisvogt.me/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "www.chrisvogt.me",
-  "version": "1.18.1",
+  "version": "1.19.0",
   "license": "GPL",
   "scripts": {
     "build": "gatsby build",

--- a/www.chrisvogt.me/src/pages/music.js
+++ b/www.chrisvogt.me/src/pages/music.js
@@ -18,6 +18,165 @@ import Layout from '../../../theme/src/components/layout'
 import PageHeader from '../../../theme/src/components/blog/page-header'
 import PostTimelineIndex from '../../../theme/src/components/blog/post-timeline-index'
 import Seo from '../../../theme/src/components/seo'
+import ColorModeImage from '../../../theme/src/shortcodes/color-mode-image'
+
+/** Same assets as `content/blog/2025-01-07-my-piano-repertoire.mdx` */
+const REPERTOIRE_URL = 'https://repertoire.chrisvogt.me/'
+const REPERTOIRE_SCREENSHOT_LIGHT =
+  'https://res.cloudinary.com/chrisvogt/image/upload/v1778490047/chrisvogt-me/photo/repertoire-screenshot-light.png'
+const REPERTOIRE_SCREENSHOT_DARK =
+  'https://res.cloudinary.com/chrisvogt/image/upload/v1778490048/chrisvogt-me/photo/repertoire-screenshot-dark.png'
+
+/** Matches timeline media frames (`post-timeline-index`) + theme card blur (`theme.js` PostCard). */
+const repertoirePromoThumbFrameSx = {
+  borderRadius: '11px',
+  borderWidth: '1px',
+  borderStyle: 'solid',
+  borderColor: 'muted',
+  boxShadow: '0 2px 10px rgba(0, 0, 0, 0.1)',
+  flexShrink: 0,
+  lineHeight: 0,
+  overflow: 'hidden',
+  /** Narrow column on phones keeps height low while staying beside copy */
+  width: ['clamp(96px, 27vw, 132px)', null, 'clamp(132px, 22vw, 200px)'],
+  maxWidth: 'none',
+  alignSelf: 'flex-start'
+}
+
+export function MusicRepertoirePromo() {
+  return (
+    <Box
+      aria-labelledby='music-repertoire-promo-heading'
+      as='section'
+      data-testid='music-repertoire-promo'
+      sx={{ mb: [4, null, null, '2.875rem'] }}
+    >
+      <Box
+        as='a'
+        href={REPERTOIRE_URL}
+        sx={{
+          backdropFilter: 'blur(12px) saturate(150%)',
+          WebkitBackdropFilter: 'blur(12px) saturate(150%)',
+          bg: 'panel-background',
+          borderColor: 'muted',
+          borderRadius: '11px',
+          borderStyle: 'solid',
+          borderWidth: '1px',
+          boxShadow: '0 2px 10px rgba(0, 0, 0, 0.08)',
+          color: 'inherit',
+          display: 'block',
+          overflow: 'hidden',
+          textDecoration: 'none',
+          transition: 'border-color 0.18s ease, box-shadow 0.18s ease, transform 0.18s ease',
+          '&:hover': {
+            borderColor: 'primary',
+            boxShadow: '0 2px 12px rgba(0, 0, 0, 0.1), 0 8px 24px rgba(66, 46, 163, 0.12)',
+            transform: 'translateY(-1px)',
+            '& #music-repertoire-promo-cta': {
+              bg: 'primary',
+              borderColor: 'primary',
+              color: 'background'
+            }
+          },
+          '&:focus-visible': {
+            outline: '2px solid',
+            outlineColor: 'primary',
+            outlineOffset: '3px'
+          }
+        }}
+      >
+        <Flex
+          sx={{
+            alignItems: 'flex-start',
+            flexDirection: 'row',
+            flexWrap: 'nowrap',
+            gap: [2, null, 3, 4],
+            justifyContent: 'space-between',
+            p: [2, null, null, 3]
+          }}
+        >
+          <Box sx={{ flex: '1 1 auto', minWidth: 0, pt: [0, null, '2px'] }}>
+            <Box
+              sx={{
+                color: 'primary',
+                fontFamily: 'heading',
+                fontSize: [0],
+                letterSpacing: '0.05em',
+                lineHeight: 1.3,
+                mb: '0.5rem',
+                textTransform: 'uppercase'
+              }}
+            >
+              Repertoire
+            </Box>
+            <Box
+              as='h2'
+              id='music-repertoire-promo-heading'
+              sx={{
+                fontFamily: 'serif',
+                fontSize: [2, null, null, 3],
+                fontWeight: 400,
+                lineHeight: [1.34, null, null, 1.36],
+                mt: 0,
+                mb: 2
+              }}
+            >
+              My piano repertoire
+            </Box>
+            <Themed.p
+              sx={{
+                color: 'text',
+                fontSize: [1, null, null, 2],
+                lineHeight: 1.7,
+                m: 0,
+                maxWidth: '38rem'
+              }}
+            >
+              Browse the full list online—performance notes, transposition, and sheet music links.
+            </Themed.p>
+            <Box
+              id='music-repertoire-promo-cta'
+              sx={{
+                alignItems: 'center',
+                borderColor: 'primary',
+                borderRadius: '7px',
+                borderStyle: 'solid',
+                borderWidth: '1px',
+                color: 'primary',
+                display: 'inline-flex',
+                fontFamily: 'body',
+                fontSize: [1],
+                fontWeight: 600,
+                justifyContent: 'center',
+                letterSpacing: '0.02em',
+                lineHeight: 1.25,
+                mt: ['1rem', null, null, '1.125rem'],
+                px: ['0.875rem', null, null, '1rem'],
+                py: ['0.5rem', null, null, '0.5625rem'],
+                transition: 'background-color 0.15s ease, color 0.15s ease, border-color 0.15s ease'
+              }}
+            >
+              Visit repertoire.chrisvogt.me
+            </Box>
+          </Box>
+          <Box aria-hidden sx={repertoirePromoThumbFrameSx}>
+            <ColorModeImage
+              alt=''
+              dark={REPERTOIRE_SCREENSHOT_DARK}
+              light={REPERTOIRE_SCREENSHOT_LIGHT}
+              loading='lazy'
+              sx={{
+                display: 'block',
+                height: 'auto',
+                width: '100%'
+              }}
+            />
+          </Box>
+        </Flex>
+      </Box>
+    </Box>
+  )
+}
 
 const MusicPage = ({ data }) => {
   const posts = getPosts(data)?.filter(post => post.fields.category?.startsWith('music')) || []
@@ -36,7 +195,7 @@ const MusicPage = ({ data }) => {
 
             {posts.length > 0 ? (
               <Box as='section' aria-label='Music posts' sx={categoryIndexPostListSectionSx}>
-                <PostTimelineIndex posts={posts} timelineAsideMedia />
+                <PostTimelineIndex afterFeatured={<MusicRepertoirePromo />} posts={posts} timelineAsideMedia />
               </Box>
             ) : (
               <Box sx={categoryIndexEmptyStateBoxSx}>

--- a/www.chronogrove.com/package.json
+++ b/www.chronogrove.com/package.json
@@ -1,6 +1,6 @@
 {
   "name": "www.chronogrove.com",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "Official demo site for gatsby-theme-chronogrove",
   "scripts": {
     "develop": "gatsby develop",


### PR DESCRIPTION
## Summary

Adds a repertoire marketing card on the Music index (linking to https://repertoire.chrisvogt.me/ with color-mode screenshots) and extends `PostTimelineIndex` with an optional `afterFeatured` slot so the featured row can drop its bottom border when that content replaces the divider.

## Changes

- **Theme**: `PostTimelineIndex` — optional `afterFeatured`; featured article `data-bottom-rule` attribute for tests
- **www.chrisvogt.me**: `MusicRepertoirePromo` on the music page; named export for tests
- **Tests**: Music page/promo/post-timeline specs; `gatsby-browser` (`onClientEntry`, same-pathname `shouldUpdateScroll`); Flickr LightGallery missing-instance path
- **Jest**: global line coverage threshold raised to **99%**
- **Versions**: theme **0.88.0**, www **1.19.0**, demo **1.6.0**
- **CHANGELOG**: `## 0.88.0`

## Notes

Same-tab navigation to repertoire; layout keeps the screenshot on the right on narrow viewports.

Made with [Cursor](https://cursor.com)