### PR TITLE
feat(widgets): AI summaries for Discogs and Spotify

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+## 0.90.0
+
+### `gatsby-theme-chronogrove` — Discogs & Spotify AI summaries
+
+- **`discogs-widget.js`**: Optional **`aiSummary`** under the header (reuses Steam **`AiSummary`** / **`AiSummarySkeleton`**, **`pickAiSummarySyncedAtRaw`**) when the metrics API provides copy.
+- **`spotify-widget.js`**: Same pattern above top tracks / playlists.
+- **Tests / snapshots**: **`discogs-widget.spec.js`**, **`spotify-widget.spec.js`** (loading skeleton, with summary, without summary).
+- **Version**: **0.90.0**
+
+### `www.chrisvogt.me`
+
+- **Version**: **1.21.0** (tracks theme **0.90.0**).
+
+### `www.chronogrove.com` (demo)
+
+- **Version**: **1.8.0** (tracks theme **0.90.0**).
+
+### Files changed
+
+- `CHANGELOG.md`
+- `theme/package.json` (version **0.90.0**)
+- `theme/src/components/widgets/discogs/discogs-widget.js`, **`discogs-widget.spec.js`**, **`__snapshots__/discogs-widget.spec.js.snap`**
+- `theme/src/components/widgets/spotify/spotify-widget.js`, **`spotify-widget.spec.js`**, **`__snapshots__/spotify-widget.spec.js.snap`**
+- `www.chrisvogt.me/package.json` (version **1.21.0**)
+- `www.chronogrove.com/package.json` (version **1.8.0**)
+
+---
+
 ## 0.89.0
 
 ### `@chronogrove/ui` — AI summary tokens, widget header, action sizing

--- a/theme/package.json
+++ b/theme/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-theme-chronogrove",
   "description": "A personal website and digital garden theme for GatsbyJS.",
-  "version": "0.89.0",
+  "version": "0.90.0",
   "author": "Chris Vogt <mail@chrisvogt.me> (https://www.chrisvogt.me)",
   "main": "index.js",
   "license": "MIT",

--- a/theme/src/components/widgets/discogs/__snapshots__/discogs-widget.spec.js.snap
+++ b/theme/src/components/widgets/discogs/__snapshots__/discogs-widget.spec.js.snap
@@ -270,6 +270,11 @@ exports[`Discogs Widget matches the loaded state snapshot 1`] = `
       </div>
     </header>
     <div
+      data-testid="ai-summary"
+    >
+      &lt;p&gt;Test Discogs AI summary.&lt;/p&gt;
+    </div>
+    <div
       class="css-18bjwv1"
     >
       <div
@@ -553,6 +558,48 @@ exports[`Discogs Widget matches the loading state snapshot 1`] = `
         </div>
       </div>
     </header>
+    <div
+      aria-hidden="true"
+      class="css-1x6v59e"
+    >
+      <div
+        class="show-loading-animation css-ylcmma"
+      >
+        <div
+          class="text-block"
+          style="width: 100%;"
+        >
+          <div
+            class="text-row"
+            style="max-height: 11.11111111111111%; width: 97%; height: 1em; background-color: rgb(239, 239, 239); margin-top: 0px;"
+          />
+          <div
+            class="text-row"
+            style="max-height: 11.11111111111111%; width: 100%; height: 1em; background-color: rgb(239, 239, 239); margin-top: 0.7em;"
+          />
+          <div
+            class="text-row"
+            style="max-height: 11.11111111111111%; width: 94%; height: 1em; background-color: rgb(239, 239, 239); margin-top: 0.7em;"
+          />
+          <div
+            class="text-row"
+            style="max-height: 11.11111111111111%; width: 90%; height: 1em; background-color: rgb(239, 239, 239); margin-top: 0.7em;"
+          />
+          <div
+            class="text-row"
+            style="max-height: 11.11111111111111%; width: 98%; height: 1em; background-color: rgb(239, 239, 239); margin-top: 0.7em;"
+          />
+        </div>
+      </div>
+      <div
+        class="css-n4yf41"
+      >
+        <div
+          aria-hidden="true"
+          class="css-obv90v"
+        />
+      </div>
+    </div>
     <div
       class="css-18bjwv1"
     >
