### PR TITLE
chore(release): gatsby-theme-chronogrove 0.90.1 — Steam game cards UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,36 @@
 # Changelog
 
+## 0.90.1
+
+### `gatsby-theme-chronogrove` — Steam game cards (UI polish)
+
+- **`steam-game-card.js`**: Spotify-style **hover/focus caption** (title and playtime copy hidden until interaction); full-bleed **`object-fit: cover`** artwork at a fixed height (fixes empty bands from `%` height + LazyLoad); **rank badge** stacks above the caption (**`z-index`**) so leaderboard numbers stay visible on the overlay; **`align-self: start`** so grid rows don’t stretch cards; transparent/block button styling for a tight image frame.
+- **`steam-widget.js`**: Recently-played **grid** aligned with Spotify density (**3 → 4 → 4 → 5 → 5** columns); loading skeleton **dropped the obsolete footer strip** under placeholders.
+- **`play-time-chart.js`**: Leaderboard grid uses the **same column scale** as recently-played.
+- **Tests**: **`steam-game-card.spec.js`** — focus/blur vs hover zoom, caption + rank stacking (`z-index`), rank null edge case, dark mode missing-image path.
+- **Version**: **0.90.1**
+
+### `www.chrisvogt.me`
+
+- **Version**: **1.21.1** (tracks theme **0.90.1**).
+
+### `www.chronogrove.com` (demo)
+
+- **Version**: **1.8.1** (tracks theme **0.90.1**).
+
+### Files changed
+
+- `CHANGELOG.md`
+- `theme/package.json` (version **0.90.1**)
+- `theme/src/components/widgets/steam/steam-game-card.js`, **`steam-game-card.spec.js`**
+- `theme/src/components/widgets/steam/steam-widget.js`
+- `theme/src/components/widgets/steam/play-time-chart.js`
+- `theme/src/components/widgets/steam/__snapshots__/steam-widget.spec.js.snap`, **`play-time-chart.spec.js.snap`**
+- `www.chrisvogt.me/package.json` (version **1.21.1**)
+- `www.chronogrove.com/package.json` (version **1.8.1**)
+
+---
+
 ## 0.90.0
 
 ### `gatsby-theme-chronogrove` — Discogs & Spotify AI summaries

--- a/theme/package.json
+++ b/theme/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-theme-chronogrove",
   "description": "A personal website and digital garden theme for GatsbyJS.",
-  "version": "0.90.0",
+  "version": "0.90.1",
   "author": "Chris Vogt <mail@chrisvogt.me> (https://www.chrisvogt.me)",
   "main": "index.js",
   "license": "MIT",

