### PR TITLE
feat(spotify): Paginate Top Tracks carousel (v0.91.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,36 @@
 # Changelog
 
+## 0.91.0
+
+### `gatsby-theme-chronogrove` — Spotify Top Tracks pagination
+
+- **`top-tracks.js`**: **Top Tracks** supports more API rows (e.g. **24**) by paginating **12 tiles per slide** with the same swipe/drag carousel pattern as Goodreads (`useSwipePagination`) plus shared **`Pagination`** controls; **`interactionDisabled`** on **`MediaItemGrid`** avoids starting playback after a drag.
+- **`media-item-grid.js`**: Optional **`interactionDisabled`** prop (prevents **`onTrackClick`** and still **`preventDefault`** on the anchor).
+- **Tests**: **`top-tracks.spec.js`** — multi-page grid, page clamp when the list shrinks, reset when track identities change; **`media-item-grid.spec.js`** — **`interactionDisabled`**; **`spotify-widget.spec.js`** snapshots updated.
+- **Jest**: Global **`coverageThreshold`** for **statements**, **functions**, and **lines** raised to **98%** (branches remain **90%**).
+- **Version**: **0.91.0**
+
+### `www.chrisvogt.me`
+
+- **Version**: **1.22.0** (tracks theme **0.91.0**).
+
+### `www.chronogrove.com` (demo)
+
+- **Version**: **1.9.0** (tracks theme **0.91.0**).
+
+### Files changed
+
+- `CHANGELOG.md`
+- `theme/jest.config.js` (coverage thresholds)
+- `theme/package.json` (version **0.91.0**)
+- `theme/src/components/widgets/spotify/top-tracks.js`, **`top-tracks.spec.js`**, **`__snapshots__/top-tracks.spec.js.snap`**
+- `theme/src/components/widgets/spotify/media-item-grid.js`, **`media-item-grid.spec.js`**
+- `theme/src/components/widgets/spotify/__snapshots__/spotify-widget.spec.js.snap`
+- `www.chrisvogt.me/package.json` (version **1.22.0**)
+- `www.chronogrove.com/package.json` (version **1.9.0**)
+
+---
+
 ## 0.90.1
 
 ### `gatsby-theme-chronogrove` — Steam game cards (UI polish)

--- a/theme/jest.config.js
+++ b/theme/jest.config.js
@@ -58,14 +58,13 @@ module.exports = {
     'src/components/widgets/recent-posts/image-thumbnails.js'
   ],
 
-  // Relaxed from 98–99% to avoid blocking on noise. Branches stay at 90% until more branch tests land
-  // (theme is ~90% branches; stmts/lines/funcs are ~98–99%).
+  // Branches stay at 90% until more branch tests land (~91% actual); stmts/lines/funcs enforced at 98%.
   coverageThreshold: {
     global: {
-      statements: 96,
+      statements: 98,
       branches: 90,
-      functions: 96,
-      lines: 96
+      functions: 98,
+      lines: 98
     }
   },
 

--- a/theme/package.json
+++ b/theme/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-theme-chronogrove",
   "description": "A personal website and digital garden theme for GatsbyJS.",
-  "version": "0.90.1",
+  "version": "0.91.0",
   "author": "Chris Vogt <mail@chrisvogt.me> (https://www.chrisvogt.me)",
   "main": "index.js",
   "license": "MIT",

--- a/theme/src/components/widgets/spotify/__snapshots__/spotify-widget.spec.js.snap
+++ b/theme/src/components/widgets/spotify/__snapshots__/spotify-widget.spec.js.snap
@@ -87,11 +87,26 @@ exports[`Spotify Widget matches the error state snapshot 1`] = `
       <p
         class="css-1qwovgy"
       >
-        My 12 most-played tracks over the last 4 weeks.
+        Tracks I've played most over the last four weeks.
       </p>
       <div
-        class="media-item_grid null css-5stlgz"
-      />
+        class="css-us3dds"
+      >
+        <div
+          class="css-kdywdz"
+          data-testid="spotify-top-tracks-carousel"
+        >
+          <div
+            aria-hidden="false"
+            class="css-4bo1uy"
+            data-testid="spotify-top-tracks-page-1"
+          >
+            <div
+              class="media-item_grid null css-5stlgz"
+            />
+          </div>
+        </div>
+      </div>
     </div>
     <div>
       <div
@@ -223,33 +238,48 @@ exports[`Spotify Widget matches the loaded state snapshot 1`] = `
       <p
         class="css-1qwovgy"
       >
-        My 12 most-played tracks over the last 4 weeks.
+        Tracks I've played most over the last four weeks.
       </p>
       <div
-        class="media-item_grid null css-5stlgz"
+        class="css-us3dds"
       >
-        <a
-          class="media-item_media css-13fusor"
-          title="Test Track – [object Object]"
+        <div
+          class="css-kdywdz"
+          data-testid="spotify-top-tracks-carousel"
         >
           <div
-            class="css-x4b07x"
+            aria-hidden="false"
+            class="css-4bo1uy"
+            data-testid="spotify-top-tracks-page-1"
           >
             <div
-              class="media-item_caption css-e7oldi"
+              class="media-item_grid null css-5stlgz"
             >
-              <span>
-                Test Track
-              </span>
+              <a
+                class="media-item_media css-13fusor"
+                title="Test Track – [object Object]"
+              >
+                <div
+                  class="css-x4b07x"
+                >
+                  <div
+                    class="media-item_caption css-e7oldi"
+                  >
+                    <span>
+                      Test Track
+                    </span>
+                  </div>
+                  <img
+                    alt="cover artwork"
+                    class="css-karewm"
+                    crossorigin="anonymous"
+                    loading="lazy"
+                  />
+                </div>
+              </a>
             </div>
-            <img
-              alt="cover artwork"
-              class="css-karewm"
-              crossorigin="anonymous"
-              loading="lazy"
-            />
           </div>
-        </a>
+        </div>
       </div>
     </div>
     <div>
@@ -422,106 +452,110 @@ exports[`Spotify Widget matches the loading state snapshot 1`] = `
       <p
         class="css-1qwovgy"
       >
-        My 12 most-played tracks over the last 4 weeks.
+        Tracks I've played most over the last four weeks.
       </p>
       <div
-        class="media-item_grid null css-5stlgz"
+        class="css-us3dds"
       >
         <div
-          class="show-loading-animation"
+          class="media-item_grid null css-5stlgz"
         >
           <div
-            class="rect-shape css-2us3i8"
-            style="background-color: rgb(239, 239, 239); width: 100%; height: 100%; margin-right: 10px;"
-          />
-        </div>
-        <div
-          class="show-loading-animation"
-        >
+            class="show-loading-animation"
+          >
+            <div
+              class="rect-shape css-2us3i8"
+              style="background-color: rgb(239, 239, 239); width: 100%; height: 100%; margin-right: 10px;"
+            />
+          </div>
           <div
-            class="rect-shape css-2us3i8"
-            style="background-color: rgb(239, 239, 239); width: 100%; height: 100%; margin-right: 10px;"
-          />
-        </div>
-        <div
-          class="show-loading-animation"
-        >
+            class="show-loading-animation"
+          >
+            <div
+              class="rect-shape css-2us3i8"
+              style="background-color: rgb(239, 239, 239); width: 100%; height: 100%; margin-right: 10px;"
+            />
+          </div>
           <div
-            class="rect-shape css-2us3i8"
-            style="background-color: rgb(239, 239, 239); width: 100%; height: 100%; margin-right: 10px;"
-          />
-        </div>
-        <div
-          class="show-loading-animation"
-        >
+            class="show-loading-animation"
+          >
+            <div
+              class="rect-shape css-2us3i8"
+              style="background-color: rgb(239, 239, 239); width: 100%; height: 100%; margin-right: 10px;"
+            />
+          </div>
           <div
-            class="rect-shape css-2us3i8"
-            style="background-color: rgb(239, 239, 239); width: 100%; height: 100%; margin-right: 10px;"
-          />
-        </div>
-        <div
-          class="show-loading-animation"
-        >
+            class="show-loading-animation"
+          >
+            <div
+              class="rect-shape css-2us3i8"
+              style="background-color: rgb(239, 239, 239); width: 100%; height: 100%; margin-right: 10px;"
+            />
+          </div>
           <div
-            class="rect-shape css-2us3i8"
-            style="background-color: rgb(239, 239, 239); width: 100%; height: 100%; margin-right: 10px;"
-          />
-        </div>
-        <div
-          class="show-loading-animation"
-        >
+            class="show-loading-animation"
+          >
+            <div
+              class="rect-shape css-2us3i8"
+              style="background-color: rgb(239, 239, 239); width: 100%; height: 100%; margin-right: 10px;"
+            />
+          </div>
           <div
-            class="rect-shape css-2us3i8"
-            style="background-color: rgb(239, 239, 239); width: 100%; height: 100%; margin-right: 10px;"
-          />
-        </div>
-        <div
-          class="show-loading-animation"
-        >
+            class="show-loading-animation"
+          >
+            <div
+              class="rect-shape css-2us3i8"
+              style="background-color: rgb(239, 239, 239); width: 100%; height: 100%; margin-right: 10px;"
+            />
+          </div>
           <div
-            class="rect-shape css-2us3i8"
-            style="background-color: rgb(239, 239, 239); width: 100%; height: 100%; margin-right: 10px;"
-          />
-        </div>
-        <div
-          class="show-loading-animation"
-        >
+            class="show-loading-animation"
+          >
+            <div
+              class="rect-shape css-2us3i8"
+              style="background-color: rgb(239, 239, 239); width: 100%; height: 100%; margin-right: 10px;"
+            />
+          </div>
           <div
-            class="rect-shape css-2us3i8"
-            style="background-color: rgb(239, 239, 239); width: 100%; height: 100%; margin-right: 10px;"
-          />
-        </div>
-        <div
-          class="show-loading-animation"
-        >
+            class="show-loading-animation"
+          >
+            <div
+              class="rect-shape css-2us3i8"
+              style="background-color: rgb(239, 239, 239); width: 100%; height: 100%; margin-right: 10px;"
+            />
+          </div>
           <div
-            class="rect-shape css-2us3i8"
-            style="background-color: rgb(239, 239, 239); width: 100%; height: 100%; margin-right: 10px;"
-          />
-        </div>
-        <div
-          class="show-loading-animation"
-        >
+            class="show-loading-animation"
+          >
+            <div
+              class="rect-shape css-2us3i8"
+              style="background-color: rgb(239, 239, 239); width: 100%; height: 100%; margin-right: 10px;"
+            />
+          </div>
           <div
-            class="rect-shape css-2us3i8"
-            style="background-color: rgb(239, 239, 239); width: 100%; height: 100%; margin-right: 10px;"
-          />
-        </div>
-        <div
-          class="show-loading-animation"
-        >
+            class="show-loading-animation"
+          >
+            <div
+              class="rect-shape css-2us3i8"
+              style="background-color: rgb(239, 239, 239); width: 100%; height: 100%; margin-right: 10px;"
+            />
+          </div>
           <div
-            class="rect-shape css-2us3i8"
-            style="background-color: rgb(239, 239, 239); width: 100%; height: 100%; margin-right: 10px;"
-          />
-        </div>
-        <div
-          class="show-loading-animation"
-        >
+            class="show-loading-animation"
+          >
+            <div
+              class="rect-shape css-2us3i8"
+              style="background-color: rgb(239, 239, 239); width: 100%; height: 100%; margin-right: 10px;"
+            />
+          </div>
           <div
-            class="rect-shape css-2us3i8"
-            style="background-color: rgb(239, 239, 239); width: 100%; height: 100%; margin-right: 10px;"
-          />
+            class="show-loading-animation"
+          >
+            <div
+              class="rect-shape css-2us3i8"
+              style="background-color: rgb(239, 239, 239); width: 100%; height: 100%; margin-right: 10px;"
+            />
+          </div>
         </div>
       </div>
     </div>
@@ -747,33 +781,48 @@ exports[`Spotify Widget renders without AI summary when not available 1`] = `
       <p
         class="css-1qwovgy"
       >
-        My 12 most-played tracks over the last 4 weeks.
+        Tracks I've played most over the last four weeks.
       </p>
       <div
-        class="media-item_grid null css-5stlgz"
+        class="css-us3dds"
       >
-        <a
-          class="media-item_media css-13fusor"
-          title="Test Track – [object Object]"
+        <div
+          class="css-kdywdz"
+          data-testid="spotify-top-tracks-carousel"
         >
           <div
-            class="css-x4b07x"
+            aria-hidden="false"
+            class="css-4bo1uy"
+            data-testid="spotify-top-tracks-page-1"
           >
             <div
-              class="media-item_caption css-e7oldi"
+              class="media-item_grid null css-5stlgz"
             >
-              <span>
-                Test Track
-              </span>
+              <a
+                class="media-item_media css-13fusor"
+                title="Test Track – [object Object]"
+              >
+                <div
+                  class="css-x4b07x"
+                >
+                  <div
+                    class="media-item_caption css-e7oldi"
+                  >
+                    <span>
+                      Test Track
+                    </span>
+                  </div>
+                  <img
+                    alt="cover artwork"
+                    class="css-karewm"
+                    crossorigin="anonymous"
+                    loading="lazy"
+                  />
+                </div>
+              </a>
             </div>
-            <img
-              alt="cover artwork"
-              class="css-karewm"
-              crossorigin="anonymous"
-              loading="lazy"
-            />
           </div>
-        </a>
+        </div>
       </div>
     </div>
     <div>

--- a/theme/src/components/widgets/spotify/__snapshots__/top-tracks.spec.js.snap
+++ b/theme/src/components/widgets/spotify/__snapshots__/top-tracks.spec.js.snap
@@ -17,11 +17,26 @@ exports[`TopTracks Component handles tracks without a 300px image gracefully 1`]
     <p
       class="css-1qwovgy"
     >
-      My 12 most-played tracks over the last 4 weeks.
+      Tracks I've played most over the last four weeks.
     </p>
     <div
-      data-testid="media-item-grid"
-    />
+      class="css-us3dds"
+    >
+      <div
+        class="css-kdywdz"
+        data-testid="spotify-top-tracks-carousel"
+      >
+        <div
+          aria-hidden="false"
+          class="css-4bo1uy"
+          data-testid="spotify-top-tracks-page-1"
+        >
+          <div
+            data-testid="media-item-grid"
+          />
+        </div>
+      </div>
+    </div>
   </div>
 </DocumentFragment>
 `;
@@ -43,11 +58,15 @@ exports[`TopTracks Component renders correctly when loading 1`] = `
     <p
       class="css-1qwovgy"
     >
-      My 12 most-played tracks over the last 4 weeks.
+      Tracks I've played most over the last four weeks.
     </p>
     <div
-      data-testid="media-item-grid"
-    />
+      class="css-us3dds"
+    >
+      <div
+        data-testid="media-item-grid"
+      />
+    </div>
   </div>
 </DocumentFragment>
 `;
@@ -69,11 +88,26 @@ exports[`TopTracks Component renders correctly with no tracks 1`] = `
     <p
       class="css-1qwovgy"
     >
-      My 12 most-played tracks over the last 4 weeks.
+      Tracks I've played most over the last four weeks.
     </p>
     <div
-      data-testid="media-item-grid"
-    />
+      class="css-us3dds"
+    >
+      <div
+        class="css-kdywdz"
+        data-testid="spotify-top-tracks-carousel"
+      >
+        <div
+          aria-hidden="false"
+          class="css-4bo1uy"
+          data-testid="spotify-top-tracks-page-1"
+        >
+          <div
+            data-testid="media-item-grid"
+          />
+        </div>
+      </div>
+    </div>
   </div>
 </DocumentFragment>
 `;
@@ -95,11 +129,26 @@ exports[`TopTracks Component renders correctly with tracks 1`] = `
     <p
       class="css-1qwovgy"
     >
-      My 12 most-played tracks over the last 4 weeks.
+      Tracks I've played most over the last four weeks.
     </p>
     <div
-      data-testid="media-item-grid"
-    />
+      class="css-us3dds"
+    >
+      <div
+        class="css-kdywdz"
+        data-testid="spotify-top-tracks-carousel"
+      >
+        <div
+          aria-hidden="false"
+          class="css-4bo1uy"
+          data-testid="spotify-top-tracks-page-1"
+        >
+          <div
+            data-testid="media-item-grid"
+          />
+        </div>
+      </div>
+    </div>
   </div>
 </DocumentFragment>
 `;

--- a/theme/src/components/widgets/spotify/media-item-grid.js
+++ b/theme/src/components/widgets/spotify/media-item-grid.js
@@ -8,7 +8,7 @@ import isDarkMode from '../../../helpers/isDarkMode'
 
 import { glassmorhismPanel } from '@chronogrove/ui/theme'
 
-const MediaItemGrid = ({ isLoading, items = [], onTrackClick }) => {
+const MediaItemGrid = ({ interactionDisabled = false, isLoading, items = [], onTrackClick }) => {
   const { colorMode } = useThemeUI()
   const darkModeActive = isDarkMode(colorMode)
   const [currentMediaId, setCurrentMediaId] = useState(false)
@@ -31,6 +31,10 @@ const MediaItemGrid = ({ isLoading, items = [], onTrackClick }) => {
     ))
 
   const handleClick = (e, spotifyURL) => {
+    if (interactionDisabled) {
+      e.preventDefault()
+      return
+    }
     if (!onTrackClick) {
       return
     }

--- a/theme/src/components/widgets/spotify/media-item-grid.spec.js
+++ b/theme/src/components/widgets/spotify/media-item-grid.spec.js
@@ -41,6 +41,18 @@ describe('MediaItemGrid', () => {
     expect(mockOnTrackClick).toHaveBeenCalledWith('https://www.google.com/')
   })
 
+  it('does not call onTrackClick when interactionDisabled', () => {
+    const mockOnTrackClick = jest.fn()
+    const { getByTitle } = render(
+      <MediaItemGrid interactionDisabled isLoading={false} items={mockItems} onTrackClick={mockOnTrackClick} />
+    )
+
+    const firstItem = getByTitle('Item #1')
+    fireEvent.click(firstItem)
+
+    expect(mockOnTrackClick).not.toHaveBeenCalled()
+  })
+
   it('prevents default behavior when item is clicked', () => {
     const mockOnTrackClick = jest.fn()
     const { getByTitle } = render(<MediaItemGrid isLoading={false} items={mockItems} onTrackClick={mockOnTrackClick} />)

--- a/theme/src/components/widgets/spotify/top-tracks.js
+++ b/theme/src/components/widgets/spotify/top-tracks.js
@@ -2,8 +2,16 @@
 import { jsx } from 'theme-ui'
 import { Heading } from '@theme-ui/components'
 import { Themed } from '@theme-ui/mdx'
+import { useEffect, useMemo, useState } from 'react'
+
 import { useAudioPlayerStore } from '../../../stores/audio-player-store'
+import useSwipePagination from '../../../hooks/use-swipe-pagination'
+
 import MediaItemGrid from './media-item-grid'
+import Pagination from '../../pagination'
+
+/** Matches prior single-view density (12 tiles); backend may return up to 24 tracks. */
+const TRACKS_PER_PAGE = 12
 
 const TopTracks = ({ isLoading, tracks = [] }) => {
   const setSpotifyTrack = useAudioPlayerStore(state => state.setSpotifyTrack)
@@ -12,20 +20,65 @@ const TopTracks = ({ isLoading, tracks = [] }) => {
     setSpotifyTrack(spotifyURL)
   }
 
-  const items = tracks.map(track => {
-    const { artists = [], albumImages = [], id, name, spotifyURL } = track
+  const pages = useMemo(() => {
+    const mapped = tracks.map(track => {
+      const { artists = [], albumImages = [], id, name, spotifyURL } = track
 
-    const thumbnail = albumImages.find(image => image.width === 300) || {}
-    const { url: thumbnailURL } = thumbnail
+      const thumbnail = albumImages.find(image => image.width === 300) || {}
+      const { url: thumbnailURL } = thumbnail
 
-    return {
-      id,
-      name,
-      spotifyURL,
-      thumbnailURL,
-      details: `${name} – ${artists.join(', ')}`
+      return {
+        id,
+        name,
+        spotifyURL,
+        thumbnailURL,
+        details: `${name} – ${artists.join(', ')}`
+      }
+    })
+
+    if (!mapped.length) {
+      return [[]]
     }
+
+    const pageCount = Math.ceil(mapped.length / TRACKS_PER_PAGE)
+    return Array.from({ length: pageCount }, (_, pageIndex) => {
+      const start = pageIndex * TRACKS_PER_PAGE
+      return mapped.slice(start, start + TRACKS_PER_PAGE)
+    })
+  }, [tracks])
+
+  const totalPages = Math.max(1, pages.length)
+  const [currentPage, setCurrentPage] = useState(1)
+
+  const {
+    getTransform,
+    handleMouseDown,
+    handleMouseLeave,
+    handleMouseMove,
+    handleMouseUp,
+    handlePageChange,
+    handlePointerCancel,
+    handlePointerDown,
+    handlePointerMove,
+    handlePointerUp,
+    isDragging,
+    isTransitioning
+  } = useSwipePagination({
+    currentPage,
+    totalPages,
+    onPageChange: setCurrentPage
   })
+
+  useEffect(() => {
+    if (totalPages > 0 && currentPage > totalPages) {
+      setCurrentPage(totalPages)
+    }
+  }, [currentPage, totalPages])
+
+  const tracksIdentityKey = tracks.map(t => t.id).join(',')
+  useEffect(() => {
+    setCurrentPage(1)
+  }, [tracksIdentityKey])
 
   return (
     <div sx={{ mb: 4 }}>
@@ -35,9 +88,70 @@ const TopTracks = ({ isLoading, tracks = [] }) => {
         </Heading>
       </div>
 
-      <Themed.p>My 12 most-played tracks over the last 4 weeks.</Themed.p>
+      <Themed.p>Tracks I&apos;ve played most over the last four weeks.</Themed.p>
 
-      <MediaItemGrid isLoading={isLoading} items={items} onTrackClick={handleTrackClick} />
+      <div
+        sx={{
+          overflow: 'hidden',
+          position: 'relative',
+          width: '100%',
+          maxWidth: '100%',
+          pb: 4,
+          mb: -4
+        }}
+      >
+        {isLoading ? (
+          <MediaItemGrid isLoading items={[]} onTrackClick={handleTrackClick} />
+        ) : (
+          <div
+            data-testid='spotify-top-tracks-carousel'
+            sx={{
+              display: 'flex',
+              width: `${totalPages * 100}%`,
+              transform: getTransform(),
+              transition: isDragging ? 'none' : 'transform 0.3s cubic-bezier(0.4, 0, 0.2, 1)',
+              cursor: totalPages > 1 ? (isDragging ? 'grabbing' : 'grab') : 'default',
+              userSelect: 'none',
+              touchAction: 'pan-y'
+            }}
+            onMouseDown={handleMouseDown}
+            onMouseMove={handleMouseMove}
+            onMouseUp={handleMouseUp}
+            onMouseLeave={handleMouseLeave}
+            onPointerDown={handlePointerDown}
+            onPointerMove={handlePointerMove}
+            onPointerUp={handlePointerUp}
+            onPointerCancel={handlePointerCancel}
+          >
+            {pages.map((pageItems, pageIndex) => (
+              <div
+                key={`spotify-top-tracks-page-${pageIndex + 1}`}
+                aria-hidden={pageIndex !== currentPage - 1}
+                data-testid={`spotify-top-tracks-page-${pageIndex + 1}`}
+                sx={{
+                  width: `${100 / totalPages}%`,
+                  flexShrink: 0,
+                  minWidth: 0,
+                  boxSizing: 'border-box',
+                  pr: 3,
+                  pb: 1
+                }}
+              >
+                <MediaItemGrid
+                  interactionDisabled={isDragging || isTransitioning}
+                  isLoading={false}
+                  items={pageItems}
+                  onTrackClick={handleTrackClick}
+                />
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {!isLoading && totalPages > 1 ? (
+        <Pagination currentPage={currentPage} onPageChange={handlePageChange} totalPages={totalPages} />
+      ) : null}
     </div>
   )
 }

--- a/theme/src/components/widgets/spotify/top-tracks.spec.js
+++ b/theme/src/components/widgets/spotify/top-tracks.spec.js
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 import React from 'react'
-import { render } from '@testing-library/react'
+import { render, fireEvent, waitFor } from '@testing-library/react'
 import '@testing-library/jest-dom'
 import { jsx } from 'theme-ui'
 import TopTracks from './top-tracks'
@@ -17,6 +17,15 @@ describe('TopTracks Component', () => {
     resetAudioPlayerStore()
     jest.clearAllMocks()
   })
+
+  const buildTracks = (count, idPrefix = '') =>
+    Array.from({ length: count }, (_, index) => ({
+      id: idPrefix ? `${idPrefix}-${index}` : String(index + 1),
+      name: `Song ${index + 1}`,
+      artists: ['Artist'],
+      albumImages: [{ url: `http://example.com/m-${index + 1}.jpg`, width: 300 }],
+      spotifyURL: `http://spotify.com/track${index + 1}`
+    }))
 
   const mockTracks = [
     {
@@ -102,5 +111,71 @@ describe('TopTracks Component', () => {
       isVisible: true,
       provider: 'spotify'
     })
+  })
+
+  it('splits more than 12 tracks into carousel pages and shows pagination', () => {
+    const manyTracks = buildTracks(13)
+
+    const { getByLabelText, getByTestId } = render(
+      <TestProviderWithState>
+        <TopTracks isLoading={false} tracks={manyTracks} />
+      </TestProviderWithState>
+    )
+
+    expect(getByTestId('spotify-top-tracks-carousel')).toBeInTheDocument()
+    expect(getByTestId('spotify-top-tracks-page-1')).toBeInTheDocument()
+    expect(getByTestId('spotify-top-tracks-page-2')).toBeInTheDocument()
+    expect(getByLabelText('Next page')).toBeInTheDocument()
+
+    const itemsLengths = MediaItemGrid.mock.calls.map(([props]) => props.items?.length ?? 0)
+    expect(itemsLengths.filter(length => length === 12)).toHaveLength(1)
+    expect(itemsLengths.filter(length => length === 1)).toHaveLength(1)
+  })
+
+  it('clamps the current page when the track list shrinks to fewer pages', async () => {
+    const thirteenTracks = buildTracks(13)
+    const twelveTracks = thirteenTracks.slice(0, 12)
+
+    const { getByLabelText, getByTestId, queryByLabelText, queryByTestId, rerender } = render(
+      <TestProviderWithState>
+        <TopTracks isLoading={false} tracks={thirteenTracks} />
+      </TestProviderWithState>
+    )
+
+    fireEvent.click(getByLabelText('Go to page 2'))
+
+    rerender(
+      <TestProviderWithState>
+        <TopTracks isLoading={false} tracks={twelveTracks} />
+      </TestProviderWithState>
+    )
+
+    await waitFor(() => {
+      expect(queryByLabelText('Next page')).not.toBeInTheDocument()
+    })
+
+    expect(getByTestId('spotify-top-tracks-page-1')).toHaveAttribute('aria-hidden', 'false')
+    expect(queryByTestId('spotify-top-tracks-page-2')).not.toBeInTheDocument()
+  })
+
+  it('resets to page 1 when track identities change', () => {
+    const tracksV1 = buildTracks(13, 'a')
+    const tracksV2 = buildTracks(13, 'b')
+
+    const { getByLabelText, rerender } = render(
+      <TestProviderWithState>
+        <TopTracks isLoading={false} tracks={tracksV1} />
+      </TestProviderWithState>
+    )
+
+    fireEvent.click(getByLabelText('Go to page 2'))
+
+    rerender(
+      <TestProviderWithState>
+        <TopTracks isLoading={false} tracks={tracksV2} />
+      </TestProviderWithState>
+    )
+
+    expect(getByLabelText('Go to page 1')).toHaveAttribute('aria-current', 'page')
   })
 })