@@ -1302,6 +1349,273 @@ exports[`Discogs Widget matches the loading state snapshot 1`] = `
         <div
           class="css-1ixi9e6"
         />
+      </div>
+    </div>
+  </section>
+</DocumentFragment>
+`;
+
+exports[`Discogs Widget renders without AI summary when not available 1`] = `
+<DocumentFragment>
+  <section
+    class="css-1gmhq94"
+    id="discogs"
+    tabindex="-1"
+  >
+    <header
+      class="css-f68fi0"
+    >
+      <div
+        class="css-3vwaby"
+      >
+        <div
+          aria-hidden="true"
+          class="css-1muvmnm"
+        >
+          <svg
+            aria-hidden="true"
+            class="svg-inline--fa fa-record-vinyl"
+            data-icon="record-vinyl"
+            data-prefix="fas"
+            role="img"
+            style="width: 14px; height: 14px; color: rgb(255, 255, 255);"
+            viewBox="0 0 512 512"
+          >
+            <path
+              d="M0 256a256 256 0 1 1 512 0 256 256 0 1 1 -512 0zm256-96a96 96 0 1 1 0 192 96 96 0 1 1 0-192zm0 240a144 144 0 1 0 0-288 144 144 0 1 0 0 288zm0-112a32 32 0 1 0 0-64 32 32 0 1 0 0 64z"
+              fill="currentColor"
+            />
+          </svg>
+        </div>
+        <div
+          class="css-m8374l"
+        >
+          <h2
+            class="css-1tfs9qy"
+          >
+            Discogs
+          </h2>
+          <a
+            class="css-bgnrb"
+            href="https://www.discogs.com/user/chrisvogt/collection"
+            title="Collection on Discogs"
+          >
+            Browse Collection
+            <span
+              class="read-more-icon"
+            >
+              →
+            </span>
+          </a>
+        </div>
+      </div>
+      <div
+        class="css-1df6wzz"
+      >
+        <div
+          class="css-1fzqdmc"
+        >
+          <div
+            class="css-8kzs4n"
+          >
+            37
+          </div>
+          <div
+            class="css-b1klod"
+          >
+            Vinyls Owned
+          </div>
+        </div>
+      </div>
+    </header>
+    <div
+      class="css-18bjwv1"
+    >
+      <div
+        class="css-7avkd0"
+      >
+        <h3
+          class="css-8ivgst"
+        >
+          Vinyl Collection
+        </h3>
+        <div
+          class="css-1vz564k"
+        >
+          <div
+            class="css-iz57sm"
+          >
+            <label
+              class="css-kbw1ti"
+              for="vinyl-collection-sort-select"
+            >
+              Sort by
+            </label>
+            <div
+              class="css-z5fbhm"
+            >
+              <select
+                class="css-1dw0swc"
+                id="vinyl-collection-sort-select"
+              >
+                <option
+                  value="added-to-collection"
+                >
+                  Date added (newest first)
+                </option>
+                <option
+                  value="release-year"
+                >
+                  Release year (newest first)
+                </option>
+                <option
+                  value="alphabetical"
+                >
+                  Album title (A–Z)
+                </option>
+                <option
+                  value="alphabetical-artist"
+                >
+                  Artist (A–Z)
+                </option>
+              </select>
+              <svg
+                class="css-1uwn3wc"
+                fill="currentcolor"
+                height="24"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M7 10l5 5 5-5z"
+                />
+              </svg>
+            </div>
+          </div>
+          <div
+            aria-label="Vinyl collection layout"
+            class="css-1l647io"
+            role="radiogroup"
+          >
+            <span
+              class="css-128a175"
+              id="vinyl-collection-view-label"
+            >
+              View:
+            </span>
+            <button
+              aria-label="Show vinyl collection as a grid"
+              aria-pressed="true"
+              class="css-1oc3a3t"
+              type="button"
+            >
+              Grid
+            </button>
+            <button
+              aria-label="Show vinyl collection as a list"
+              aria-pressed="false"
+              class="css-1lig866"
+              type="button"
+            >
+              List
+            </button>
+          </div>
+        </div>
+      </div>
+      <p
+        class="css-1x7q8nj"
+      >
+        My owned vinyl records from Discogs.
+      </p>
+      <div
+        class="css-us3dds"
+      >
+        <div
+          class="css-nlq8f0"
+          data-testid="vinyl-carousel"
+        >
+          <div
+            class="css-ynlqmx"
+          >
+            <div
+              class="vinyl-collection_grid null css-4go7zc"
+            >
+              <div
+                class="css-g3ckzk"
+              >
+                <div
+                  aria-label="The Rise & Fall Of A Midwest Princess (2023) - Chappell Roan. Click to view details."
+                  class="vinyl-record css-1uxsoal"
+                  role="button"
+                  tabindex="0"
+                  title="The Rise & Fall Of A Midwest Princess (2023) - Chappell Roan"
+                >
+                  <div
+                    class="css-12d7pfc"
+                  >
+                    <div
+                      class="vinyl-record_image css-18n965x"
+                    >
+                      <img
+                        alt="The Rise & Fall Of A Midwest Princess album cover"
+                        class="vinyl-record_album-art css-1ybonlr"
+                        crossorigin="anonymous"
+                        loading="lazy"
+                        src="https://example.com/thumb.jpg"
+                      />
+                    </div>
+                    <div
+                      class="vinyl-record_caption css-12vw5gc"
+                    >
+                      <span
+                        class="css-kvy207"
+                      >
+                        The Rise & Fall Of A Midwest Princess (2023) - Chappell Roan
+                      </span>
+                      <div
+                        class="vinyl-record_orbit css-nh7rc5"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          height="100%"
+                          role="presentation"
+                          style="display: block;"
+                          viewBox="0 0 100 100"
+                          width="100%"
+                        >
+                          <defs>
+                            <path
+                              d="M50,50 m0,-44 a44,44 0 1,1 0,88 a44,44 0 1,1 0,-88"
+                              id="textCircle-28461454"
+                            />
+                          </defs>
+                          <g
+                            class="css-1uqa7mt"
+                          >
+                            <text
+                              class="css-ir7wai"
+                              fill="currentColor"
+                            >
+                              <textpath
+                                href="#textCircle-28461454"
+                                method="align"
+                                spacing="auto"
+                                startOffset="0%"
+                              >
+                                The Rise & Fall Of A Midwest Princess • Chappell Roan • 2023 • The Rise & Fall Of A Midwest Princess • Chappell Roan • 2023 • 
+                              </textpath>
+                            </text>
+                          </g>
+                        </svg>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
   </section>

--- a/theme/src/components/widgets/discogs/discogs-widget.js
+++ b/theme/src/components/widgets/discogs/discogs-widget.js
@@ -2,20 +2,26 @@
 import { jsx } from 'theme-ui'
 import { faRecordVinyl } from '@fortawesome/free-solid-svg-icons'
 
+import { pickAiSummarySyncedAtRaw } from '../../../helpers/ai-summary-synced-at'
+import { getDiscogsWidgetDataSource } from '../../../selectors/metadata'
+import useSiteMetadata from '../../../hooks/use-site-metadata'
+import useWidgetData from '../../../hooks/use-widget-data'
+
+import AiSummary from '../steam/ai-summary'
+import AiSummarySkeleton from '../steam/ai-summary-skeleton'
 import CallToAction from '../call-to-action'
 import VinylCollection from './vinyl-collection'
 import Widget from '../widget'
 import WidgetHeader from '../widget-header'
-
-import { getDiscogsWidgetDataSource } from '../../../selectors/metadata'
-import useSiteMetadata from '../../../hooks/use-site-metadata'
-import useWidgetData from '../../../hooks/use-widget-data'
 
 const DiscogsWidget = () => {
   const metadata = useSiteMetadata()
   const discogsDataSource = getDiscogsWidgetDataSource(metadata)
 
   const { data, isLoading, hasFatalError } = useWidgetData('discogs', discogsDataSource)
+
+  const aiSummary = data?.aiSummary
+  const aiSummarySyncedAt = pickAiSummarySyncedAtRaw(data)
 
   // Extract data from the query result
   // Metrics come as an object and need to be transformed to array format
@@ -38,11 +44,18 @@ const DiscogsWidget = () => {
     </CallToAction>
   )
 
+  const discogsAiBlockSx = { mb: [2, 3] }
+
   return (
     <Widget id='discogs' hasFatalError={hasFatalError}>
       <WidgetHeader aside={callToAction} icon={faRecordVinyl} metrics={metrics} metricsLoading={isLoading}>
         Discogs
       </WidgetHeader>
+
+      {isLoading && !aiSummary ? <AiSummarySkeleton skeletonRows={5} sx={discogsAiBlockSx} /> : null}
+      {aiSummary ? (
+        <AiSummary aiSummary={aiSummary} aiSummarySyncedAt={aiSummarySyncedAt} sx={discogsAiBlockSx} />
+      ) : null}
 
       <VinylCollection isLoading={isLoading} releases={releases} />
     </Widget>

--- a/theme/src/components/widgets/discogs/discogs-widget.spec.js
+++ b/theme/src/components/widgets/discogs/discogs-widget.spec.js
@@ -9,6 +9,7 @@ import useWidgetData from '../../../hooks/use-widget-data'
 
 jest.mock('../../../hooks/use-site-metadata')
 jest.mock('../../../hooks/use-widget-data')
+jest.mock('../steam/ai-summary', () => ({ aiSummary }) => <div data-testid='ai-summary'>{aiSummary}</div>)
 
 const mockSiteMetadata = {
   widgets: {
@@ -28,6 +29,7 @@ const mockLoadingState = {
 
 const mockSuccessState = {
   data: {
+    aiSummary: '<p>Test Discogs AI summary.</p>',
     collections: {
       releases: [
         {
@@ -51,6 +53,20 @@ const mockSuccessState = {
     profile: {
       profileURL: 'https://www.discogs.com/user/chrisvogt/collection'
     }
+  },
+  isLoading: false,
+  hasFatalError: false,
+  isError: false,
+  error: null
+}
+
+const mockSuccessStateWithoutAiSummary = {
+  data: {
+    collections: {
+      releases: mockSuccessState.data.collections.releases
+    },
+    metrics: mockSuccessState.data.metrics,
+    profile: mockSuccessState.data.profile
   },
   isLoading: false,
   hasFatalError: false,
@@ -88,6 +104,17 @@ describe('Discogs Widget', () => {
 
   it('matches the loaded state snapshot', () => {
     useWidgetData.mockReturnValue(mockSuccessState)
+
+    const { asFragment } = render(
+      <TestProviderWithQuery>
+        <DiscogsWidget />
+      </TestProviderWithQuery>
+    )
+    expect(asFragment()).toMatchSnapshot()
+  })
+
+  it('renders without AI summary when not available', () => {
+    useWidgetData.mockReturnValue(mockSuccessStateWithoutAiSummary)
 
     const { asFragment } = render(
       <TestProviderWithQuery>

--- a/theme/src/components/widgets/spotify/__snapshots__/spotify-widget.spec.js.snap
+++ b/theme/src/components/widgets/spotify/__snapshots__/spotify-widget.spec.js.snap
@@ -204,6 +204,11 @@ exports[`Spotify Widget matches the loaded state snapshot 1`] = `
       </div>
     </header>
     <div