--- a/theme/src/components/widgets/steam/__snapshots__/play-time-chart.spec.js.snap
+++ b/theme/src/components/widgets/steam/__snapshots__/play-time-chart.spec.js.snap
@@ -6,11 +6,11 @@ exports[`PlayTimeChart Dark Mode Coverage matches snapshot for a game card in da
     class="css-sak8bt"
   >
     <div
-      class="css-zxiliy"
+      class="css-munl51"
     >
       <button
         aria-label="View Cities: Skylines on Steam"
-        class="css-1cffl98"
+        class="css-1br4deq"
         type="button"
       >
         <div
@@ -18,36 +18,33 @@ exports[`PlayTimeChart Dark Mode Coverage matches snapshot for a game card in da
         >
           <img
             alt="Cities: Skylines header"
-            class="css-1hlyxwi"
+            class="css-17nz09e"
             src="https://example.com/cities-header.jpg"
           />
           <div
-            class="css-c86zxy"
+            class="css-17mv9gi"
           >
             1
           </div>
           <div
-            class="css-13txfr7"
-          />
-        </div>
-        <div
-          class="css-rr301l"
-        >
-          <div
-            class="css-rkrxe3"
+            class="steam-game-card_caption css-k8brg5"
           >
-            Cities: Skylines
-          </div>
-          <div
-            class="css-k763k9"
-          >
-            757.35h total • 2h recently
+            <div
+              class="css-h3pxs9"
+            >
+              Cities: Skylines
+            </div>
+            <div
+              class="css-1i7ls3l"
+            >
+              757.35h total • 2h recently
+            </div>
           </div>
         </div>
       </button>
       <button
         aria-label="View ARK: Survival Evolved on Steam"
-        class="css-1cffl98"
+        class="css-1br4deq"
         type="button"
       >
         <div
@@ -55,36 +52,33 @@ exports[`PlayTimeChart Dark Mode Coverage matches snapshot for a game card in da
         >
           <img
             alt="ARK: Survival Evolved header"
-            class="css-1hlyxwi"
+            class="css-17nz09e"
             src="https://example.com/ark-header.jpg"
           />
           <div
-            class="css-c86zxy"
+            class="css-17mv9gi"
           >
             2
           </div>
           <div
-            class="css-13txfr7"
-          />
-        </div>
-        <div
-          class="css-rr301l"
-        >
-          <div
-            class="css-rkrxe3"
+            class="steam-game-card_caption css-k8brg5"
           >
-            ARK: Survival Evolved
-          </div>
-          <div
-            class="css-k763k9"
-          >
-            277.83h total
+            <div
+              class="css-h3pxs9"
+            >
+              ARK: Survival Evolved
+            </div>
+            <div
+              class="css-1i7ls3l"
+            >
+              277.83h total
+            </div>
           </div>
         </div>
       </button>
       <button
         aria-label="View PUBG: BATTLEGROUNDS on Steam"
-        class="css-1cffl98"
+        class="css-1br4deq"
         type="button"
       >
         <div
@@ -92,30 +86,27 @@ exports[`PlayTimeChart Dark Mode Coverage matches snapshot for a game card in da
         >
           <img
             alt="PUBG: BATTLEGROUNDS header"
-            class="css-1hlyxwi"
+            class="css-17nz09e"
             src="https://example.com/pubg-header.jpg"
           />
           <div
-            class="css-c86zxy"
+            class="css-17mv9gi"
           >
             3
           </div>
           <div
-            class="css-13txfr7"
-          />
-        </div>
-        <div
-          class="css-rr301l"
-        >
-          <div
-            class="css-rkrxe3"
+            class="steam-game-card_caption css-k8brg5"
           >
-            PUBG: BATTLEGROUNDS
-          </div>
-          <div
-            class="css-k763k9"
-          >
-            200h total • 1h recently
+            <div
+              class="css-h3pxs9"
+            >
+              PUBG: BATTLEGROUNDS
+            </div>
+            <div
+              class="css-1i7ls3l"
+            >
+              200h total • 1h recently
+            </div>
           </div>
         </div>
       </button>
@@ -154,11 +145,11 @@ exports[`PlayTimeChart Dark Mode Coverage matches snapshot for a hovered game ca
     class="css-sak8bt"
   >
     <div
-      class="css-zxiliy"
+      class="css-munl51"
     >
       <button
         aria-label="View Cities: Skylines on Steam"
-        class="css-1cffl98"
+        class="css-1br4deq"
         type="button"
       >
         <div
@@ -166,36 +157,33 @@ exports[`PlayTimeChart Dark Mode Coverage matches snapshot for a hovered game ca
         >
           <img
             alt="Cities: Skylines header"
-            class="css-1hlyxwi"
+            class="css-17nz09e"
             src="https://example.com/cities-header.jpg"
           />
           <div
-            class="css-c86zxy"
+            class="css-17mv9gi"
           >
             1
           </div>
           <div
-            class="css-13txfr7"
-          />
-        </div>
-        <div
-          class="css-rr301l"
-        >
-          <div
-            class="css-rkrxe3"
+            class="steam-game-card_caption css-k8brg5"
           >
-            Cities: Skylines
-          </div>
-          <div
-            class="css-k763k9"
-          >
-            757.35h total • 2h recently
+            <div
+              class="css-h3pxs9"
+            >
+              Cities: Skylines
+            </div>
+            <div
+              class="css-1i7ls3l"
+            >
+              757.35h total • 2h recently
+            </div>
           </div>
         </div>
       </button>
       <button
         aria-label="View ARK: Survival Evolved on Steam"
-        class="css-1cffl98"
+        class="css-1br4deq"
         type="button"
       >
         <div
@@ -203,36 +191,33 @@ exports[`PlayTimeChart Dark Mode Coverage matches snapshot for a hovered game ca
         >
           <img
             alt="ARK: Survival Evolved header"
-            class="css-1hlyxwi"
+            class="css-17nz09e"
             src="https://example.com/ark-header.jpg"
           />
           <div
-            class="css-c86zxy"
+            class="css-17mv9gi"
           >
             2
           </div>
           <div
-            class="css-13txfr7"
-          />
-        </div>
-        <div
-          class="css-rr301l"
-        >
-          <div
-            class="css-rkrxe3"
+            class="steam-game-card_caption css-k8brg5"
           >
-            ARK: Survival Evolved
-          </div>
-          <div
-            class="css-k763k9"
-          >
-            277.83h total
+            <div
+              class="css-h3pxs9"
+            >
+              ARK: Survival Evolved
+            </div>
+            <div
+              class="css-1i7ls3l"
+            >
+              277.83h total
+            </div>
           </div>
         </div>
       </button>
       <button
         aria-label="View PUBG: BATTLEGROUNDS on Steam"
-        class="css-1cffl98"
+        class="css-1br4deq"
         type="button"
       >
         <div
@@ -240,30 +225,27 @@ exports[`PlayTimeChart Dark Mode Coverage matches snapshot for a hovered game ca
         >
           <img
             alt="PUBG: BATTLEGROUNDS header"
-            class="css-1hlyxwi"
+            class="css-17nz09e"
             src="https://example.com/pubg-header.jpg"
           />
           <div
-            class="css-c86zxy"
+            class="css-17mv9gi"
           >
             3
           </div>
           <div
-            class="css-13txfr7"
-          />
-        </div>
-        <div
-          class="css-rr301l"
-        >
-          <div
-            class="css-rkrxe3"
+            class="steam-game-card_caption css-k8brg5"
           >
-            PUBG: BATTLEGROUNDS
-          </div>
-          <div
-            class="css-k763k9"
-          >
-            200h total • 1h recently
+            <div
+              class="css-h3pxs9"
+            >
+              PUBG: BATTLEGROUNDS
+            </div>
+            <div
+              class="css-1i7ls3l"
+            >
+              200h total • 1h recently
+            </div>
           </div>
         </div>
       </button>
@@ -302,11 +284,11 @@ exports[`PlayTimeChart Data Processing filters out games with zero playtime 1`] 
     class="css-sak8bt"
   >
     <div
-      class="css-zxiliy"
+      class="css-munl51"
     >
       <button
         aria-label="View Cities: Skylines on Steam"
-        class="css-1cffl98"
+        class="css-1br4deq"
         type="button"
       >
         <div
@@ -314,36 +296,33 @@ exports[`PlayTimeChart Data Processing filters out games with zero playtime 1`] 
         >
           <img
             alt="Cities: Skylines header"
-            class="css-1hlyxwi"
+            class="css-17nz09e"
             src="https://example.com/cities-header.jpg"
           />
           <div
-            class="css-c86zxy"
+            class="css-17mv9gi"
           >
             1
           </div>
           <div
-            class="css-13txfr7"
-          />
-        </div>
-        <div
-          class="css-rr301l"
-        >
-          <div
-            class="css-rkrxe3"
+            class="steam-game-card_caption css-k8brg5"
           >
-            Cities: Skylines
-          </div>
-          <div
-            class="css-k763k9"
-          >
-            757.35h total • 2h recently
+            <div
+              class="css-h3pxs9"
+            >
+              Cities: Skylines
+            </div>
+            <div
+              class="css-1i7ls3l"
+            >
+              757.35h total • 2h recently
+            </div>
           </div>
         </div>
       </button>
       <button
         aria-label="View ARK: Survival Evolved on Steam"
-        class="css-1cffl98"
+        class="css-1br4deq"
         type="button"
       >
         <div
@@ -351,36 +330,33 @@ exports[`PlayTimeChart Data Processing filters out games with zero playtime 1`] 
         >
           <img
             alt="ARK: Survival Evolved header"
-            class="css-1hlyxwi"
+            class="css-17nz09e"
             src="https://example.com/ark-header.jpg"
           />
           <div
-            class="css-c86zxy"
+            class="css-17mv9gi"
           >
             2
           </div>
           <div
-            class="css-13txfr7"
-          />
-        </div>
-        <div
-          class="css-rr301l"
-        >
-          <div
-            class="css-rkrxe3"
+            class="steam-game-card_caption css-k8brg5"
           >
-            ARK: Survival Evolved
-          </div>
-          <div
-            class="css-k763k9"
-          >
-            277.83h total
+            <div
+              class="css-h3pxs9"
+            >
+              ARK: Survival Evolved
+            </div>
+            <div
+              class="css-1i7ls3l"
+            >
+              277.83h total
+            </div>
           </div>
         </div>
       </button>
       <button
         aria-label="View PUBG: BATTLEGROUNDS on Steam"
-        class="css-1cffl98"
+        class="css-1br4deq"
         type="button"
       >
         <div
@@ -388,30 +364,27 @@ exports[`PlayTimeChart Data Processing filters out games with zero playtime 1`] 
         >
           <img
             alt="PUBG: BATTLEGROUNDS header"
-            class="css-1hlyxwi"
+            class="css-17nz09e"
             src="https://example.com/pubg-header.jpg"
           />
           <div
-            class="css-c86zxy"
+            class="css-17mv9gi"
           >
             3
           </div>
           <div
-            class="css-13txfr7"
-          />
-        </div>
-        <div
-          class="css-rr301l"
-        >
-          <div
-            class="css-rkrxe3"
+            class="steam-game-card_caption css-k8brg5"
           >
-            PUBG: BATTLEGROUNDS
-          </div>
-          <div
-            class="css-k763k9"
-          >
-            200h total • 1h recently
+            <div
+              class="css-h3pxs9"
+            >
+              PUBG: BATTLEGROUNDS
+            </div>
+            <div
+              class="css-1i7ls3l"
+            >
+              200h total • 1h recently
+            </div>
           </div>
         </div>
       </button>
@@ -450,11 +423,11 @@ exports[`PlayTimeChart Data Processing renders correctly with sample data 1`] = 
     class="css-sak8bt"
   >
     <div
-      class="css-zxiliy"
+      class="css-munl51"
     >
       <button
         aria-label="View Cities: Skylines on Steam"
-        class="css-1cffl98"
+        class="css-1br4deq"
         type="button"
       >
         <div
@@ -462,36 +435,33 @@ exports[`PlayTimeChart Data Processing renders correctly with sample data 1`] = 
         >
           <img
             alt="Cities: Skylines header"
-            class="css-1hlyxwi"
+            class="css-17nz09e"
             src="https://example.com/cities-header.jpg"
           />
           <div
-            class="css-c86zxy"
+            class="css-17mv9gi"
           >
             1
           </div>
           <div
-            class="css-13txfr7"
-          />
-        </div>
-        <div
-          class="css-rr301l"
-        >
-          <div
-            class="css-rkrxe3"
+            class="steam-game-card_caption css-k8brg5"
           >
-            Cities: Skylines
-          </div>
-          <div
-            class="css-k763k9"
-          >
-            757.35h total • 2h recently
+            <div
+              class="css-h3pxs9"
+            >
+              Cities: Skylines
+            </div>
+            <div
+              class="css-1i7ls3l"
+            >
+              757.35h total • 2h recently
+            </div>
           </div>
         </div>
       </button>
       <button
         aria-label="View ARK: Survival Evolved on Steam"
-        class="css-1cffl98"
+        class="css-1br4deq"
         type="button"
       >
         <div
@@ -499,36 +469,33 @@ exports[`PlayTimeChart Data Processing renders correctly with sample data 1`] = 
         >
           <img
             alt="ARK: Survival Evolved header"
-            class="css-1hlyxwi"
+            class="css-17nz09e"
             src="https://example.com/ark-header.jpg"
           />
           <div
-            class="css-c86zxy"
+            class="css-17mv9gi"
           >
             2
           </div>
           <div
-            class="css-13txfr7"
-          />
-        </div>
-        <div
-          class="css-rr301l"
-        >
-          <div
-            class="css-rkrxe3"
+            class="steam-game-card_caption css-k8brg5"
           >
-            ARK: Survival Evolved
-          </div>
-          <div
-            class="css-k763k9"
-          >
-            277.83h total
+            <div
+              class="css-h3pxs9"
+            >
+              ARK: Survival Evolved
+            </div>
+            <div
+              class="css-1i7ls3l"
+            >
+              277.83h total
+            </div>
           </div>
         </div>
       </button>
       <button
         aria-label="View PUBG: BATTLEGROUNDS on Steam"
-        class="css-1cffl98"
+        class="css-1br4deq"
         type="button"
       >
         <div
@@ -536,30 +503,27 @@ exports[`PlayTimeChart Data Processing renders correctly with sample data 1`] = 
         >
           <img
             alt="PUBG: BATTLEGROUNDS header"
-            class="css-1hlyxwi"
+            class="css-17nz09e"
             src="https://example.com/pubg-header.jpg"
           />
           <div
-            class="css-c86zxy"
+            class="css-17mv9gi"
           >
             3
           </div>
           <div
-            class="css-13txfr7"
-          />
-        </div>
-        <div
-          class="css-rr301l"
-        >
-          <div
-            class="css-rkrxe3"
+            class="steam-game-card_caption css-k8brg5"
           >
-            PUBG: BATTLEGROUNDS
-          </div>
-          <div
-            class="css-k763k9"
-          >
-            200h total • 1h recently
+            <div
+              class="css-h3pxs9"
+            >
+              PUBG: BATTLEGROUNDS
+            </div>
+            <div
+              class="css-1i7ls3l"
+            >
+              200h total • 1h recently
+            </div>
           </div>
         </div>
       </button>
@@ -598,11 +562,11 @@ exports[`PlayTimeChart Edge Cases handles single game scenario 1`] = `
     class="css-sak8bt"
   >
     <div
-      class="css-zxiliy"
+      class="css-munl51"
     >
       <button
         aria-label="View Cities: Skylines on Steam"
-        class="css-1cffl98"
+        class="css-1br4deq"
         type="button"
       >
         <div
@@ -610,30 +574,27 @@ exports[`PlayTimeChart Edge Cases handles single game scenario 1`] = `
         >
           <img
             alt="Cities: Skylines header"
-            class="css-1hlyxwi"
+            class="css-17nz09e"
             src="https://example.com/cities-header.jpg"
           />
           <div
-            class="css-c86zxy"
+            class="css-17mv9gi"
           >
             1
           </div>
           <div
-            class="css-13txfr7"
-          />
-        </div>
-        <div
-          class="css-rr301l"
-        >
-          <div
-            class="css-rkrxe3"
+            class="steam-game-card_caption css-k8brg5"
           >
-            Cities: Skylines
-          </div>
-          <div
-            class="css-k763k9"
-          >
-            757.35h total • 2h recently
+            <div
+              class="css-h3pxs9"
+            >
+              Cities: Skylines
+            </div>
+            <div
+              class="css-1i7ls3l"
+            >
+              757.35h total • 2h recently
+            </div>
           </div>
         </div>
       </button>
@@ -726,11 +687,11 @@ exports[`PlayTimeChart Light Mode Coverage matches snapshot for a game card in l
     class="css-sak8bt"
   >
     <div
-      class="css-zxiliy"
+      class="css-munl51"
     >
       <button
         aria-label="View Cities: Skylines on Steam"
-        class="css-1cffl98"
+        class="css-1br4deq"
         type="button"
       >
         <div
@@ -738,36 +699,33 @@ exports[`PlayTimeChart Light Mode Coverage matches snapshot for a game card in l
         >
           <img
             alt="Cities: Skylines header"
-            class="css-1hlyxwi"
+            class="css-17nz09e"
             src="https://example.com/cities-header.jpg"
           />
           <div
-            class="css-c86zxy"
+            class="css-17mv9gi"
           >
             1
           </div>
           <div
-            class="css-13txfr7"
-          />
-        </div>
-        <div
-          class="css-rr301l"
-        >
-          <div
-            class="css-rkrxe3"
+            class="steam-game-card_caption css-k8brg5"
           >
-            Cities: Skylines
-          </div>
-          <div
-            class="css-k763k9"
-          >
-            757.35h total • 2h recently
+            <div
+              class="css-h3pxs9"
+            >
+              Cities: Skylines
+            </div>
+            <div
+              class="css-1i7ls3l"
+            >
+              757.35h total • 2h recently
+            </div>
           </div>
         </div>
       </button>
       <button
         aria-label="View ARK: Survival Evolved on Steam"
-        class="css-1cffl98"
+        class="css-1br4deq"
         type="button"
       >
         <div
@@ -775,36 +733,33 @@ exports[`PlayTimeChart Light Mode Coverage matches snapshot for a game card in l
         >
           <img
             alt="ARK: Survival Evolved header"
-            class="css-1hlyxwi"
+            class="css-17nz09e"
             src="https://example.com/ark-header.jpg"
           />
           <div
-            class="css-c86zxy"
+            class="css-17mv9gi"
           >
             2
           </div>
           <div
-            class="css-13txfr7"
-          />
-        </div>
-        <div
-          class="css-rr301l"
-        >
-          <div
-            class="css-rkrxe3"
+            class="steam-game-card_caption css-k8brg5"
           >
-            ARK: Survival Evolved
-          </div>
-          <div
-            class="css-k763k9"
-          >
-            277.83h total
+            <div
+              class="css-h3pxs9"
+            >
+              ARK: Survival Evolved
+            </div>
+            <div
+              class="css-1i7ls3l"
+            >
+              277.83h total
+            </div>
           </div>
         </div>
       </button>
       <button
         aria-label="View PUBG: BATTLEGROUNDS on Steam"
-        class="css-1cffl98"
+        class="css-1br4deq"
         type="button"
       >
         <div
@@ -812,30 +767,27 @@ exports[`PlayTimeChart Light Mode Coverage matches snapshot for a game card in l
         >
           <img
             alt="PUBG: BATTLEGROUNDS header"
-            class="css-1hlyxwi"
+            class="css-17nz09e"
             src="https://example.com/pubg-header.jpg"
           />
           <div
-            class="css-c86zxy"
+            class="css-17mv9gi"
           >
             3
           </div>
           <div
-            class="css-13txfr7"
-          />
-        </div>
-        <div
-          class="css-rr301l"
-        >
-          <div
-            class="css-rkrxe3"
+            class="steam-game-card_caption css-k8brg5"
           >
-            PUBG: BATTLEGROUNDS
-          </div>
-          <div
-            class="css-k763k9"
-          >
-            200h total • 1h recently
+            <div
+              class="css-h3pxs9"
+            >
+              PUBG: BATTLEGROUNDS
+            </div>
+            <div
+              class="css-1i7ls3l"
+            >
+              200h total • 1h recently
+            </div>
           </div>
         </div>
       </button>
@@ -874,11 +826,11 @@ exports[`PlayTimeChart Light Mode Coverage matches snapshot for a hovered game c
     class="css-sak8bt"
   >
     <div
-      class="css-zxiliy"
+      class="css-munl51"
     >
       <button
         aria-label="View Cities: Skylines on Steam"
-        class="css-1cffl98"
+        class="css-1br4deq"
         type="button"
       >
         <div
@@ -886,36 +838,33 @@ exports[`PlayTimeChart Light Mode Coverage matches snapshot for a hovered game c
         >
           <img
             alt="Cities: Skylines header"
-            class="css-1hlyxwi"
+            class="css-17nz09e"
             src="https://example.com/cities-header.jpg"
           />
           <div
-            class="css-c86zxy"
+            class="css-17mv9gi"
           >
             1
           </div>
           <div
-            class="css-13txfr7"
-          />
-        </div>
-        <div
-          class="css-rr301l"
-        >
-          <div
-            class="css-rkrxe3"
+            class="steam-game-card_caption css-k8brg5"
           >
-            Cities: Skylines
-          </div>
-          <div
-            class="css-k763k9"
-          >
-            757.35h total • 2h recently
+            <div
+              class="css-h3pxs9"
+            >
+              Cities: Skylines
+            </div>
+            <div
+              class="css-1i7ls3l"
+            >
+              757.35h total • 2h recently
+            </div>
           </div>
         </div>
       </button>
       <button
         aria-label="View ARK: Survival Evolved on Steam"
-        class="css-1cffl98"
+        class="css-1br4deq"
         type="button"
       >
         <div
@@ -923,36 +872,33 @@ exports[`PlayTimeChart Light Mode Coverage matches snapshot for a hovered game c
         >
           <img
             alt="ARK: Survival Evolved header"
-            class="css-1hlyxwi"
+            class="css-17nz09e"
             src="https://example.com/ark-header.jpg"
           />
           <div
-            class="css-c86zxy"
+            class="css-17mv9gi"
           >
             2
           </div>
           <div
-            class="css-13txfr7"
-          />
-        </div>
-        <div
-          class="css-rr301l"
-        >
-          <div
-            class="css-rkrxe3"
+            class="steam-game-card_caption css-k8brg5"
           >
-            ARK: Survival Evolved
-          </div>
-          <div
-            class="css-k763k9"
-          >
-            277.83h total
+            <div
+              class="css-h3pxs9"
+            >
+              ARK: Survival Evolved
+            </div>
+            <div
+              class="css-1i7ls3l"
+            >
+              277.83h total
+            </div>
           </div>
         </div>
       </button>
       <button
         aria-label="View PUBG: BATTLEGROUNDS on Steam"
-        class="css-1cffl98"
+        class="css-1br4deq"
         type="button"
       >
         <div
@@ -960,30 +906,27 @@ exports[`PlayTimeChart Light Mode Coverage matches snapshot for a hovered game c
         >
           <img
             alt="PUBG: BATTLEGROUNDS header"
-            class="css-1hlyxwi"
+            class="css-17nz09e"
             src="https://example.com/pubg-header.jpg"
           />
           <div
-            class="css-c86zxy"
+            class="css-17mv9gi"
           >
             3
           </div>
           <div
-            class="css-13txfr7"
-          />
-        </div>
-        <div
-          class="css-rr301l"
-        >
-          <div
-            class="css-rkrxe3"
+            class="steam-game-card_caption css-k8brg5"
           >
-            PUBG: BATTLEGROUNDS
-          </div>
-          <div
-            class="css-k763k9"
-          >
-            200h total • 1h recently
+            <div
+              class="css-h3pxs9"
+            >
+              PUBG: BATTLEGROUNDS
+            </div>
+            <div
+              class="css-1i7ls3l"
+            >
+              200h total • 1h recently
+            </div>
           </div>
         </div>
       </button>
@@ -1043,11 +986,11 @@ exports[`PlayTimeChart Theme Integration adapts to dark mode styling 1`] = `
     class="css-sak8bt"
   >
     <div
-      class="css-zxiliy"
+      class="css-munl51"
     >
       <button
         aria-label="View Cities: Skylines on Steam"
-        class="css-1cffl98"
+        class="css-1br4deq"
         type="button"
       >
         <div
@@ -1055,36 +998,33 @@ exports[`PlayTimeChart Theme Integration adapts to dark mode styling 1`] = `
         >
           <img
             alt="Cities: Skylines header"
-            class="css-1hlyxwi"
+            class="css-17nz09e"
             src="https://example.com/cities-header.jpg"
           />
           <div
-            class="css-c86zxy"
+            class="css-17mv9gi"
           >
             1
           </div>
           <div
-            class="css-13txfr7"
-          />
-        </div>
-        <div
-          class="css-rr301l"
-        >
-          <div
-            class="css-rkrxe3"
+            class="steam-game-card_caption css-k8brg5"
           >
-            Cities: Skylines
-          </div>
-          <div
-            class="css-k763k9"
-          >
-            757.35h total • 2h recently
+            <div
+              class="css-h3pxs9"
+            >
+              Cities: Skylines
+            </div>
+            <div
+              class="css-1i7ls3l"
+            >
+              757.35h total • 2h recently
+            </div>
           </div>
         </div>
       </button>
       <button
         aria-label="View ARK: Survival Evolved on Steam"
-        class="css-1cffl98"
+        class="css-1br4deq"
         type="button"
       >
         <div
@@ -1092,36 +1032,33 @@ exports[`PlayTimeChart Theme Integration adapts to dark mode styling 1`] = `
         >
           <img
             alt="ARK: Survival Evolved header"
-            class="css-1hlyxwi"
+            class="css-17nz09e"
             src="https://example.com/ark-header.jpg"
           />
           <div
-            class="css-c86zxy"
+            class="css-17mv9gi"
           >
             2
           </div>
           <div
-            class="css-13txfr7"
-          />
-        </div>
-        <div
-          class="css-rr301l"
-        >
-          <div
-            class="css-rkrxe3"
+            class="steam-game-card_caption css-k8brg5"
           >
-            ARK: Survival Evolved
-          </div>
-          <div
-            class="css-k763k9"
-          >
-            277.83h total
+            <div
+              class="css-h3pxs9"
+            >
+              ARK: Survival Evolved
+            </div>
+            <div
+              class="css-1i7ls3l"
+            >
+              277.83h total
+            </div>
           </div>
         </div>
       </button>
       <button
         aria-label="View PUBG: BATTLEGROUNDS on Steam"
-        class="css-1cffl98"
+        class="css-1br4deq"
         type="button"
       >
         <div
@@ -1129,30 +1066,27 @@ exports[`PlayTimeChart Theme Integration adapts to dark mode styling 1`] = `
         >
           <img
             alt="PUBG: BATTLEGROUNDS header"
-            class="css-1hlyxwi"
+            class="css-17nz09e"
             src="https://example.com/pubg-header.jpg"
           />
           <div
-            class="css-c86zxy"
+            class="css-17mv9gi"
           >
             3
           </div>
           <div
-            class="css-13txfr7"
-          />
-        </div>
-        <div
-          class="css-rr301l"
-        >
-          <div
-            class="css-rkrxe3"
+            class="steam-game-card_caption css-k8brg5"
           >
-            PUBG: BATTLEGROUNDS
-          </div>
-          <div
-            class="css-k763k9"
-          >
-            200h total • 1h recently
+            <div
+              class="css-h3pxs9"
+            >
+              PUBG: BATTLEGROUNDS
+            </div>
+            <div
+              class="css-1i7ls3l"
+            >
+              200h total • 1h recently
+            </div>
           </div>
         </div>
       </button>
@@ -1191,11 +1125,11 @@ exports[`PlayTimeChart Theme Integration renders correctly in light mode 1`] = `
     class="css-sak8bt"
   >
     <div
-      class="css-zxiliy"
+      class="css-munl51"
     >
       <button
         aria-label="View Cities: Skylines on Steam"
-        class="css-1cffl98"
+        class="css-1br4deq"
         type="button"
       >
         <div
@@ -1203,36 +1137,33 @@ exports[`PlayTimeChart Theme Integration renders correctly in light mode 1`] = `
         >
           <img
             alt="Cities: Skylines header"
-            class="css-1hlyxwi"
+            class="css-17nz09e"
             src="https://example.com/cities-header.jpg"
           />
           <div
-            class="css-c86zxy"
+            class="css-17mv9gi"
           >
             1
           </div>
           <div
-            class="css-13txfr7"
-          />
-        </div>
-        <div
-          class="css-rr301l"
-        >
-          <div
-            class="css-rkrxe3"
+            class="steam-game-card_caption css-k8brg5"
           >
-            Cities: Skylines
-          </div>
-          <div
-            class="css-k763k9"
-          >
-            757.35h total • 2h recently
+            <div
+              class="css-h3pxs9"
+            >
+              Cities: Skylines
+            </div>
+            <div
+              class="css-1i7ls3l"
+            >
+              757.35h total • 2h recently
+            </div>
           </div>
         </div>
       </button>
       <button
         aria-label="View ARK: Survival Evolved on Steam"
-        class="css-1cffl98"
+        class="css-1br4deq"
         type="button"
       >
         <div
@@ -1240,36 +1171,33 @@ exports[`PlayTimeChart Theme Integration renders correctly in light mode 1`] = `
         >
           <img
             alt="ARK: Survival Evolved header"
-            class="css-1hlyxwi"
+            class="css-17nz09e"
             src="https://example.com/ark-header.jpg"
           />
           <div
-            class="css-c86zxy"
+            class="css-17mv9gi"
           >
             2
           </div>
           <div
-            class="css-13txfr7"
-          />
-        </div>
-        <div
-          class="css-rr301l"
-        >
-          <div
-            class="css-rkrxe3"
+            class="steam-game-card_caption css-k8brg5"
           >
-            ARK: Survival Evolved
-          </div>
-          <div
-            class="css-k763k9"
-          >
-            277.83h total
+            <div
+              class="css-h3pxs9"
+            >
+              ARK: Survival Evolved
+            </div>
+            <div
+              class="css-1i7ls3l"
+            >
+              277.83h total
+            </div>
           </div>
         </div>
       </button>
       <button
         aria-label="View PUBG: BATTLEGROUNDS on Steam"
-        class="css-1cffl98"
+        class="css-1br4deq"
         type="button"
       >
         <div
@@ -1277,30 +1205,27 @@ exports[`PlayTimeChart Theme Integration renders correctly in light mode 1`] = `
         >
           <img
             alt="PUBG: BATTLEGROUNDS header"
-            class="css-1hlyxwi"
+            class="css-17nz09e"
             src="https://example.com/pubg-header.jpg"
           />
           <div
-            class="css-c86zxy"
+            class="css-17mv9gi"
           >
             3
           </div>
           <div
-            class="css-13txfr7"
-          />
-        </div>
-        <div
-          class="css-rr301l"
-        >
-          <div
-            class="css-rkrxe3"
+            class="steam-game-card_caption css-k8brg5"
           >
-            PUBG: BATTLEGROUNDS
-          </div>
-          <div
-            class="css-k763k9"
-          >
-            200h total • 1h recently
+            <div
+              class="css-h3pxs9"
+            >
+              PUBG: BATTLEGROUNDS
+            </div>
+            <div
+              class="css-1i7ls3l"
+            >
+              200h total • 1h recently
+            </div>
           </div>
         </div>
       </button>

--- a/theme/src/components/widgets/steam/__snapshots__/steam-widget.spec.js.snap
+++ b/theme/src/components/widgets/steam/__snapshots__/steam-widget.spec.js.snap
@@ -41,11 +41,11 @@ exports[`SteamWidget renders AI summary if present 1`] = `
       Games I've played in the last two weeks.
     </p>
     <div
-      class="css-1jvl2a0"
+      class="css-1o4v4vi"
     >
       <button
         aria-label="View Half-Life on Steam"
-        class="css-1cffl98"
+        class="css-1br4deq"
         type="button"
       >
         <div
@@ -53,31 +53,28 @@ exports[`SteamWidget renders AI summary if present 1`] = `
         >
           <img
             alt="Half-Life header"
-            class="css-1hlyxwi"
+            class="css-17nz09e"
             src="https://example.com/halflife.jpg"
           />
           <div
-            class="css-13txfr7"
-          />
-        </div>
-        <div
-          class="css-rr301l"
-        >
-          <div
-            class="css-rkrxe3"
+            class="steam-game-card_caption css-k8brg5"
           >
-            Half-Life
-          </div>
-          <div
-            class="css-k763k9"
-          >
-            2 hours
+            <div
+              class="css-h3pxs9"
+            >
+              Half-Life
+            </div>
+            <div
+              class="css-1i7ls3l"
+            >
+              2 hours
+            </div>
           </div>
         </div>
       </button>
       <button
         aria-label="View Portal on Steam"
-        class="css-1cffl98"
+        class="css-1br4deq"
         type="button"
       >
         <div
@@ -85,25 +82,22 @@ exports[`SteamWidget renders AI summary if present 1`] = `
         >
           <img
             alt="Portal header"
-            class="css-1hlyxwi"
+            class="css-17nz09e"
             src="https://example.com/portal.jpg"
           />
           <div
-            class="css-13txfr7"
-          />
-        </div>
-        <div
-          class="css-rr301l"
-        >
-          <div
-            class="css-rkrxe3"
+            class="steam-game-card_caption css-k8brg5"
           >
-            Portal
-          </div>
-          <div
-            class="css-k763k9"
-          >
-            45 minutes
+            <div
+              class="css-h3pxs9"
+            >
+              Portal
+            </div>
+            <div
+              class="css-1i7ls3l"
+            >
+              45 minutes
+            </div>
           </div>
         </div>
       </button>
@@ -126,11 +120,11 @@ exports[`SteamWidget renders AI summary if present 1`] = `
       class="css-sak8bt"
     >
       <div
-        class="css-zxiliy"
+        class="css-munl51"
       >
         <button
           aria-label="View Cities: Skylines on Steam"
-          class="css-1cffl98"
+          class="css-1br4deq"
           type="button"
         >
           <div
@@ -138,36 +132,33 @@ exports[`SteamWidget renders AI summary if present 1`] = `
           >
             <img
               alt="Cities: Skylines header"
-              class="css-1hlyxwi"
+              class="css-17nz09e"
               src="https://example.com/cities-icon.jpg"
             />
             <div
-              class="css-c86zxy"
+              class="css-17mv9gi"
             >
               1
             </div>
             <div
-              class="css-13txfr7"
-            />
-          </div>
-          <div
-            class="css-rr301l"
-          >
-            <div
-              class="css-rkrxe3"
+              class="steam-game-card_caption css-k8brg5"
             >
-              Cities: Skylines
-            </div>
-            <div
-              class="css-k763k9"
-            >
-              757.35h total • 2 hours recently
+              <div
+                class="css-h3pxs9"
+              >
+                Cities: Skylines
+              </div>
+              <div
+                class="css-1i7ls3l"
+              >
+                757.35h total • 2 hours recently
+              </div>
             </div>
           </div>
         </button>
         <button
           aria-label="View ARK: Survival Evolved on Steam"
-          class="css-1cffl98"
+          class="css-1br4deq"
           type="button"
         >
           <div
@@ -175,30 +166,27 @@ exports[`SteamWidget renders AI summary if present 1`] = `
           >
             <img
               alt="ARK: Survival Evolved header"
-              class="css-1hlyxwi"
+              class="css-17nz09e"
               src="https://example.com/ark-icon.jpg"
             />
             <div
-              class="css-c86zxy"
+              class="css-17mv9gi"
             >
               2
             </div>
             <div
-              class="css-13txfr7"
-            />
-          </div>
-          <div
-            class="css-rr301l"
-          >
-            <div
-              class="css-rkrxe3"
+              class="steam-game-card_caption css-k8brg5"
             >
-              ARK: Survival Evolved
-            </div>
-            <div
-              class="css-k763k9"
-            >
-              277.83h total
+              <div
+                class="css-h3pxs9"
+              >
+                ARK: Survival Evolved
+              </div>
+              <div
+                class="css-1i7ls3l"
+              >
+                277.83h total
+              </div>
             </div>
           </div>
         </button>
@@ -282,11 +270,11 @@ exports[`SteamWidget renders correctly with sample data 1`] = `
       Games I've played in the last two weeks.
     </p>
     <div
-      class="css-1jvl2a0"
+      class="css-1o4v4vi"
     >
       <button
         aria-label="View Half-Life on Steam"
-        class="css-1cffl98"
+        class="css-1br4deq"
         type="button"
       >
         <div
@@ -294,31 +282,28 @@ exports[`SteamWidget renders correctly with sample data 1`] = `
         >
           <img
             alt="Half-Life header"
-            class="css-1hlyxwi"
+            class="css-17nz09e"
             src="https://example.com/halflife.jpg"
           />
           <div
-            class="css-13txfr7"
-          />
-        </div>
-        <div
-          class="css-rr301l"
-        >
-          <div
-            class="css-rkrxe3"
+            class="steam-game-card_caption css-k8brg5"
           >
-            Half-Life
-          </div>
-          <div
-            class="css-k763k9"
-          >
-            2 hours
+            <div
+              class="css-h3pxs9"
+            >
+              Half-Life
+            </div>
+            <div
+              class="css-1i7ls3l"
+            >
+              2 hours
+            </div>
           </div>
         </div>
       </button>
       <button
         aria-label="View Portal on Steam"
-        class="css-1cffl98"
+        class="css-1br4deq"
         type="button"
       >
         <div
@@ -326,25 +311,22 @@ exports[`SteamWidget renders correctly with sample data 1`] = `
         >
           <img
             alt="Portal header"
-            class="css-1hlyxwi"
+            class="css-17nz09e"
             src="https://example.com/portal.jpg"
           />
           <div
-            class="css-13txfr7"
-          />
-        </div>
-        <div
-          class="css-rr301l"
-        >
-          <div
-            class="css-rkrxe3"
+            class="steam-game-card_caption css-k8brg5"
           >
-            Portal
-          </div>
-          <div
-            class="css-k763k9"
-          >
-            45 minutes
+            <div
+              class="css-h3pxs9"
+            >
+              Portal
+            </div>
+            <div
+              class="css-1i7ls3l"
+            >
+              45 minutes
+            </div>
           </div>
         </div>
       </button>
@@ -367,11 +349,11 @@ exports[`SteamWidget renders correctly with sample data 1`] = `
       class="css-sak8bt"
     >
       <div
-        class="css-zxiliy"
+        class="css-munl51"
       >
         <button
           aria-label="View Cities: Skylines on Steam"
-          class="css-1cffl98"
+          class="css-1br4deq"
           type="button"
         >
           <div
@@ -379,36 +361,33 @@ exports[`SteamWidget renders correctly with sample data 1`] = `
           >
             <img
               alt="Cities: Skylines header"
-              class="css-1hlyxwi"
+              class="css-17nz09e"
               src="https://example.com/cities-icon.jpg"
             />
             <div
-              class="css-c86zxy"
+              class="css-17mv9gi"
             >
               1
             </div>
             <div
-              class="css-13txfr7"
-            />
-          </div>
-          <div
-            class="css-rr301l"
-          >
-            <div
-              class="css-rkrxe3"
+              class="steam-game-card_caption css-k8brg5"
             >
-              Cities: Skylines
-            </div>
-            <div
-              class="css-k763k9"
-            >
-              757.35h total • 2 hours recently
+              <div
+                class="css-h3pxs9"
+              >
+                Cities: Skylines
+              </div>
+              <div
+                class="css-1i7ls3l"
+              >
+                757.35h total • 2 hours recently
+              </div>
             </div>
           </div>
         </button>
         <button
           aria-label="View ARK: Survival Evolved on Steam"
-          class="css-1cffl98"
+          class="css-1br4deq"
           type="button"
         >
           <div
@@ -416,30 +395,27 @@ exports[`SteamWidget renders correctly with sample data 1`] = `
           >
             <img
               alt="ARK: Survival Evolved header"
-              class="css-1hlyxwi"
+              class="css-17nz09e"
               src="https://example.com/ark-icon.jpg"
             />
             <div
-              class="css-c86zxy"
+              class="css-17mv9gi"
             >
               2
             </div>
             <div
-              class="css-13txfr7"
-            />
-          </div>
-          <div
-            class="css-rr301l"
-          >
-            <div
-              class="css-rkrxe3"
+              class="steam-game-card_caption css-k8brg5"
             >
-              ARK: Survival Evolved
-            </div>
-            <div
-              class="css-k763k9"
-            >
-              277.83h total
+              <div
+                class="css-h3pxs9"
+              >
+                ARK: Survival Evolved
+              </div>
+              <div
+                class="css-1i7ls3l"
+              >
+                277.83h total
+              </div>
             </div>
           </div>
         </button>
@@ -598,7 +574,7 @@ exports[`SteamWidget renders loading state 1`] = `
       Games I've played in the last two weeks.
     </p>
     <div
-      class="css-1jvl2a0"
+      class="css-1o4v4vi"
     >
       <div
         aria-hidden="true"
@@ -613,9 +589,6 @@ exports[`SteamWidget renders loading state 1`] = `
             style="background-color: rgb(239, 239, 239); width: 100%; height: 200px; margin-right: 10px; border-radius: 8px;"
           />
         </div>
-        <div
-          class="css-16i9tn4"
-        />
       </div>
       <div
         aria-hidden="true"
@@ -630,9 +603,6 @@ exports[`SteamWidget renders loading state 1`] = `
             style="background-color: rgb(239, 239, 239); width: 100%; height: 200px; margin-right: 10px; border-radius: 8px;"
           />
         </div>
-        <div
-          class="css-16i9tn4"
-        />
       </div>
       <div
         aria-hidden="true"
@@ -647,9 +617,6 @@ exports[`SteamWidget renders loading state 1`] = `
             style="background-color: rgb(239, 239, 239); width: 100%; height: 200px; margin-right: 10px; border-radius: 8px;"
           />
         </div>
-        <div
-          class="css-16i9tn4"
-        />
       </div>
       <div
         aria-hidden="true"
@@ -664,9 +631,6 @@ exports[`SteamWidget renders loading state 1`] = `
             style="background-color: rgb(239, 239, 239); width: 100%; height: 200px; margin-right: 10px; border-radius: 8px;"
           />
         </div>
-        <div
-          class="css-16i9tn4"
-        />
       </div>
       <div
         aria-hidden="true"
@@ -681,9 +645,6 @@ exports[`SteamWidget renders loading state 1`] = `
             style="background-color: rgb(239, 239, 239); width: 100%; height: 200px; margin-right: 10px; border-radius: 8px;"
           />
         </div>
-        <div
-          class="css-16i9tn4"
-        />
       </div>
       <div
         aria-hidden="true"
@@ -698,9 +659,6 @@ exports[`SteamWidget renders loading state 1`] = `
             style="background-color: rgb(239, 239, 239); width: 100%; height: 200px; margin-right: 10px; border-radius: 8px;"
           />
         </div>
-        <div
-          class="css-16i9tn4"
-        />
       </div>
     </div>
     <div
@@ -762,11 +720,11 @@ exports[`SteamWidget renders with empty metrics 1`] = `
       Games I've played in the last two weeks.
     </p>
     <div
-      class="css-1jvl2a0"
+      class="css-1o4v4vi"
     >
       <button
         aria-label="View Half-Life on Steam"
-        class="css-1cffl98"
+        class="css-1br4deq"
         type="button"
       >
         <div
@@ -774,31 +732,28 @@ exports[`SteamWidget renders with empty metrics 1`] = `
         >
           <img
             alt="Half-Life header"
-            class="css-1hlyxwi"
+            class="css-17nz09e"
             src="https://example.com/halflife.jpg"
           />
           <div
-            class="css-13txfr7"
-          />
-        </div>
-        <div
-          class="css-rr301l"
-        >
-          <div
-            class="css-rkrxe3"
+            class="steam-game-card_caption css-k8brg5"
           >
-            Half-Life
-          </div>
-          <div
-            class="css-k763k9"
-          >
-            2 hours
+            <div
+              class="css-h3pxs9"
+            >
+              Half-Life
+            </div>
+            <div
+              class="css-1i7ls3l"
+            >
+              2 hours
+            </div>
           </div>
         </div>
       </button>
       <button
         aria-label="View Portal on Steam"
-        class="css-1cffl98"
+        class="css-1br4deq"
         type="button"
       >
         <div
@@ -806,25 +761,22 @@ exports[`SteamWidget renders with empty metrics 1`] = `
         >
           <img
             alt="Portal header"
-            class="css-1hlyxwi"
+            class="css-17nz09e"
             src="https://example.com/portal.jpg"
           />
           <div
-            class="css-13txfr7"
-          />
-        </div>
-        <div
-          class="css-rr301l"
-        >
-          <div
-            class="css-rkrxe3"
+            class="steam-game-card_caption css-k8brg5"
           >
-            Portal
-          </div>
-          <div
-            class="css-k763k9"
-          >
-            45 minutes
+            <div
+              class="css-h3pxs9"
+            >
+              Portal
+            </div>
+            <div
+              class="css-1i7ls3l"
+            >
+              45 minutes
+            </div>
           </div>
         </div>
       </button>
@@ -847,11 +799,11 @@ exports[`SteamWidget renders with empty metrics 1`] = `
       class="css-sak8bt"
     >
       <div
-        class="css-zxiliy"
+        class="css-munl51"
       >
         <button
           aria-label="View Cities: Skylines on Steam"
-          class="css-1cffl98"
+          class="css-1br4deq"
           type="button"
         >
           <div
@@ -859,36 +811,33 @@ exports[`SteamWidget renders with empty metrics 1`] = `
           >
             <img
               alt="Cities: Skylines header"
-              class="css-1hlyxwi"
+              class="css-17nz09e"
               src="https://example.com/cities-icon.jpg"
             />
             <div
-              class="css-c86zxy"
+              class="css-17mv9gi"
             >
               1
             </div>
             <div
-              class="css-13txfr7"
-            />
-          </div>
-          <div
-            class="css-rr301l"
-          >
-            <div
-              class="css-rkrxe3"
+              class="steam-game-card_caption css-k8brg5"
             >
-              Cities: Skylines
-            </div>
-            <div
-              class="css-k763k9"
-            >
-              757.35h total • 2 hours recently
+              <div
+                class="css-h3pxs9"
+              >
+                Cities: Skylines
+              </div>
+              <div
+                class="css-1i7ls3l"
+              >
+                757.35h total • 2 hours recently
+              </div>
             </div>
           </div>
         </button>
         <button
           aria-label="View ARK: Survival Evolved on Steam"
-          class="css-1cffl98"
+          class="css-1br4deq"
           type="button"
         >
           <div
@@ -896,30 +845,27 @@ exports[`SteamWidget renders with empty metrics 1`] = `
           >
             <img
               alt="ARK: Survival Evolved header"
-              class="css-1hlyxwi"
+              class="css-17nz09e"
               src="https://example.com/ark-icon.jpg"
             />
             <div
-              class="css-c86zxy"
+              class="css-17mv9gi"
             >
               2
             </div>
             <div
-              class="css-13txfr7"
-            />
-          </div>
-          <div
-            class="css-rr301l"
-          >
-            <div
-              class="css-rkrxe3"
+              class="steam-game-card_caption css-k8brg5"
             >
-              ARK: Survival Evolved
-            </div>
-            <div
-              class="css-k763k9"
-            >
-              277.83h total
+              <div
+                class="css-h3pxs9"
+              >
+                ARK: Survival Evolved
+              </div>
+              <div
+                class="css-1i7ls3l"
+              >
+                277.83h total
+              </div>
             </div>
           </div>
         </button>

--- a/theme/src/components/widgets/steam/play-time-chart.js
+++ b/theme/src/components/widgets/steam/play-time-chart.js
@@ -97,7 +97,13 @@ const PlayTimeChart = ({ games = [], isLoading = false, profileURL = '' }) => {
       <Grid
         sx={{
           gridGap: [3, 2, 2, 3],
-          gridTemplateColumns: ['repeat(2, 1fr)', 'repeat(3, 1fr)', 'repeat(4, 1fr)'],
+          gridTemplateColumns: [
+            'repeat(3, 1fr)',
+            'repeat(4, 1fr)',
+            'repeat(4, 1fr)',
+            'repeat(5, 1fr)',
+            'repeat(5, 1fr)'
+          ],
           mb: 4
         }}
       >

--- a/theme/src/components/widgets/steam/steam-game-card.js
+++ b/theme/src/components/widgets/steam/steam-game-card.js
@@ -7,8 +7,13 @@ import LazyLoad from '../../lazy-load'
 
 import 'react-placeholder/lib/reactPlaceholder.css'
 
+/** px; must match lazy placeholder + RectShape — img can't use height % inside LazyLoad’s auto-height Box */
+const STEAM_CARD_IMAGE_HEIGHT = 200
+
 const SteamGameCard = ({ game, showRank = false, rank = null, subtitle = null, onClick = null }) => {
   const [isHovered, setIsHovered] = useState(false)
+  const [isFocused, setIsFocused] = useState(false)
+  const isImageZoomed = isHovered || isFocused
   const { colorMode } = useThemeUI()
   const darkModeActive = isDarkMode(colorMode)
 
@@ -22,21 +27,30 @@ const SteamGameCard = ({ game, showRank = false, rank = null, subtitle = null, o
       aria-label={`View ${game.displayName} on Steam`}
       onMouseEnter={() => setIsHovered(true)}
       onMouseLeave={() => setIsHovered(false)}
+      onFocus={() => setIsFocused(true)}
+      onBlur={() => setIsFocused(false)}
       onClick={handleClick}
       sx={{
         variant: 'styles.InstagramItem',
         position: 'relative',
+        display: 'block',
+        width: '100%',
         overflow: 'hidden',
         cursor: 'pointer',
         background: 'none',
+        backgroundColor: 'transparent',
         border: 'none',
         p: 0,
         borderRadius: '8px',
         boxShadow: 'md',
         transition: 'all 200ms ease-in-out',
+        alignSelf: 'start',
         '&:hover, &:focus': {
           transform: 'scale(1.015)',
           boxShadow: 'lg'
+        },
+        '&:hover .steam-game-card_caption, &:focus .steam-game-card_caption': {
+          opacity: 1
         }
       }}
     >
@@ -45,19 +59,19 @@ const SteamGameCard = ({ game, showRank = false, rank = null, subtitle = null, o
         sx={{
           position: 'relative',
           width: '100%',
-          height: '200px',
+          height: STEAM_CARD_IMAGE_HEIGHT,
           overflow: 'hidden'
         }}
       >
         {gameImage ? (
           <LazyLoad
             placeholder={
-              <div className='show-loading-animation' style={{ width: '100%', height: '200px' }}>
+              <div className='show-loading-animation' style={{ width: '100%', height: STEAM_CARD_IMAGE_HEIGHT }}>
                 <RectShape
                   color={darkModeActive ? '#3a3a4a' : '#efefef'}
                   style={{
                     width: '100%',
-                    height: '200px'
+                    height: STEAM_CARD_IMAGE_HEIGHT
                   }}
                 />
               </div>
@@ -67,21 +81,22 @@ const SteamGameCard = ({ game, showRank = false, rank = null, subtitle = null, o
               src={gameImage}
               alt={`${game.displayName} header`}
               sx={{
+                display: 'block',
                 width: '100%',
-                height: '100%',
+                height: STEAM_CARD_IMAGE_HEIGHT,
                 objectFit: 'cover',
                 transition: 'transform 0.3s ease',
-                transform: isHovered ? 'scale(1.05)' : 'scale(1)'
+                transform: isImageZoomed ? 'scale(1.05)' : 'scale(1)'
               }}
             />
           </LazyLoad>
         ) : (
-          <div className='show-loading-animation' style={{ width: '100%', height: '200px' }}>
+          <div className='show-loading-animation' style={{ width: '100%', height: STEAM_CARD_IMAGE_HEIGHT }}>
             <RectShape
               color={darkModeActive ? '#3a3a4a' : '#efefef'}
               style={{
                 width: '100%',
-                height: '200px'
+                height: STEAM_CARD_IMAGE_HEIGHT
               }}
             />
           </div>
@@ -94,6 +109,7 @@ const SteamGameCard = ({ game, showRank = false, rank = null, subtitle = null, o
               position: 'absolute',
               top: 2,
               left: 2,
+              zIndex: 2,
               background: darkModeActive ? 'rgba(20, 20, 31, 0.85)' : 'rgba(255, 255, 255, 0.9)',
               backdropFilter: 'blur(10px)',
               WebkitBackdropFilter: 'blur(10px)',
@@ -114,60 +130,55 @@ const SteamGameCard = ({ game, showRank = false, rank = null, subtitle = null, o
           </div>
         )}
 
-        {/* Gradient Overlay */}
+        {/* Title / subtitle: hidden until hover or focus (Spotify media grid pattern) */}
         <div
+          className='steam-game-card_caption'
           sx={{
-            position: 'absolute',
+            alignItems: 'center',
+            background: 'rgba(0, 0, 0, 0.85)',
+            backdropFilter: 'blur(2px)',
+            WebkitBackdropFilter: 'blur(2px)',
             bottom: 0,
+            color: 'white',
+            display: 'flex',
+            flexDirection: 'column',
+            justifyContent: 'center',
             left: 0,
+            opacity: 0,
+            padding: 3,
+            pointerEvents: 'none',
+            position: 'absolute',
             right: 0,
-            height: '140px',
-            background: darkModeActive
-              ? 'linear-gradient(to top, rgba(0,0,0,0.95) 0%, rgba(0,0,0,0.85) 20%, rgba(0,0,0,0.6) 50%, rgba(0,0,0,0.3) 80%, transparent 100%)'
-              : 'linear-gradient(to top, rgba(255,255,255,0.98) 0%, rgba(255,255,255,0.9) 20%, rgba(255,255,255,0.7) 50%, rgba(255,255,255,0.4) 80%, transparent 100%)',
-            pointerEvents: 'none'
-          }}
-        />
-      </div>
-
-      {/* Text Content */}
-      <div
-        sx={{
-          position: 'absolute',
-          bottom: 0,
-          left: 0,
-          right: 0,
-          padding: 3,
-          color: darkModeActive ? '#fff' : '#000'
-        }}
-      >
-        {/* Game Name */}
-        <div
-          sx={{
-            fontSize: '14px',
-            fontWeight: 'bold',
-            mb: 1,
-            overflow: 'hidden',
-            textOverflow: 'ellipsis',
-            whiteSpace: 'nowrap',
-            textShadow: darkModeActive ? '0 1px 3px rgba(0,0,0,0.8)' : '0 1px 3px rgba(255,255,255,0.8)'
+            textAlign: 'center',
+            top: 0,
+            transition: 'opacity 0.2s ease-in-out',
+            zIndex: 1
           }}
         >
-          {game.displayName}
-        </div>
-
-        {/* Subtitle */}
-        {subtitle && (
           <div
             sx={{
-              fontSize: '12px',
-              color: darkModeActive ? 'rgba(255,255,255,0.8)' : 'rgba(0,0,0,0.7)',
-              textShadow: darkModeActive ? '0 1px 2px rgba(0,0,0,0.8)' : '0 1px 2px rgba(255,255,255,0.8)'
+              fontSize: '14px',
+              fontWeight: 'bold',
+              mb: subtitle ? 1 : 0,
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+              width: '100%'
             }}
           >
-            {subtitle}
+            {game.displayName}
           </div>
-        )}
+          {subtitle && (
+            <div
+              sx={{
+                fontSize: '12px',
+                color: 'rgba(255,255,255,0.85)'
+              }}
+            >
+              {subtitle}
+            </div>
+          )}
+        </div>
       </div>
     </Box>
   )

--- a/theme/src/components/widgets/steam/steam-game-card.spec.js
+++ b/theme/src/components/widgets/steam/steam-game-card.spec.js
@@ -63,6 +63,12 @@ describe('SteamGameCard', () => {
     expect(container.querySelector('.show-loading-animation')).toBeInTheDocument()
   })
 
+  it('uses dark skeleton colors when images are missing in dark mode', () => {
+    const gameWithoutImages = { ...mockGame, images: {} }
+    const { container } = renderWithTheme(<SteamGameCard game={gameWithoutImages} />, 'dark')
+    expect(container.querySelector('.show-loading-animation')).toBeInTheDocument()
+  })
+
   it('displays rank badge when showRank is true', () => {
     const { container } = renderWithTheme(<SteamGameCard game={mockGame} showRank={true} rank={1} />)
     expect(container.textContent).toContain('1')
@@ -126,6 +132,44 @@ describe('SteamGameCard', () => {
     fireEvent.mouseLeave(card)
     // Component should update hover state
     expect(card).toBeTruthy()
+  })
+
+  it('uses focus/blur for the same image zoom behavior as hover', () => {
+    const { container } = renderWithTheme(<SteamGameCard game={mockGame} />)
+    const card = container.firstChild
+    const img = container.querySelector('img')
+
+    const baseline = window.getComputedStyle(img).transform
+    fireEvent.focus(card)
+    expect(window.getComputedStyle(img).transform).not.toBe(baseline)
+
+    fireEvent.blur(card)
+    expect(window.getComputedStyle(img).transform).toBe(baseline)
+  })
+
+  it('renders the hover caption overlay (Spotify-style)', () => {
+    const { container } = renderWithTheme(<SteamGameCard game={mockGame} subtitle='1h' />)
+    expect(container.querySelector('.steam-game-card_caption')).toBeInTheDocument()
+  })
+
+  it('stacks rank badge above the caption overlay', () => {
+    const { container } = renderWithTheme(<SteamGameCard game={mockGame} showRank={true} rank={4} subtitle='10h' />)
+    const caption = container.querySelector('.steam-game-card_caption')
+    const badge = [...container.querySelectorAll('div')].find(
+      el => el !== caption && el.textContent === '4' && el !== container.firstChild
+    )
+    expect(caption).toBeTruthy()
+    expect(badge).toBeTruthy()
+    expect(window.getComputedStyle(caption).zIndex).toBe('1')
+    expect(window.getComputedStyle(badge).zIndex).toBe('2')
+  })
+
+  it('does not render rank badge when showRank is true but rank is null', () => {
+    const { container } = renderWithTheme(
+      <SteamGameCard game={{ ...mockGame, displayName: 'Alpha' }} showRank={true} rank={null} />
+    )
+    const digitOnlyDivs = [...container.querySelectorAll('div')].filter(d => /^\d+$/.test((d.textContent || '').trim()))
+    expect(digitOnlyDivs).toHaveLength(0)
   })
 
   describe('Dark mode', () => {

--- a/theme/src/components/widgets/steam/steam-widget.js
+++ b/theme/src/components/widgets/steam/steam-widget.js
@@ -73,7 +73,13 @@ const SteamWidget = React.memo(() => {
             sx={{
               display: 'grid',
               gridGap: [3, 2, 2, 3],
-              gridTemplateColumns: ['repeat(2, 1fr)', 'repeat(3, 1fr)', 'repeat(4, 1fr)'],
+              gridTemplateColumns: [
+                'repeat(3, 1fr)',
+                'repeat(4, 1fr)',
+                'repeat(4, 1fr)',
+                'repeat(5, 1fr)',
+                'repeat(5, 1fr)'
+              ],
               mb: 4
             }}
           >
@@ -95,7 +101,6 @@ const SteamWidget = React.memo(() => {
                         style={{ width: '100%', height: '200px', borderRadius: '8px' }}
                       />
                     </div>
-                    <div sx={{ height: '72px', p: 3 }} />
                   </div>
                 ))
               : recentlyPlayedGames.map(game => (

--- a/www.chrisvogt.me/package.json
+++ b/www.chrisvogt.me/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "www.chrisvogt.me",
-  "version": "1.21.0",
+  "version": "1.21.1",
   "license": "GPL",
   "scripts": {
     "build": "gatsby build",

--- a/www.chronogrove.com/package.json
+++ b/www.chronogrove.com/package.json
@@ -1,6 +1,6 @@
 {
   "name": "www.chronogrove.com",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "Official demo site for gatsby-theme-chronogrove",
   "scripts": {
     "develop": "gatsby develop",


### PR DESCRIPTION
## Summary

Patch release (**0.90.1**): Steam widget game cards get Spotify-style hover/focus captions, fixed-height `object-fit: cover` art (no empty bands), leaderboard rank badge above the overlay, denser responsive grids (**3 → 4 → 4 → 5 → 5**), and loading skeleton cleanup.

## Changes

- **`steam-game-card.js`**: Hover/focus caption overlay; fixed image height; `align-self: start`; rank `z-index` above caption; transparent/block button styling.
- **`steam-widget.js`** / **`play-time-chart.js`**: Shared grid column scale; removed obsolete skeleton footer strip.
- **Tests**: Expanded **`steam-game-card.spec.js`** (focus/blur, stacking, edge cases).
- **Versions**: theme **0.90.1**, **www.chrisvogt.me** **1.21.1**, **www.chronogrove.com** **1.8.1**; **`CHANGELOG.md`** updated.

## Verification

- `pnpm --filter gatsby-theme-chronogrove test:coverage` passes global thresholds.


Made with [Cursor](https://cursor.com)