--- a/www.chrisvogt.me/package.json
+++ b/www.chrisvogt.me/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "www.chrisvogt.me",
-  "version": "1.21.1",
+  "version": "1.22.0",
   "license": "GPL",
   "scripts": {
     "build": "gatsby build",

--- a/www.chronogrove.com/package.json
+++ b/www.chronogrove.com/package.json
@@ -1,6 +1,6 @@
 {
   "name": "www.chronogrove.com",
-  "version": "1.8.1",
+  "version": "1.9.0",
   "description": "Official demo site for gatsby-theme-chronogrove",
   "scripts": {
     "develop": "gatsby develop",


### PR DESCRIPTION
## Summary

Paginates Spotify **Top Tracks** when the metrics API returns more than **12** tracks (e.g. **24**): **12 tiles per slide**, swipe/drag carousel (`useSwipePagination`), and shared **`Pagination`** controls. **`MediaItemGrid`** supports **`interactionDisabled`** so drag gestures do not trigger the audio player.

Also raises theme Jest **coverage thresholds** to **98%** statements / lines / functions (branches remain **90%**), updates **`CHANGELOG.md`**, and bumps consumer package versions.

## Release / versioning

| Package | Version |
|---------|---------|
| `gatsby-theme-chronogrove` | **0.91.0** |
| `www.chrisvogt.me` | **1.22.0** |
| `www.chronogrove.com` | **1.9.0** |

## Screenshots

### Top Tracks — overview

| Before | After |
|--------|-------|
|  <img width="1729" height="1089" alt="Screenshot 2026-05-12 at 12 21 15 AM" src="https://github.com/user-attachments/assets/1caecf35-0c30-4182-adf5-2abc51a71a52" /> | <img width="1729" height="1089" alt="Screenshot 2026-05-12 at 12 21 10 AM" src="https://github.com/user-attachments/assets/6a17bb96-e13c-477a-a7a1-6d9fe6e87fac" /> |