+      data-testid="ai-summary"
+    >
+      &lt;p&gt;Test Spotify AI summary.&lt;/p&gt;
+    </div>
+    <div
       class="css-sak8bt"
     >
       <div
@@ -360,6 +365,48 @@ exports[`Spotify Widget matches the loading state snapshot 1`] = `
         </div>
       </div>
     </header>
+    <div
+      aria-hidden="true"
+      class="css-1x6v59e"
+    >
+      <div
+        class="show-loading-animation css-ylcmma"
+      >
+        <div
+          class="text-block"
+          style="width: 100%;"
+        >
+          <div
+            class="text-row"
+            style="max-height: 11.11111111111111%; width: 97%; height: 1em; background-color: rgb(239, 239, 239); margin-top: 0px;"
+          />
+          <div
+            class="text-row"
+            style="max-height: 11.11111111111111%; width: 100%; height: 1em; background-color: rgb(239, 239, 239); margin-top: 0.7em;"
+          />
+          <div
+            class="text-row"
+            style="max-height: 11.11111111111111%; width: 94%; height: 1em; background-color: rgb(239, 239, 239); margin-top: 0.7em;"
+          />
+          <div
+            class="text-row"
+            style="max-height: 11.11111111111111%; width: 90%; height: 1em; background-color: rgb(239, 239, 239); margin-top: 0.7em;"
+          />
+          <div
+            class="text-row"
+            style="max-height: 11.11111111111111%; width: 98%; height: 1em; background-color: rgb(239, 239, 239); margin-top: 0.7em;"
+          />
+        </div>
+      </div>
+      <div
+        class="css-n4yf41"
+      >
+        <div
+          aria-hidden="true"
+          class="css-obv90v"
+        />
+      </div>
+    </div>
     <div
       class="css-sak8bt"
     >
@@ -593,6 +640,160 @@ exports[`Spotify Widget matches the loading state snapshot 1`] = `
           />
         </div>
       </div>
+    </div>
+  </section>
+</DocumentFragment>
+`;
+
+exports[`Spotify Widget renders without AI summary when not available 1`] = `
+<DocumentFragment>
+  <section
+    class="css-1gmhq94"
+    id="spotify"
+    tabindex="-1"
+  >
+    <header
+      class="css-f68fi0"
+    >
+      <div
+        class="css-3vwaby"
+      >
+        <div
+          aria-hidden="true"
+          class="css-1muvmnm"
+        >
+          <svg
+            aria-hidden="true"
+            class="svg-inline--fa fa-spotify"
+            data-icon="spotify"
+            data-prefix="fab"
+            role="img"
+            style="width: 14px; height: 14px; color: rgb(255, 255, 255);"
+            viewBox="0 0 512 512"
+          >
+            <path
+              d="M256 8a248 248 0 1 0 0 496 248 248 0 1 0 0-496zM356.7 372.9c-4.2 0-6.8-1.3-10.7-3.6-62.4-37.6-135-39.2-206.7-24.5-3.9 1-9 2.6-11.9 2.6-9.7 0-15.8-7.7-15.8-15.8 0-10.3 6.1-15.2 13.6-16.8 81.9-18.1 165.6-16.5 237 26.2 6.1 3.9 9.7 7.4 9.7 16.5s-7.1 15.4-15.2 15.4zm26.9-65.6c-5.2 0-8.7-2.3-12.3-4.2-62.5-37-155.7-51.9-238.6-29.4-4.8 1.3-7.4 2.6-11.9 2.6-10.7 0-19.4-8.7-19.4-19.4s5.2-17.8 15.5-20.7c27.8-7.8 56.2-13.6 97.8-13.6 64.9 0 127.6 16.1 177 45.5 8.1 4.8 11.3 11 11.3 19.7-.1 10.8-8.5 19.5-19.4 19.5zm31-76.2c-5.2 0-8.4-1.3-12.9-3.9-71.2-42.5-198.5-52.7-280.9-29.7-3.6 1-8.1 2.6-12.9 2.6-13.2 0-23.3-10.3-23.3-23.6 0-13.6 8.4-21.3 17.4-23.9 35.2-10.3 74.6-15.2 117.5-15.2 73 0 149.5 15.2 205.4 47.8 7.8 4.5 12.9 10.7 12.9 22.6 0 13.6-11 23.3-23.2 23.3z"
+              fill="currentColor"
+            />
+          </svg>
+        </div>
+        <div
+          class="css-m8374l"
+        >
+          <h2
+            class="css-1tfs9qy"
+          >
+            Spotify
+          </h2>
+          <a
+            class="css-bgnrb"
+            href="https://spotify.com/user/test"
+            title="Test User on Spotify"
+          >
+            Browse Playlists
+            <span
+              class="read-more-icon"
+            >
+              →
+            </span>
+          </a>
+        </div>
+      </div>
+      <div
+        class="css-1df6wzz"
+      >
+        <div
+          class="css-1fzqdmc"
+        >
+          <div
+            class="css-8kzs4n"
+          >
+            10
+          </div>
+          <div
+            class="css-b1klod"
+          >
+            Playlists
+          </div>
+        </div>
+        <div
+          class="css-1fzqdmc"
+        >
+          <div
+            class="css-8kzs4n"
+          >
+            20
+          </div>
+          <div
+            class="css-b1klod"
+          >
+            Top Tracks
+          </div>
+        </div>
+      </div>
+    </header>
+    <div
+      class="css-sak8bt"
+    >
+      <div
+        class="css-ccroti"
+      >
+        <h3
+          class="css-9nh3l5"
+        >
+          Top Tracks
+        </h3>
+      </div>
+      <p
+        class="css-1qwovgy"
+      >
+        My 12 most-played tracks over the last 4 weeks.
+      </p>
+      <div
+        class="media-item_grid null css-5stlgz"
+      >
+        <a
+          class="media-item_media css-13fusor"
+          title="Test Track – [object Object]"
+        >
+          <div
+            class="css-x4b07x"
+          >
+            <div
+              class="media-item_caption css-e7oldi"
+            >
+              <span>
+                Test Track
+              </span>
+            </div>
+            <img
+              alt="cover artwork"
+              class="css-karewm"
+              crossorigin="anonymous"
+              loading="lazy"
+            />
+          </div>
+        </a>
+      </div>
+    </div>
+    <div>
+      <div
+        class="css-ccroti"
+      >
+        <h3
+          class="css-9nh3l5"
+        >
+          Playlists
+        </h3>
+      </div>
+      <p
+        class="css-1qwovgy"
+      >
+        My 12 favorite playlists.
+      </p>
+      <div
+        class="media-item_grid null css-5stlgz"
+      />
     </div>
   </section>
 </DocumentFragment>

--- a/theme/src/components/widgets/spotify/spotify-widget.js
+++ b/theme/src/components/widgets/spotify/spotify-widget.js
@@ -2,6 +2,13 @@
 import { jsx } from 'theme-ui'
 import { faSpotify } from '@fortawesome/free-brands-svg-icons'
 
+import { pickAiSummarySyncedAtRaw } from '../../../helpers/ai-summary-synced-at'
+import { getSpotifyWidgetDataSource } from '../../../selectors/metadata'
+import useSiteMetadata from '../../../hooks/use-site-metadata'
+import useWidgetData from '../../../hooks/use-widget-data'
+
+import AiSummary from '../steam/ai-summary'
+import AiSummarySkeleton from '../steam/ai-summary-skeleton'
 import CallToAction from '../call-to-action'
 import Playlists from './playlists'
 import PlaylistsErrorBoundary from './playlists-error-boundary'
@@ -9,15 +16,14 @@ import TopTracks from './top-tracks'
 import Widget from '../widget'
 import WidgetHeader from '../widget-header'
 
-import { getSpotifyWidgetDataSource } from '../../../selectors/metadata'
-import useSiteMetadata from '../../../hooks/use-site-metadata'
-import useWidgetData from '../../../hooks/use-widget-data'
-
 const SpotifyWidget = () => {
   const metadata = useSiteMetadata()
   const spotifyDataSource = getSpotifyWidgetDataSource(metadata)
 
   const { data, isLoading, hasFatalError } = useWidgetData('spotify', spotifyDataSource)
+
+  const aiSummary = data?.aiSummary
+  const aiSummarySyncedAt = pickAiSummarySyncedAtRaw(data)
 
   // Extract data from the query result
   const metrics = data?.metrics
@@ -34,11 +40,18 @@ const SpotifyWidget = () => {
     </CallToAction>
   )
 
+  const spotifyAiBlockSx = { mb: [2, 3] }
+
   return (
     <Widget id='spotify' hasFatalError={hasFatalError}>
       <WidgetHeader aside={callToAction} icon={faSpotify} metrics={metrics} metricsLoading={isLoading}>
         Spotify
       </WidgetHeader>
+
+      {isLoading && !aiSummary ? <AiSummarySkeleton skeletonRows={5} sx={spotifyAiBlockSx} /> : null}
+      {aiSummary ? (
+        <AiSummary aiSummary={aiSummary} aiSummarySyncedAt={aiSummarySyncedAt} sx={spotifyAiBlockSx} />
+      ) : null}
 
       <TopTracks isLoading={isLoading} tracks={topTracks} />
       <PlaylistsErrorBoundary>

--- a/theme/src/components/widgets/spotify/spotify-widget.spec.js
+++ b/theme/src/components/widgets/spotify/spotify-widget.spec.js
@@ -8,6 +8,7 @@ import useWidgetData from '../../../hooks/use-widget-data'
 
 jest.mock('../../../hooks/use-site-metadata')
 jest.mock('../../../hooks/use-widget-data')
+jest.mock('../steam/ai-summary', () => ({ aiSummary }) => <div data-testid='ai-summary'>{aiSummary}</div>)
 
 const mockSiteMetadata = {
   widgets: {
@@ -28,6 +29,7 @@ const mockLoadingState = {
 
 const mockSuccessState = {
   data: {
+    aiSummary: '<p>Test Spotify AI summary.</p>',
     collections: {
       playlists: [
         {
@@ -66,6 +68,19 @@ const mockSuccessState = {
   error: null
 }
 
+const mockSuccessStateWithoutAiSummary = {
+  data: {
+    collections: mockSuccessState.data.collections,
+    metrics: mockSuccessState.data.metrics,
+    profile: mockSuccessState.data.profile,
+    provider: mockSuccessState.data.provider
+  },
+  isLoading: false,
+  hasFatalError: false,
+  isError: false,
+  error: null
+}
+
 const mockErrorState = {
   data: undefined,
   isLoading: false,
@@ -96,6 +111,17 @@ describe('Spotify Widget', () => {
 
   it('matches the loaded state snapshot', () => {
     useWidgetData.mockReturnValue(mockSuccessState)
+
+    const { asFragment } = render(
+      <TestProviderWithQuery>
+        <SpotifyWidget />
+      </TestProviderWithQuery>
+    )
+    expect(asFragment()).toMatchSnapshot()
+  })
+
+  it('renders without AI summary when not available', () => {
+    useWidgetData.mockReturnValue(mockSuccessStateWithoutAiSummary)
 
     const { asFragment } = render(
       <TestProviderWithQuery>

--- a/www.chrisvogt.me/package.json
+++ b/www.chrisvogt.me/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "www.chrisvogt.me",
-  "version": "1.20.0",
+  "version": "1.21.0",
   "license": "GPL",
   "scripts": {
     "build": "gatsby build",

--- a/www.chronogrove.com/package.json
+++ b/www.chronogrove.com/package.json
@@ -1,6 +1,6 @@
 {
   "name": "www.chronogrove.com",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "Official demo site for gatsby-theme-chronogrove",
   "scripts": {
     "develop": "gatsby develop",


### PR DESCRIPTION
## Summary

Reuses the Steam/Goodreads AI summary stack (`AiSummary`, `AiSummarySkeleton`, `pickAiSummarySyncedAtRaw`) for optional metrics-API copy on the Discogs and Spotify widgets (under the header, before vinyl / top tracks).

## Changes

- **Discogs** / **Spotify** widget: loading skeleton when fetching without summary; rendered summary when `data.aiSummary` is present.
- **Tests**: extended discogs- and spotify-widget specs + snapshots (with / without summary).
- **Release**: theme **0.90.0**; `www.chrisvogt.me` **1.21.0**; `www.chronogrove.com` **1.8.0**; CHANGELOG updated.

## Coverage

Focused coverage on the two widget source files: **100%** statements/branches. Full theme `test:coverage` still meets global thresholds.

Made with [Cursor](https://cursor.com)