### PR TITLE
chore(theme): Sonar cleanups across widgets, parser, and templates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Run tests and collect coverage
-        run: pnpm exec turbo run test:coverage -- --maxWorkers=2
+        run: pnpm exec turbo run test:coverage --concurrency=1 -- --maxWorkers=2
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,47 @@
 # Changelog
 
+## 0.91.2
+
+### `gatsby-theme-chronogrove` — Sonar/widget refactors, safer HTML, Theme UI aliases, `prop-types`
+
+- **`safeHtmlParser.js`**: **`Element`** imported as **`DomElement`** so it is not mistaken for **`React.Element`**; allowlist as **`Set`**; stable **`nextKey`** instead of **`Math.random()`** for parsed nodes; **`renderAnchor`** / **`renderSemanticTag`** helpers; explicit **`undefined`** when a node is not handled in **`replace`**.
+- **`home.js`** / **`media.js`**: Outer layout uses **`Box`** where **`sx`** was applied to a raw **`div`**; hidden **`h-card`** **`u-url`** includes visually clipped canonical text; keyword microformat keys use **`keyword`**; **`MediaTemplate.propTypes`** for **`children`** / **`data`**.
+- **Dependencies**: **`prop-types`** added for **`MediaTemplate`** via **`catalog:`** ( **`pnpm-workspace.yaml`** ) so workspace packages share one pinned version.
+- **`gatsby-node.js`**: **`getThemeUiSingleInstanceAliases`** aliases **`@emotion/react`**, Theme UI packages (**`@theme-ui/*`**, **`gatsby-plugin-theme-ui`**, etc.) to the same install as **`theme-ui`** to avoid **`[useColorMode] requires the ColorModeProvider`** when pnpm resolves duplicates.
+- **Widgets & shortcodes**: Goodreads, Instagram, Recent Posts, Spotify, Steam, GitHub, Flickr — readability and Sonar-oriented fixes with updated specs/snapshots; **`soundcloud`** / **`spotify`** shortcodes and **`spotify`** snapshot tweaks.
+- **Tests**: **`gatsby-node.spec.js`** and widget snapshots aligned with the above.
+- **Version**: **0.91.2**
+
+### `www.chrisvogt.me`
+
+- **Version**: **1.22.2** (tracks theme **0.91.2**).
+
+### `www.chronogrove.com` (demo)
+
+- **Version**: **1.9.2** (tracks theme **0.91.2**).
+
+### Files changed
+
+- `CHANGELOG.md`
+- `pnpm-lock.yaml`
+- `pnpm-workspace.yaml` (**`catalog.prop-types`**)
+- `theme/package.json` (version **0.91.2**, **`prop-types`**: **`catalog:`**)
+- `theme/gatsby-node.js`, **`gatsby-node.spec.js`**
+- `theme/src/helpers/safeHtmlParser.js`
+- `theme/src/templates/home.js`, **`media.js`**, **`__snapshots__/media.spec.js.snap`**
+- `theme/src/shortcodes/soundcloud.js`, **`spotify.js`**, **`__snapshots__/spotify.spec.js.snap`**
+- `theme/src/components/widgets/flickr/` — **`flickr-widget.js`**, **`flickr-widget-item.js`**, snapshots
+- `theme/src/components/widgets/github/` — **`github-widget.js`**, **`contribution-graph.js`**, **`pinned-item-card.js`**, **`pinned-items.js`**, **`renderers/`**, snapshots
+- `theme/src/components/widgets/goodreads/` — **`book-explorer.js`**, **`book-link.js`**, **`goodreads-widget.js`**, **`recently-read-books.js`**, **`user-profile.js`**, **`user-status.js`**, specs and **`goodreads-widget`** snapshot
+- `theme/src/components/widgets/instagram/` — **`instagram-widget.js`**, **`instagram-widget-item.js`**, snapshots
+- `theme/src/components/widgets/recent-posts/` — **`post-card.js`**, **`recent-posts-widget.js`**, **`post-card`** snapshots
+- `theme/src/components/widgets/spotify/` — **`media-item-grid.js`**, **`playlists.js`**, **`spotify-widget.js`**, **`top-tracks.js`**, **`track-preview.js`**, specs/snapshots
+- `theme/src/components/widgets/steam/` — **`play-time-chart.js`**, **`steam-game-card.js`**, **`steam-widget.js`**, snapshots
+- `www.chrisvogt.me/package.json` (version **1.22.2**)
+- `www.chronogrove.com/package.json` (version **1.9.2**)
+
+---
+
 ## 0.91.1
 
 ### `@chronogrove/ui` — Accessibility polish and Sonar-driven refactors (patch)

--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
     "postinstall": "node ./scripts/postinstall-banner.mjs",
     "prepare": "husky",
     "prettier": "prettier --check .",
-    "test": "turbo run test",
-    "test:coverage": "turbo run test:coverage",
+    "test": "turbo run test --concurrency=1",
+    "test:coverage": "turbo run test:coverage --concurrency=1",
     "test:watch": "pnpm --filter gatsby-theme-chronogrove test:watch",
     "build": "turbo run build"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,6 +57,9 @@ catalogs:
     prettier:
       specifier: ^3.8.3
       version: 3.8.3
+    prop-types:
+      specifier: ^15.8.1
+      version: 15.8.1
     react:
       specifier: ^19.2.6
       version: 19.2.6
@@ -165,7 +168,7 @@ importers:
         version: 7.2.0
       '@theme-ui/components':
         specifier: 'catalog:'
-        version: 0.17.4(@emotion/react@11.14.0(react@19.2.6))(@theme-ui/theme-provider@0.17.4(@emotion/react@11.14.0(react@19.2.6))(react@19.2.6))(react@19.2.6)
+        version: 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@theme-ui/theme-provider@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react@19.2.6)
       next:
         specifier: 'catalog:'
         version: 16.2.6(@babel/core@7.29.0)(babel-plugin-macros@3.1.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -180,7 +183,7 @@ importers:
         version: 4.1.0(react@19.2.6)
       theme-ui:
         specifier: 'catalog:'
-        version: 0.17.4(@emotion/react@11.14.0(react@19.2.6))(react@19.2.6)
+        version: 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
 
   packages/ui:
     dependencies:
@@ -201,7 +204,7 @@ importers:
         version: 4.1.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@theme-ui/components':
         specifier: 'catalog:'
-        version: 0.17.4(@emotion/react@11.14.0(react@19.2.6))(@theme-ui/theme-provider@0.17.4(@emotion/react@11.14.0(react@19.2.6))(react@19.2.6))(react@19.2.6)
+        version: 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@theme-ui/theme-provider@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react@19.2.6)
       '@theme-ui/presets':
         specifier: 'catalog:'
         version: 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6)))
@@ -210,7 +213,7 @@ importers:
         version: 10.0.3(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       theme-ui:
         specifier: 'catalog:'
-        version: 0.17.4(@emotion/react@11.14.0(react@19.2.6))(react@19.2.6)
+        version: 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
       three:
         specifier: 'catalog:'
         version: 0.184.0
@@ -307,10 +310,10 @@ importers:
         version: 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))
       '@theme-ui/components':
         specifier: 'catalog:'
-        version: 0.17.4(@emotion/react@11.14.0(react@19.2.6))(@theme-ui/theme-provider@0.17.4(@emotion/react@11.14.0(react@19.2.6))(react@19.2.6))(react@19.2.6)
+        version: 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@theme-ui/theme-provider@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react@19.2.6)
       '@theme-ui/css':
         specifier: 'catalog:'
-        version: 0.17.4(@emotion/react@11.14.0(react@19.2.6))
+        version: 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))
       '@theme-ui/mdx':
         specifier: 'catalog:'
         version: 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/mdx@2.0.13)(react@19.2.6)
@@ -396,7 +399,7 @@ importers:
         specifier: ^1.30.0
         version: 1.30.0
       prop-types:
-        specifier: ^15.8.1
+        specifier: 'catalog:'
         version: 15.8.1
       react:
         specifier: 'catalog:'
@@ -421,7 +424,7 @@ importers:
         version: 3.1.1
       theme-ui:
         specifier: 'catalog:'
-        version: 0.17.4(@emotion/react@11.14.0(react@19.2.6))(react@19.2.6)
+        version: 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
       three:
         specifier: 'catalog:'
         version: 0.184.0
@@ -476,7 +479,7 @@ importers:
         version: 3.1.1(@types/react@19.2.14)(react@19.2.6)
       '@theme-ui/components':
         specifier: 'catalog:'
-        version: 0.17.4(@emotion/react@11.14.0(react@19.2.6))(@theme-ui/theme-provider@0.17.4(@emotion/react@11.14.0(react@19.2.6))(react@19.2.6))(react@19.2.6)
+        version: 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@theme-ui/theme-provider@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react@19.2.6)
       '@theme-ui/mdx':
         specifier: 'catalog:'
         version: 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/mdx@2.0.13)(react@19.2.6)
@@ -521,7 +524,7 @@ importers:
         version: 8.0.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       theme-ui:
         specifier: 'catalog:'
-        version: 0.17.4(@emotion/react@11.14.0(react@19.2.6))(react@19.2.6)
+        version: 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
 
   www.chronogrove.com:
     dependencies:
@@ -533,7 +536,7 @@ importers:
         version: 3.1.1(@types/react@19.2.14)(react@19.2.6)
       '@theme-ui/components':
         specifier: 'catalog:'
-        version: 0.17.4(@emotion/react@11.14.0(react@19.2.6))(@theme-ui/theme-provider@0.17.4(@emotion/react@11.14.0(react@19.2.6))(react@19.2.6))(react@19.2.6)
+        version: 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@theme-ui/theme-provider@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react@19.2.6)
       '@theme-ui/mdx':
         specifier: 'catalog:'
         version: 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/mdx@2.0.13)(react@19.2.6)
@@ -551,7 +554,7 @@ importers:
         version: 19.2.6(react@19.2.6)
       theme-ui:
         specifier: 'catalog:'
-        version: 0.17.4(@emotion/react@11.14.0(react@19.2.6))(react@19.2.6)
+        version: 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
 
 packages:
 
@@ -11971,122 +11974,122 @@ snapshots:
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
 
-  '@theme-ui/color-modes@0.17.4(@emotion/react@11.14.0(react@19.2.6))(react@19.2.6)':
+  '@theme-ui/color-modes@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.6)
-      '@theme-ui/core': 0.17.4(@emotion/react@11.14.0(react@19.2.6))(react@19.2.6)
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
+      '@theme-ui/core': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))
       deepmerge: 4.3.1
       react: 19.2.6
 
   '@theme-ui/color@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))':
     dependencies:
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))
       polished: 4.3.1
     transitivePeerDependencies:
       - '@emotion/react'
 
-  '@theme-ui/components@0.17.4(@emotion/react@11.14.0(react@19.2.6))(@theme-ui/theme-provider@0.17.4(@emotion/react@11.14.0(react@19.2.6))(react@19.2.6))(react@19.2.6)':
+  '@theme-ui/components@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@theme-ui/theme-provider@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.6)
       '@styled-system/color': 5.1.2
       '@styled-system/should-forward-prop': 5.1.5
       '@styled-system/space': 5.1.2
-      '@theme-ui/core': 0.17.4(@emotion/react@11.14.0(react@19.2.6))(react@19.2.6)
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
-      '@theme-ui/theme-provider': 0.17.4(@emotion/react@11.14.0(react@19.2.6))(react@19.2.6)
+      '@theme-ui/core': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))
+      '@theme-ui/theme-provider': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
       '@types/styled-system': 5.1.25
       react: 19.2.6
 
-  '@theme-ui/core@0.17.4(@emotion/react@11.14.0(react@19.2.6))(react@19.2.6)':
+  '@theme-ui/core@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.6)
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))
       deepmerge: 4.3.1
       react: 19.2.6
 
-  '@theme-ui/css@0.17.4(@emotion/react@11.14.0(react@19.2.6))':
+  '@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))':
     dependencies:
       '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.6)
       csstype: 3.2.3
 
-  '@theme-ui/global@0.17.4(@emotion/react@11.14.0(react@19.2.6))(react@19.2.6)':
+  '@theme-ui/global@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.6)
-      '@theme-ui/core': 0.17.4(@emotion/react@11.14.0(react@19.2.6))(react@19.2.6)
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
+      '@theme-ui/core': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))
       react: 19.2.6
 
   '@theme-ui/mdx@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/mdx@2.0.13)(react@19.2.6)':
     dependencies:
       '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.6)
-      '@theme-ui/core': 0.17.4(@emotion/react@11.14.0(react@19.2.6))(react@19.2.6)
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
+      '@theme-ui/core': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))
       '@types/mdx': 2.0.13
       react: 19.2.6
 
   '@theme-ui/preset-base@0.17.4(@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6)))':
     dependencies:
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))
 
   '@theme-ui/preset-bootstrap@0.17.4(@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6)))':
     dependencies:
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))
 
   '@theme-ui/preset-bulma@0.17.4(@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6)))':
     dependencies:
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))
       '@theme-ui/preset-base': 0.17.4(@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6)))
 
   '@theme-ui/preset-dark@0.17.4(@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6)))':
     dependencies:
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))
 
   '@theme-ui/preset-deep@0.17.4(@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6)))':
     dependencies:
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))
 
   '@theme-ui/preset-funk@0.17.4(@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6)))':
     dependencies:
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))
       '@theme-ui/preset-base': 0.17.4(@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6)))
 
   '@theme-ui/preset-future@0.17.4(@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6)))':
     dependencies:
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))
       '@theme-ui/preset-base': 0.17.4(@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6)))
 
   '@theme-ui/preset-polaris@0.17.4(@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6)))':
     dependencies:
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))
       '@theme-ui/preset-base': 0.17.4(@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6)))
 
   '@theme-ui/preset-roboto@0.17.4(@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6)))':
     dependencies:
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))
       '@theme-ui/preset-base': 0.17.4(@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6)))
 
   '@theme-ui/preset-sketchy@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))':
     dependencies:
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))
     transitivePeerDependencies:
       - '@emotion/react'
 
   '@theme-ui/preset-swiss@0.17.4(@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6)))':
     dependencies:
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))
 
   '@theme-ui/preset-system@0.17.4(@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6)))':
     dependencies:
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))
 
   '@theme-ui/preset-tailwind@0.17.4(@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6)))':
     dependencies:
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))
 
   '@theme-ui/preset-tosh@0.17.4(@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6)))':
     dependencies:
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))
 
   '@theme-ui/presets@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6)))':
     dependencies:
@@ -12110,10 +12113,10 @@ snapshots:
 
   '@theme-ui/prism@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@theme-ui/mdx@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/mdx@2.0.13)(react@19.2.6))(react@19.2.6)(theme-ui@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))':
     dependencies:
-      '@theme-ui/core': 0.17.4(@emotion/react@11.14.0(react@19.2.6))(react@19.2.6)
+      '@theme-ui/core': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
       '@theme-ui/mdx': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/mdx@2.0.13)(react@19.2.6)
       prism-react-renderer: 1.3.5(react@19.2.6)
-      theme-ui: 0.17.4(@emotion/react@11.14.0(react@19.2.6))(react@19.2.6)
+      theme-ui: 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
     transitivePeerDependencies:
       - '@emotion/react'
       - react
@@ -12121,23 +12124,23 @@ snapshots:
   '@theme-ui/style-guide@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6)))(react@19.2.6)(theme-ui@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))':
     dependencies:
       '@theme-ui/color': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))
-      '@theme-ui/core': 0.17.4(@emotion/react@11.14.0(react@19.2.6))(react@19.2.6)
+      '@theme-ui/core': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
       '@theme-ui/presets': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6)))
       '@types/color': 3.0.7
       color: 3.2.1
       lodash.get: 4.4.2
       react: 19.2.6
-      theme-ui: 0.17.4(@emotion/react@11.14.0(react@19.2.6))(react@19.2.6)
+      theme-ui: 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
     transitivePeerDependencies:
       - '@emotion/react'
       - '@theme-ui/css'
 
-  '@theme-ui/theme-provider@0.17.4(@emotion/react@11.14.0(react@19.2.6))(react@19.2.6)':
+  '@theme-ui/theme-provider@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.6)
-      '@theme-ui/color-modes': 0.17.4(@emotion/react@11.14.0(react@19.2.6))(react@19.2.6)
-      '@theme-ui/core': 0.17.4(@emotion/react@11.14.0(react@19.2.6))(react@19.2.6)
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
+      '@theme-ui/color-modes': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
+      '@theme-ui/core': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))
       react: 19.2.6
 
   '@tokenizer/token@0.3.0': {}
@@ -15537,11 +15540,11 @@ snapshots:
     dependencies:
       '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.6)
       '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@19.2.6)
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))
       '@theme-ui/mdx': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/mdx@2.0.13)(react@19.2.6)
       gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)
       react: 19.2.6
-      theme-ui: 0.17.4(@emotion/react@11.14.0(react@19.2.6))(react@19.2.6)
+      theme-ui: 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
 
   gatsby-plugin-typescript@5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@10.3.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)):
     dependencies:
@@ -15701,7 +15704,7 @@ snapshots:
       gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
-      theme-ui: 0.17.4(@emotion/react@11.14.0(react@19.2.6))(react@19.2.6)
+      theme-ui: 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
     transitivePeerDependencies:
       - '@emotion/react'
       - '@theme-ui/css'
@@ -20699,15 +20702,15 @@ snapshots:
 
   text-table@0.2.0: {}
 
-  theme-ui@0.17.4(@emotion/react@11.14.0(react@19.2.6))(react@19.2.6):
+  theme-ui@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6):
     dependencies:
       '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.6)
-      '@theme-ui/color-modes': 0.17.4(@emotion/react@11.14.0(react@19.2.6))(react@19.2.6)
-      '@theme-ui/components': 0.17.4(@emotion/react@11.14.0(react@19.2.6))(@theme-ui/theme-provider@0.17.4(@emotion/react@11.14.0(react@19.2.6))(react@19.2.6))(react@19.2.6)
-      '@theme-ui/core': 0.17.4(@emotion/react@11.14.0(react@19.2.6))(react@19.2.6)
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
-      '@theme-ui/global': 0.17.4(@emotion/react@11.14.0(react@19.2.6))(react@19.2.6)
-      '@theme-ui/theme-provider': 0.17.4(@emotion/react@11.14.0(react@19.2.6))(react@19.2.6)
+      '@theme-ui/color-modes': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
+      '@theme-ui/components': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@theme-ui/theme-provider@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react@19.2.6)
+      '@theme-ui/core': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))
+      '@theme-ui/global': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
+      '@theme-ui/theme-provider': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
       react: 19.2.6
 
   three@0.184.0: {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -165,7 +165,7 @@ importers:
         version: 7.2.0
       '@theme-ui/components':
         specifier: 'catalog:'
-        version: 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@theme-ui/theme-provider@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react@19.2.6)
+        version: 0.17.4(@emotion/react@11.14.0(react@19.2.6))(@theme-ui/theme-provider@0.17.4(@emotion/react@11.14.0(react@19.2.6))(react@19.2.6))(react@19.2.6)
       next:
         specifier: 'catalog:'
         version: 16.2.6(@babel/core@7.29.0)(babel-plugin-macros@3.1.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -180,7 +180,7 @@ importers:
         version: 4.1.0(react@19.2.6)
       theme-ui:
         specifier: 'catalog:'
-        version: 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
+        version: 0.17.4(@emotion/react@11.14.0(react@19.2.6))(react@19.2.6)
 
   packages/ui:
     dependencies:
@@ -201,7 +201,7 @@ importers:
         version: 4.1.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@theme-ui/components':
         specifier: 'catalog:'
-        version: 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@theme-ui/theme-provider@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react@19.2.6)
+        version: 0.17.4(@emotion/react@11.14.0(react@19.2.6))(@theme-ui/theme-provider@0.17.4(@emotion/react@11.14.0(react@19.2.6))(react@19.2.6))(react@19.2.6)
       '@theme-ui/presets':
         specifier: 'catalog:'
         version: 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6)))
@@ -210,7 +210,7 @@ importers:
         version: 10.0.3(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       theme-ui:
         specifier: 'catalog:'
-        version: 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
+        version: 0.17.4(@emotion/react@11.14.0(react@19.2.6))(react@19.2.6)
       three:
         specifier: 'catalog:'
         version: 0.184.0
@@ -307,10 +307,10 @@ importers:
         version: 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))
       '@theme-ui/components':
         specifier: 'catalog:'
-        version: 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@theme-ui/theme-provider@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react@19.2.6)
+        version: 0.17.4(@emotion/react@11.14.0(react@19.2.6))(@theme-ui/theme-provider@0.17.4(@emotion/react@11.14.0(react@19.2.6))(react@19.2.6))(react@19.2.6)
       '@theme-ui/css':
         specifier: 'catalog:'
-        version: 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))
+        version: 0.17.4(@emotion/react@11.14.0(react@19.2.6))
       '@theme-ui/mdx':
         specifier: 'catalog:'
         version: 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/mdx@2.0.13)(react@19.2.6)
@@ -395,6 +395,9 @@ importers:
       prismjs:
         specifier: ^1.30.0
         version: 1.30.0
+      prop-types:
+        specifier: ^15.8.1
+        version: 15.8.1
       react:
         specifier: 'catalog:'
         version: 19.2.6
@@ -418,7 +421,7 @@ importers:
         version: 3.1.1
       theme-ui:
         specifier: 'catalog:'
-        version: 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
+        version: 0.17.4(@emotion/react@11.14.0(react@19.2.6))(react@19.2.6)
       three:
         specifier: 'catalog:'
         version: 0.184.0
@@ -473,7 +476,7 @@ importers:
         version: 3.1.1(@types/react@19.2.14)(react@19.2.6)
       '@theme-ui/components':
         specifier: 'catalog:'
-        version: 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@theme-ui/theme-provider@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react@19.2.6)
+        version: 0.17.4(@emotion/react@11.14.0(react@19.2.6))(@theme-ui/theme-provider@0.17.4(@emotion/react@11.14.0(react@19.2.6))(react@19.2.6))(react@19.2.6)
       '@theme-ui/mdx':
         specifier: 'catalog:'
         version: 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/mdx@2.0.13)(react@19.2.6)
@@ -518,7 +521,7 @@ importers:
         version: 8.0.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       theme-ui:
         specifier: 'catalog:'
-        version: 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
+        version: 0.17.4(@emotion/react@11.14.0(react@19.2.6))(react@19.2.6)
 
   www.chronogrove.com:
     dependencies:
@@ -530,7 +533,7 @@ importers:
         version: 3.1.1(@types/react@19.2.14)(react@19.2.6)
       '@theme-ui/components':
         specifier: 'catalog:'
-        version: 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@theme-ui/theme-provider@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react@19.2.6)
+        version: 0.17.4(@emotion/react@11.14.0(react@19.2.6))(@theme-ui/theme-provider@0.17.4(@emotion/react@11.14.0(react@19.2.6))(react@19.2.6))(react@19.2.6)
       '@theme-ui/mdx':
         specifier: 'catalog:'
         version: 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/mdx@2.0.13)(react@19.2.6)
@@ -548,7 +551,7 @@ importers:
         version: 19.2.6(react@19.2.6)
       theme-ui:
         specifier: 'catalog:'
-        version: 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
+        version: 0.17.4(@emotion/react@11.14.0(react@19.2.6))(react@19.2.6)
 
 packages:
 
@@ -11968,122 +11971,122 @@ snapshots:
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
 
-  '@theme-ui/color-modes@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)':
+  '@theme-ui/color-modes@0.17.4(@emotion/react@11.14.0(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.6)
-      '@theme-ui/core': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))
+      '@theme-ui/core': 0.17.4(@emotion/react@11.14.0(react@19.2.6))(react@19.2.6)
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
       deepmerge: 4.3.1
       react: 19.2.6
 
   '@theme-ui/color@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))':
     dependencies:
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
       polished: 4.3.1
     transitivePeerDependencies:
       - '@emotion/react'
 
-  '@theme-ui/components@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@theme-ui/theme-provider@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react@19.2.6)':
+  '@theme-ui/components@0.17.4(@emotion/react@11.14.0(react@19.2.6))(@theme-ui/theme-provider@0.17.4(@emotion/react@11.14.0(react@19.2.6))(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.6)
       '@styled-system/color': 5.1.2
       '@styled-system/should-forward-prop': 5.1.5
       '@styled-system/space': 5.1.2
-      '@theme-ui/core': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))
-      '@theme-ui/theme-provider': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
+      '@theme-ui/core': 0.17.4(@emotion/react@11.14.0(react@19.2.6))(react@19.2.6)
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
+      '@theme-ui/theme-provider': 0.17.4(@emotion/react@11.14.0(react@19.2.6))(react@19.2.6)
       '@types/styled-system': 5.1.25
       react: 19.2.6
 
-  '@theme-ui/core@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)':
+  '@theme-ui/core@0.17.4(@emotion/react@11.14.0(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.6)
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
       deepmerge: 4.3.1
       react: 19.2.6
 
-  '@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))':
+  '@theme-ui/css@0.17.4(@emotion/react@11.14.0(react@19.2.6))':
     dependencies:
       '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.6)
       csstype: 3.2.3
 
-  '@theme-ui/global@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)':
+  '@theme-ui/global@0.17.4(@emotion/react@11.14.0(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.6)
-      '@theme-ui/core': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))
+      '@theme-ui/core': 0.17.4(@emotion/react@11.14.0(react@19.2.6))(react@19.2.6)
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
       react: 19.2.6
 
   '@theme-ui/mdx@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/mdx@2.0.13)(react@19.2.6)':
     dependencies:
       '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.6)
-      '@theme-ui/core': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))
+      '@theme-ui/core': 0.17.4(@emotion/react@11.14.0(react@19.2.6))(react@19.2.6)
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
       '@types/mdx': 2.0.13
       react: 19.2.6
 
   '@theme-ui/preset-base@0.17.4(@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6)))':
     dependencies:
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
 
   '@theme-ui/preset-bootstrap@0.17.4(@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6)))':
     dependencies:
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
 
   '@theme-ui/preset-bulma@0.17.4(@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6)))':
     dependencies:
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
       '@theme-ui/preset-base': 0.17.4(@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6)))
 
   '@theme-ui/preset-dark@0.17.4(@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6)))':
     dependencies:
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
 
   '@theme-ui/preset-deep@0.17.4(@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6)))':
     dependencies:
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
 
   '@theme-ui/preset-funk@0.17.4(@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6)))':
     dependencies:
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
       '@theme-ui/preset-base': 0.17.4(@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6)))
 
   '@theme-ui/preset-future@0.17.4(@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6)))':
     dependencies:
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
       '@theme-ui/preset-base': 0.17.4(@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6)))
 
   '@theme-ui/preset-polaris@0.17.4(@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6)))':
     dependencies:
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
       '@theme-ui/preset-base': 0.17.4(@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6)))
 
   '@theme-ui/preset-roboto@0.17.4(@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6)))':
     dependencies:
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
       '@theme-ui/preset-base': 0.17.4(@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6)))
 
   '@theme-ui/preset-sketchy@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))':
     dependencies:
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
     transitivePeerDependencies:
       - '@emotion/react'
 
   '@theme-ui/preset-swiss@0.17.4(@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6)))':
     dependencies:
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
 
   '@theme-ui/preset-system@0.17.4(@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6)))':
     dependencies:
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
 
   '@theme-ui/preset-tailwind@0.17.4(@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6)))':
     dependencies:
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
 
   '@theme-ui/preset-tosh@0.17.4(@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6)))':
     dependencies:
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
 
   '@theme-ui/presets@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6)))':
     dependencies:
@@ -12107,10 +12110,10 @@ snapshots:
 
   '@theme-ui/prism@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@theme-ui/mdx@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/mdx@2.0.13)(react@19.2.6))(react@19.2.6)(theme-ui@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))':
     dependencies:
-      '@theme-ui/core': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
+      '@theme-ui/core': 0.17.4(@emotion/react@11.14.0(react@19.2.6))(react@19.2.6)
       '@theme-ui/mdx': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/mdx@2.0.13)(react@19.2.6)
       prism-react-renderer: 1.3.5(react@19.2.6)
-      theme-ui: 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
+      theme-ui: 0.17.4(@emotion/react@11.14.0(react@19.2.6))(react@19.2.6)
     transitivePeerDependencies:
       - '@emotion/react'
       - react
@@ -12118,23 +12121,23 @@ snapshots:
   '@theme-ui/style-guide@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6)))(react@19.2.6)(theme-ui@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))':
     dependencies:
       '@theme-ui/color': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))
-      '@theme-ui/core': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
+      '@theme-ui/core': 0.17.4(@emotion/react@11.14.0(react@19.2.6))(react@19.2.6)
       '@theme-ui/presets': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6)))
       '@types/color': 3.0.7
       color: 3.2.1
       lodash.get: 4.4.2
       react: 19.2.6
-      theme-ui: 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
+      theme-ui: 0.17.4(@emotion/react@11.14.0(react@19.2.6))(react@19.2.6)
     transitivePeerDependencies:
       - '@emotion/react'
       - '@theme-ui/css'
 
-  '@theme-ui/theme-provider@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)':
+  '@theme-ui/theme-provider@0.17.4(@emotion/react@11.14.0(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.6)
-      '@theme-ui/color-modes': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
-      '@theme-ui/core': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))
+      '@theme-ui/color-modes': 0.17.4(@emotion/react@11.14.0(react@19.2.6))(react@19.2.6)
+      '@theme-ui/core': 0.17.4(@emotion/react@11.14.0(react@19.2.6))(react@19.2.6)
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
       react: 19.2.6
 
   '@tokenizer/token@0.3.0': {}
@@ -15534,11 +15537,11 @@ snapshots:
     dependencies:
       '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.6)
       '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@19.2.6)
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
       '@theme-ui/mdx': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/mdx@2.0.13)(react@19.2.6)
       gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)
       react: 19.2.6
-      theme-ui: 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
+      theme-ui: 0.17.4(@emotion/react@11.14.0(react@19.2.6))(react@19.2.6)
 
   gatsby-plugin-typescript@5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@10.3.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)):
     dependencies:
@@ -15698,7 +15701,7 @@ snapshots:
       gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
-      theme-ui: 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
+      theme-ui: 0.17.4(@emotion/react@11.14.0(react@19.2.6))(react@19.2.6)
     transitivePeerDependencies:
       - '@emotion/react'
       - '@theme-ui/css'
@@ -20696,15 +20699,15 @@ snapshots:
 
   text-table@0.2.0: {}
 
-  theme-ui@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6):
+  theme-ui@0.17.4(@emotion/react@11.14.0(react@19.2.6))(react@19.2.6):
     dependencies:
       '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.6)
-      '@theme-ui/color-modes': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
-      '@theme-ui/components': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@theme-ui/theme-provider@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react@19.2.6)
-      '@theme-ui/core': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))
-      '@theme-ui/global': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
-      '@theme-ui/theme-provider': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
+      '@theme-ui/color-modes': 0.17.4(@emotion/react@11.14.0(react@19.2.6))(react@19.2.6)
+      '@theme-ui/components': 0.17.4(@emotion/react@11.14.0(react@19.2.6))(@theme-ui/theme-provider@0.17.4(@emotion/react@11.14.0(react@19.2.6))(react@19.2.6))(react@19.2.6)
+      '@theme-ui/core': 0.17.4(@emotion/react@11.14.0(react@19.2.6))(react@19.2.6)
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
+      '@theme-ui/global': 0.17.4(@emotion/react@11.14.0(react@19.2.6))(react@19.2.6)
+      '@theme-ui/theme-provider': 0.17.4(@emotion/react@11.14.0(react@19.2.6))(react@19.2.6)
       react: 19.2.6
 
   three@0.184.0: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -26,6 +26,7 @@ catalog:
   lightgallery: ^2.9.0
   next: ^16.2.6
   prettier: ^3.8.3
+  prop-types: ^15.8.1
   react: ^19.2.6
   react-dom: ^19.2.6
   react-intersection-observer: ^10.0.3

--- a/theme/gatsby-node.js
+++ b/theme/gatsby-node.js
@@ -5,14 +5,28 @@ const startCase = require('lodash/startCase')
  * pnpm can install multiple physical copies of Theme UI (different peer-dependency graphs). React
  * context from `ColorModeProvider` in one `@theme-ui/color-modes` instance is then invisible to
  * `useColorMode` loaded from another — runtime error:
- * "[useColorMode] requires the ColorModeProvider component". Force webpack to resolve `theme-ui`
- * and the core Theme UI packages from the same tree as `ChronogroveThemeProvider` (see
- * `wrapRootElement.js`).
+ * "[useColorMode] requires the ColorModeProvider component". Force webpack to resolve `theme-ui`,
+ * `@emotion/react`, and every Theme UI package the app imports from the same tree as
+ * `ChronogroveThemeProvider` (see `wrapRootElement.js`).
  */
 function getThemeUiSingleInstanceAliases() {
   const themeUiPkgDir = path.dirname(require.resolve('theme-ui/package.json', { paths: [__dirname] }))
   const searchPaths = [themeUiPkgDir]
-  const pkgs = ['theme-ui', '@theme-ui/color-modes', '@theme-ui/core', '@theme-ui/theme-provider']
+  const pkgs = [
+    '@emotion/react',
+    'theme-ui',
+    '@theme-ui/color',
+    '@theme-ui/color-modes',
+    '@theme-ui/components',
+    '@theme-ui/core',
+    '@theme-ui/css',
+    '@theme-ui/mdx',
+    '@theme-ui/presets',
+    '@theme-ui/prism',
+    '@theme-ui/style-guide',
+    '@theme-ui/theme-provider',
+    'gatsby-plugin-theme-ui'
+  ]
   return pkgs.reduce((alias, pkg) => {
     alias[pkg] = path.dirname(require.resolve(`${pkg}/package.json`, { paths: searchPaths }))
     return alias

--- a/theme/gatsby-node.spec.js
+++ b/theme/gatsby-node.spec.js
@@ -62,6 +62,67 @@ const mockGetNode = jest.fn()
 // Import the functions to test
 const gatsbyNode = require('./gatsby-node')
 
+class ESLintWebpackPlugin {
+  constructor() {}
+}
+
+describe('onCreateWebpackConfig', () => {
+  const replaceWebpackConfig = jest.fn()
+
+  beforeEach(() => {
+    replaceWebpackConfig.mockClear()
+  })
+
+  it('merges Theme UI aliases into object resolve.alias and strips ESLintWebpackPlugin', () => {
+    const otherPlugin = { constructor: { name: 'OtherPlugin' } }
+    const config = {
+      plugins: [otherPlugin, new ESLintWebpackPlugin()],
+      resolve: {
+        alias: { 'existing-alias': '/abs/existing' }
+      }
+    }
+    const getConfig = jest.fn(() => config)
+
+    gatsbyNode.onCreateWebpackConfig({ actions: { replaceWebpackConfig }, getConfig })
+
+    expect(config.plugins).toEqual([otherPlugin])
+    expect(replaceWebpackConfig).toHaveBeenCalledTimes(1)
+    const out = replaceWebpackConfig.mock.calls[0][0]
+    expect(out.resolve.alias['existing-alias']).toBe('/abs/existing')
+    expect(out.resolve.alias['theme-ui']).toMatch(/[/\\]theme-ui$/)
+    expect(out.resolve.alias['@theme-ui/color-modes']).toMatch(/[/\\]color-modes$/)
+    expect(out.resolve.alias['@emotion/react']).toMatch(/[/\\]react$/)
+    expect(out.resolve.alias['gatsby-plugin-theme-ui']).toMatch(/[/\\]gatsby-plugin-theme-ui$/)
+  })
+
+  it('appends Theme UI aliases when resolve.alias is a webpack array', () => {
+    const aliasArr = [{ name: 'x', alias: '/x' }]
+    const config = {
+      plugins: [],
+      resolve: { alias: aliasArr }
+    }
+    const getConfig = jest.fn(() => config)
+
+    gatsbyNode.onCreateWebpackConfig({ actions: { replaceWebpackConfig }, getConfig })
+
+    const out = replaceWebpackConfig.mock.calls[0][0]
+    expect(out.resolve.alias).toBe(aliasArr)
+    const themeUiEntry = aliasArr.find(a => a.name === 'theme-ui')
+    expect(themeUiEntry.alias).toMatch(/theme-ui$/)
+    expect(aliasArr.some(a => a.name === '@theme-ui/mdx')).toBe(true)
+  })
+
+  it('initializes resolve and object alias when missing', () => {
+    const config = { plugins: [] }
+    const getConfig = jest.fn(() => config)
+
+    gatsbyNode.onCreateWebpackConfig({ actions: { replaceWebpackConfig }, getConfig })
+
+    const out = replaceWebpackConfig.mock.calls[0][0]
+    expect(out.resolve.alias['theme-ui']).toBeDefined()
+  })
+})
+
 describe('gatsby-node', () => {
   beforeEach(() => {
     jest.clearAllMocks()

--- a/theme/jest.config.js
+++ b/theme/jest.config.js
@@ -7,6 +7,10 @@
 const themeUiEntry = require.resolve('theme-ui')
 
 module.exports = {
+  // Recycle jest-worker processes before idle RAM grows large — reduces intermittent SIGSEGV when
+  // multiple workers run alongside Turbo’s other packages (see root `pnpm test --concurrency=1`).
+  workerIdleMemoryLimit: '512MB',
+
   // Automatically clear mock calls and instances between every test
   clearMocks: true,
 

--- a/theme/package.json
+++ b/theme/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-theme-chronogrove",
   "description": "A personal website and digital garden theme for GatsbyJS.",
-  "version": "0.91.1",
+  "version": "0.91.2",
   "author": "Chris Vogt <mail@chrisvogt.me> (https://www.chrisvogt.me)",
   "main": "index.js",
   "license": "MIT",
@@ -103,7 +103,7 @@
     "lottie-react-web": "github:chrisvogt/lottie-react-web#codex/modernize-tooling-and-ci",
     "prettier": "catalog:",
     "prismjs": "^1.30.0",
-    "prop-types": "^15.8.1",
+    "prop-types": "catalog:",
     "react": "catalog:",
     "react-dom": "catalog:",
     "react-error-boundary": "^6.1.1",

--- a/theme/package.json
+++ b/theme/package.json
@@ -103,6 +103,7 @@
     "lottie-react-web": "github:chrisvogt/lottie-react-web#codex/modernize-tooling-and-ci",
     "prettier": "catalog:",
     "prismjs": "^1.30.0",
+    "prop-types": "^15.8.1",
     "react": "catalog:",
     "react-dom": "catalog:",
     "react-error-boundary": "^6.1.1",

--- a/theme/src/components/widgets/flickr/__snapshots__/flickr-widget-item.spec.js.snap
+++ b/theme/src/components/widgets/flickr/__snapshots__/flickr-widget-item.spec.js.snap
@@ -3,11 +3,12 @@
 exports[`FlickrWidgetItem matches the snapshot 1`] = `
 <DocumentFragment>
   <button
-    class="flickr-item-button css-1u8qly9"
+    class="flickr-item-button css-lwcnm9"
+    type="button"
   >
     <img
       alt="Flickr photo: Test Photo Title"
-      class="flickr-item-image css-16gz8ax"
+      class="flickr-item-image css-u88sdg"
       crossorigin="anonymous"
       height="280"
       loading="lazy"

--- a/theme/src/components/widgets/flickr/flickr-widget-item.js
+++ b/theme/src/components/widgets/flickr/flickr-widget-item.js
@@ -1,18 +1,22 @@
 /** @jsx jsx */
 import { jsx } from 'theme-ui'
+import { Box } from '@theme-ui/components'
 
 const FlickrWidgetItem = ({ photo = {}, handleClick = () => {}, index }) => {
   const { title = '', thumbnailUrl = '' } = photo || {}
 
   return (
-    <button
+    <Box
+      as='button'
+      type='button'
       onClick={() => handleClick(index)}
       className='flickr-item-button'
       sx={{
         variant: 'styles.InstagramItem'
       }}
     >
-      <img
+      <Box
+        as='img'
         crossOrigin='anonymous'
         className='flickr-item-image'
         loading='lazy'
@@ -27,7 +31,7 @@ const FlickrWidgetItem = ({ photo = {}, handleClick = () => {}, index }) => {
           objectFit: 'cover'
         }}
       />
-    </button>
+    </Box>
   )
 }
 

--- a/theme/src/components/widgets/flickr/flickr-widget.js
+++ b/theme/src/components/widgets/flickr/flickr-widget.js
@@ -1,7 +1,7 @@
 /** @jsx jsx */
 import { jsx, useThemeUI } from 'theme-ui'
 
-import { Grid } from '@theme-ui/components'
+import { Box, Grid } from '@theme-ui/components'
 import { RectShape } from 'react-placeholder/lib/placeholders'
 import { useState, useEffect, useCallback, useRef } from 'react'
 import isDarkMode from '../../../helpers/isDarkMode'
@@ -82,8 +82,7 @@ export default () => {
       url={`https://www.flickr.com/photos/${flickrUsername}`}
       isLoading={isLoading}
     >
-      Visit Profile
-      <span className='read-more-icon'>&rarr;</span>
+      Visit Profile <span className='read-more-icon'>&rarr;</span>
     </CallToAction>
   )
 
@@ -131,8 +130,8 @@ export default () => {
 
       {/* Reserve space for Show More when loading; show button when loaded */}
       {isLoading ? (
-        <div sx={{ my: 4, textAlign: 'center' }} aria-hidden>
-          <div
+        <Box sx={{ my: 4, textAlign: 'center' }} aria-hidden>
+          <Box
             sx={{
               display: 'inline-block',
               height: '44px',
@@ -142,13 +141,13 @@ export default () => {
               opacity: 0.5
             }}
           />
-        </div>
+        </Box>
       ) : (
-        <div sx={{ my: 4, textAlign: 'center' }}>
+        <Box sx={{ my: 4, textAlign: 'center' }}>
           <ActionButton size='large' onClick={() => setIsShowingMore(!isShowingMore)}>
             {isShowingMore ? 'Show Less' : 'Show More'}
           </ActionButton>
-        </div>
+        </Box>
       )}
 
       {photos?.length && (

--- a/theme/src/components/widgets/github/__snapshots__/github-widget.spec.js.snap
+++ b/theme/src/components/widgets/github/__snapshots__/github-widget.spec.js.snap
@@ -62,7 +62,7 @@ exports[`GitHub Widget matches the error state snapshot 1`] = `
             href="https://www.github.com/mockusername"
             title="mockusername on GitHub"
           >
-            Visit Profile
+            Visit Profile 
             <span
               class="read-more-icon"
             >
@@ -86,7 +86,7 @@ exports[`GitHub Widget matches the error state snapshot 1`] = `
         Pinned items on my GitHub profile.
       </p>
       <div
-        class="css-r2v68e"
+        class="css-1eii8wb"
       >
         <a
           class="css-nf0qmy"
@@ -107,7 +107,7 @@ exports[`GitHub Widget matches the error state snapshot 1`] = `
                   />
                 </div>
                 <div
-                  class="css-fjakwv"
+                  class="css-1fsahx3"
                 >
                   <div
                     class="text-block"
@@ -163,7 +163,7 @@ exports[`GitHub Widget matches the error state snapshot 1`] = `
                   />
                 </div>
                 <div
-                  class="css-fjakwv"
+                  class="css-1fsahx3"
                 >
                   <div
                     class="text-block"
@@ -219,7 +219,7 @@ exports[`GitHub Widget matches the error state snapshot 1`] = `
                   />
                 </div>
                 <div
-                  class="css-fjakwv"
+                  class="css-1fsahx3"
                 >
                   <div
                     class="text-block"
@@ -275,7 +275,7 @@ exports[`GitHub Widget matches the error state snapshot 1`] = `
                   />
                 </div>
                 <div
-                  class="css-fjakwv"
+                  class="css-1fsahx3"
                 >
                   <div
                     class="text-block"
@@ -331,7 +331,7 @@ exports[`GitHub Widget matches the error state snapshot 1`] = `
                   />
                 </div>
                 <div
-                  class="css-fjakwv"
+                  class="css-1fsahx3"
                 >
                   <div
                     class="text-block"
@@ -387,7 +387,7 @@ exports[`GitHub Widget matches the error state snapshot 1`] = `
                   />
                 </div>
                 <div
-                  class="css-fjakwv"
+                  class="css-1fsahx3"
                 >
                   <div
                     class="text-block"
@@ -1635,7 +1635,7 @@ exports[`GitHub Widget matches the loaded state snapshot 1`] = `
             href="https://www.github.com/mockusername"
             title="mockusername on GitHub"
           >
-            Visit Profile
+            Visit Profile 
             <span
               class="read-more-icon"
             >
@@ -1691,7 +1691,7 @@ exports[`GitHub Widget matches the loaded state snapshot 1`] = `
         Pinned items on my GitHub profile.
       </p>
       <div
-        class="css-r2v68e"
+        class="css-1eii8wb"
       >
         <a
           class="css-nf0qmy"
@@ -1713,7 +1713,7 @@ exports[`GitHub Widget matches the loaded state snapshot 1`] = `
                   />
                 </div>
                 <div
-                  class="css-fjakwv"
+                  class="css-1fsahx3"
                 >
                   <div
                     class="text-block"
@@ -3026,7 +3026,7 @@ exports[`GitHub Widget matches the loading state snapshot 1`] = `
         Pinned items on my GitHub profile.
       </p>
       <div
-        class="css-r2v68e"
+        class="css-1eii8wb"
       >
         <a
           class="css-nf0qmy"
@@ -3047,7 +3047,7 @@ exports[`GitHub Widget matches the loading state snapshot 1`] = `
                   />
                 </div>
                 <div
-                  class="css-fjakwv"
+                  class="css-1fsahx3"
                 >
                   <div
                     class="text-block"
@@ -3103,7 +3103,7 @@ exports[`GitHub Widget matches the loading state snapshot 1`] = `
                   />
                 </div>
                 <div
-                  class="css-fjakwv"
+                  class="css-1fsahx3"
                 >
                   <div
                     class="text-block"
@@ -3159,7 +3159,7 @@ exports[`GitHub Widget matches the loading state snapshot 1`] = `
                   />
                 </div>
                 <div
-                  class="css-fjakwv"
+                  class="css-1fsahx3"
                 >
                   <div
                     class="text-block"
@@ -3215,7 +3215,7 @@ exports[`GitHub Widget matches the loading state snapshot 1`] = `
                   />
                 </div>
                 <div
-                  class="css-fjakwv"
+                  class="css-1fsahx3"
                 >
                   <div
                     class="text-block"
@@ -3271,7 +3271,7 @@ exports[`GitHub Widget matches the loading state snapshot 1`] = `
                   />
                 </div>
                 <div
-                  class="css-fjakwv"
+                  class="css-1fsahx3"
                 >
                   <div
                     class="text-block"
@@ -3327,7 +3327,7 @@ exports[`GitHub Widget matches the loading state snapshot 1`] = `
                   />
                 </div>
                 <div
-                  class="css-fjakwv"
+                  class="css-1fsahx3"
                 >
                   <div
                     class="text-block"

--- a/theme/src/components/widgets/github/__snapshots__/pinned-item-card.spec.js.snap
+++ b/theme/src/components/widgets/github/__snapshots__/pinned-item-card.spec.js.snap
@@ -18,7 +18,7 @@ exports[`Widget/GitHub/PinnedItemCard snapshots matches the placeholder snapshot
           />
         </div>
         <div
-          class="css-fjakwv"
+          class="css-1fsahx3"
         >
           <div
             class="text-block"
@@ -71,7 +71,7 @@ exports[`Widget/GitHub/PinnedItemCard snapshots matches the repository variant s
         themeuser/sample-repo
       </h4>
       <span
-        class="css-gulexy"
+        class="css-1e5uqy3"
       >
         A fake NodeJS project.
       </span>

--- a/theme/src/components/widgets/github/__snapshots__/pinned-items.spec.js.snap
+++ b/theme/src/components/widgets/github/__snapshots__/pinned-items.spec.js.snap
@@ -16,7 +16,7 @@ exports[`Widget/GitHub/PinnedItems snapshots matches the placeholder snapshot 1`
       Pinned items on my GitHub profile.
     </p>
     <div
-      class="css-uz5s83"
+      class="css-1j3au96"
     >
       <a
         class="css-1l9an2g"
@@ -37,7 +37,7 @@ exports[`Widget/GitHub/PinnedItems snapshots matches the placeholder snapshot 1`
                 />
               </div>
               <div
-                class="css-fjakwv"
+                class="css-1fsahx3"
               >
                 <div
                   class="text-block"
@@ -93,7 +93,7 @@ exports[`Widget/GitHub/PinnedItems snapshots matches the placeholder snapshot 1`
                 />
               </div>
               <div
-                class="css-fjakwv"
+                class="css-1fsahx3"
               >
                 <div
                   class="text-block"
@@ -149,7 +149,7 @@ exports[`Widget/GitHub/PinnedItems snapshots matches the placeholder snapshot 1`
                 />
               </div>
               <div
-                class="css-fjakwv"
+                class="css-1fsahx3"
               >
                 <div
                   class="text-block"
@@ -205,7 +205,7 @@ exports[`Widget/GitHub/PinnedItems snapshots matches the placeholder snapshot 1`
                 />
               </div>
               <div
-                class="css-fjakwv"
+                class="css-1fsahx3"
               >
                 <div
                   class="text-block"
@@ -263,7 +263,7 @@ exports[`Widget/GitHub/PinnedItems snapshots matches the successful state 1`] = 
       Pinned items on my GitHub profile.
     </p>
     <div
-      class="css-uz5s83"
+      class="css-1j3au96"
     >
       <a
         class="css-1l9an2g"
@@ -284,7 +284,7 @@ exports[`Widget/GitHub/PinnedItems snapshots matches the successful state 1`] = 
                 />
               </div>
               <div
-                class="css-fjakwv"
+                class="css-1fsahx3"
               >
                 <div
                   class="text-block"
@@ -340,7 +340,7 @@ exports[`Widget/GitHub/PinnedItems snapshots matches the successful state 1`] = 
                 />
               </div>
               <div
-                class="css-fjakwv"
+                class="css-1fsahx3"
               >
                 <div
                   class="text-block"
@@ -396,7 +396,7 @@ exports[`Widget/GitHub/PinnedItems snapshots matches the successful state 1`] = 
                 />
               </div>
               <div
-                class="css-fjakwv"
+                class="css-1fsahx3"
               >
                 <div
                   class="text-block"
@@ -452,7 +452,7 @@ exports[`Widget/GitHub/PinnedItems snapshots matches the successful state 1`] = 
                 />
               </div>
               <div
-                class="css-fjakwv"
+                class="css-1fsahx3"
               >
                 <div
                   class="text-block"

--- a/theme/src/components/widgets/github/contribution-graph.js
+++ b/theme/src/components/widgets/github/contribution-graph.js
@@ -9,6 +9,32 @@ import isDarkMode from '../../../helpers/isDarkMode'
 /** Must match grid / legend gap so month labels and row math align with cells (Theme UI `gap: 1` is not guaranteed to be 4px). */
 const CONTRIBUTION_CELL_GAP_PX = 4
 
+/** Stable keys for loading skeleton cells (53 columns × 7 rows, trimmed to 365). */
+const CONTRIBUTION_GRAPH_LOADING_KEYS = (() => {
+  const keys = []
+  for (let col = 0; col < 53 && keys.length < 365; col += 1) {
+    for (let row = 0; row < 7 && keys.length < 365; row += 1) {
+      keys.push(`contrib-graph-loading-${col}-${row}`)
+    }
+  }
+  return keys
+})()
+
+function githubCalendarRowIndex(dayOfWeek) {
+  if (dayOfWeek === 0) return 1
+  if (dayOfWeek === 6) return 0
+  return dayOfWeek + 1
+}
+
+function contributionLegendSquareBackground(level, darkMode) {
+  if (level === 0) {
+    return darkMode ? '#161b22' : '#ebedf0'
+  }
+  const dark = ['#0e4429', '#006d32', '#26a641', '#39d353']
+  const light = ['#9be9a8', '#40c463', '#30a14e', '#216e39']
+  return darkMode ? dark[level - 1] : light[level - 1]
+}
+
 function earliestContributionDate(weeks) {
   let min = null
   for (const week of weeks) {
@@ -105,9 +131,7 @@ const ContributionGraph = ({ isLoading, contributionCalendar }) => {
         const [year, month, dayOfMonth] = day.date.split('-').map(Number)
         const date = new Date(year, month - 1, dayOfMonth)
         const dayOfWeek = date.getDay() // 0=Sun, 1=Mon, ..., 6=Sat
-        // Convert to GitHub week: Sat=0, Sun=1, Mon=2, ..., Fri=6
-        const githubDayOfWeek = dayOfWeek === 0 ? 1 : dayOfWeek === 6 ? 0 : dayOfWeek + 1
-        map[githubDayOfWeek] = day
+        map[githubCalendarRowIndex(dayOfWeek)] = day
       })
       return map
     })
@@ -183,9 +207,9 @@ const ContributionGraph = ({ isLoading, contributionCalendar }) => {
               p: 3
             }}
           >
-            {Array.from({ length: 365 }).map((_, i) => (
+            {CONTRIBUTION_GRAPH_LOADING_KEYS.map(cellKey => (
               <Box
-                key={i}
+                key={cellKey}
                 sx={{
                   width: `${cellSize}px`,
                   height: `${cellSize}px`,
@@ -378,6 +402,11 @@ const ContributionGraph = ({ isLoading, contributionCalendar }) => {
                   const contributionText = hasContributions
                     ? `${day.contributionCount} contribution${day.contributionCount !== 1 ? 's' : ''}`
                     : 'No contributions'
+                  const emptyContributionCellBg = darkModeActive ? '#161b22' : '#ebedf0'
+                  const cellBackground = day.contributionCount === 0 ? emptyContributionCellBg : day.color
+                  const contributionHoverShadow = darkModeActive
+                    ? '0 0 0 2px rgba(255,255,255,0.25), 0 0 12px rgba(255,255,255,0.08)'
+                    : '0 0 0 2px rgba(0,0,0,0.12), 0 0 12px rgba(0,0,0,0.08)'
 
                   return (
                     <Box
@@ -402,7 +431,7 @@ const ContributionGraph = ({ isLoading, contributionCalendar }) => {
                         width: `${cellSize}px`,
                         height: `${cellSize}px`,
                         borderRadius: '2px',
-                        bg: day.contributionCount === 0 ? (darkModeActive ? '#161b22' : '#ebedf0') : day.color,
+                        bg: cellBackground,
                         position: 'relative',
                         cursor: hasContributions ? 'pointer' : 'default',
                         overflow: 'hidden',
@@ -423,9 +452,7 @@ const ContributionGraph = ({ isLoading, contributionCalendar }) => {
                             pointerEvents: 'none'
                           },
                           '&:hover': {
-                            boxShadow: darkModeActive
-                              ? '0 0 0 2px rgba(255,255,255,0.25), 0 0 12px rgba(255,255,255,0.08)'
-                              : '0 0 0 2px rgba(0,0,0,0.12), 0 0 12px rgba(0,0,0,0.08)',
+                            boxShadow: contributionHoverShadow,
                             transform: 'scale(1.12)',
                             zIndex: 5,
                             '&::after': {
@@ -471,14 +498,7 @@ const ContributionGraph = ({ isLoading, contributionCalendar }) => {
                   width: `${cellSize}px`,
                   height: `${cellSize}px`,
                   borderRadius: '2px',
-                  bg:
-                    level === 0
-                      ? darkModeActive
-                        ? '#161b22'
-                        : '#ebedf0'
-                      : darkModeActive
-                        ? ['#0e4429', '#006d32', '#26a641', '#39d353'][level - 1]
-                        : ['#9be9a8', '#40c463', '#30a14e', '#216e39'][level - 1]
+                  bg: contributionLegendSquareBackground(level, darkModeActive)
                 }}
               />
             ))}

--- a/theme/src/components/widgets/github/contribution-graph.resize.spec.js
+++ b/theme/src/components/widgets/github/contribution-graph.resize.spec.js
@@ -18,6 +18,13 @@ const calendar = {
   ]
 }
 
+const mockOffsetWidth = value => {
+  Object.defineProperty(HTMLElement.prototype, 'offsetWidth', {
+    configurable: true,
+    value
+  })
+}
+
 describe('ContributionGraph resize behavior', () => {
   it('handles window resize without errors and initializes cell size', () => {
     render(
@@ -36,15 +43,7 @@ describe('ContributionGraph resize behavior', () => {
   })
 
   it('scales cell size up on wide containers (no upper clamp)', () => {
-    const defineOffset = value => {
-      Object.defineProperty(HTMLElement.prototype, 'offsetWidth', {
-        configurable: true,
-        value
-      })
-    }
-
-    // Wide container
-    defineOffset(1200)
+    mockOffsetWidth(1200)
 
     // Create a more realistic 53-week calendar with at least one day per week
     const weeks = Array.from({ length: 53 }, (_, i) => {
@@ -74,15 +73,7 @@ describe('ContributionGraph resize behavior', () => {
   })
 
   it('clamps cell size to a minimum on narrow containers', () => {
-    const defineOffset = value => {
-      Object.defineProperty(HTMLElement.prototype, 'offsetWidth', {
-        configurable: true,
-        value
-      })
-    }
-
-    // Narrow container (e.g., small mobile)
-    defineOffset(320)
+    mockOffsetWidth(320)
 
     // Use a full-year-like structure to stress the calculation
     const weeks = Array.from({ length: 53 }, (_, i) => {

--- a/theme/src/components/widgets/github/github-widget.js
+++ b/theme/src/components/widgets/github/github-widget.js
@@ -55,8 +55,7 @@ const GitHubWidget = () => {
       url={`https://www.github.com/${githubUsername}`}
       isLoading={isLoading}
     >
-      Visit Profile
-      <span className='read-more-icon'>&rarr;</span>
+      Visit Profile <span className='read-more-icon'>&rarr;</span>
     </CallToAction>
   )
 

--- a/theme/src/components/widgets/github/pinned-item-card.js
+++ b/theme/src/components/widgets/github/pinned-item-card.js
@@ -16,7 +16,7 @@ const rendererRegistry = {
 
 const PinnedItemCard = ({ item, type = PLACEHOLDER }) => (
   <Card variant='actionCard' sx={actionCardPinnedLayoutSx}>
-    {rendererRegistry[type] && rendererRegistry[type](item)}
+    {rendererRegistry[type]?.(item)}
   </Card>
 )
 

--- a/theme/src/components/widgets/github/pinned-items.js
+++ b/theme/src/components/widgets/github/pinned-items.js
@@ -25,7 +25,7 @@ const PinnedItems = ({ isLoading, items = [], placeholderCount = 4 }) => {
 
       <Themed.p>Pinned items on my GitHub profile.</Themed.p>
 
-      <Themed.div
+      <Box
         sx={{
           display: 'grid',
           gridAutoRows: '1fr',
@@ -48,7 +48,7 @@ const PinnedItems = ({ isLoading, items = [], placeholderCount = 4 }) => {
             <PinnedItemCard item={item} type={item.__typename} />
           </Themed.a>
         ))}
-      </Themed.div>
+      </Box>
     </Box>
   )
 }

--- a/theme/src/components/widgets/github/renderers/__snapshots__/placeholder.spec.js.snap
+++ b/theme/src/components/widgets/github/renderers/__snapshots__/placeholder.spec.js.snap
@@ -15,7 +15,7 @@ exports[`GitHub Placeholder Renderer matches the snapshot 1`] = `
         />
       </div>
       <div
-        class="css-fjakwv"
+        class="css-1fsahx3"
       >
         <div
           class="text-block"

--- a/theme/src/components/widgets/github/renderers/__snapshots__/repository.spec.js.snap
+++ b/theme/src/components/widgets/github/renderers/__snapshots__/repository.spec.js.snap
@@ -11,7 +11,7 @@ exports[`GitHub Repository Renderer falls back to updatedAt when pushedAt is not
       themeuser/legacy-repo
     </h4>
     <span
-      class="css-gulexy"
+      class="css-1e5uqy3"
     >
       Legacy repository without pushedAt field.
     </span>
@@ -52,7 +52,7 @@ exports[`GitHub Repository Renderer matches the snapshot 1`] = `
       themeuser/gatsby-theme-chronogrove
     </h4>
     <span
-      class="css-gulexy"
+      class="css-1e5uqy3"
     >
       GatsbyJS blog theme with built-in social widgets for creatives and developers.
     </span>

--- a/theme/src/components/widgets/github/renderers/placeholder.js
+++ b/theme/src/components/widgets/github/renderers/placeholder.js
@@ -1,5 +1,6 @@
 /** @jsx jsx */
 import { jsx, Flex, useThemeUI } from 'theme-ui'
+import { Box } from '@theme-ui/components'
 import { TextBlock, RectShape } from 'react-placeholder/lib/placeholders'
 import isDarkMode from '../../../../helpers/isDarkMode'
 
@@ -16,9 +17,9 @@ const GitHubPlaceholder = () => {
         <div>
           <RectShape color={placeholderColor} style={{ width: 40, height: 40, marginBottom: '2em' }} />
         </div>
-        <div sx={{ width: '100%', height: '100%' }}>
+        <Box sx={{ width: '100%', height: '100%' }}>
           <TextBlock rows={2} color={placeholderColor} />
-        </div>
+        </Box>
       </Flex>
       <TextBlock rows={3} color={placeholderColor} />
     </div>

--- a/theme/src/components/widgets/github/renderers/repository.js
+++ b/theme/src/components/widgets/github/renderers/repository.js
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 import { jsx } from 'theme-ui'
-import { Flex, Heading } from '@theme-ui/components'
+import { Box, Flex, Heading } from '@theme-ui/components'
 import ago from 's-ago'
 
 import CardFooter from '../../card-footer'
@@ -22,7 +22,9 @@ const Repository = ({ description, nameWithOwner, pushedAt, updatedAt }) => {
         {nameWithOwner}
       </Heading>
 
-      <span sx={{ flexGrow: 1, mb: 2 }}>{description}</span>
+      <Box as='span' sx={{ flexGrow: 1, mb: 2 }}>
+        {description}
+      </Box>
 
       <CardFooter>
         <span>Last updated {ago(new Date(lastActivityDate))}</span>

--- a/theme/src/components/widgets/goodreads/__snapshots__/goodreads-widget.spec.js.snap
+++ b/theme/src/components/widgets/goodreads/__snapshots__/goodreads-widget.spec.js.snap
@@ -213,7 +213,7 @@ exports[`Goodreads Widget renders error state 1`] = `
             href="https://www.goodreads.com/mockusername"
             title="mockusername on Goodreads"
           >
-            Visit Profile
+            Visit Profile 
             <span
               class="read-more-icon"
             >
@@ -282,7 +282,7 @@ exports[`Goodreads Widget renders with data and AI summary 1`] = `
             href="https://www.goodreads.com/mockusername"
             title="mockusername on Goodreads"
           >
-            Visit Profile
+            Visit Profile 
             <span
               class="read-more-icon"
             >
@@ -388,7 +388,7 @@ exports[`Goodreads Widget renders without AI summary when not available 1`] = `
             href="https://www.goodreads.com/mockusername"
             title="mockusername on Goodreads"
           >
-            Visit Profile
+            Visit Profile 
             <span
               class="read-more-icon"
             >

--- a/theme/src/components/widgets/goodreads/book-explorer.js
+++ b/theme/src/components/widgets/goodreads/book-explorer.js
@@ -110,7 +110,7 @@ const BookExplorer = ({ book, onClose }) => {
                 My Rating:
               </Box>
               <Box as='span' sx={{ color: 'primary' }}>
-                {renderStarsForRating(parseInt(rating, 10))}
+                {renderStarsForRating(Number.parseInt(rating, 10))}
               </Box>
             </Box>
 

--- a/theme/src/components/widgets/goodreads/book-explorer.js
+++ b/theme/src/components/widgets/goodreads/book-explorer.js
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 import { jsx } from 'theme-ui'
-import { Card, Heading } from '@theme-ui/components'
+import { Box, Card, Heading } from '@theme-ui/components'
 import { Themed } from '@theme-ui/mdx'
 import { Link } from 'gatsby'
 import { useLocation } from '@gatsbyjs/reach-router'
@@ -25,7 +25,7 @@ const BookExplorer = ({ book, onClose }) => {
 
   return (
     <Card variant='actionCard'>
-      <div
+      <Box
         sx={{
           display: 'flex',
           flexDirection: 'column',
@@ -33,7 +33,9 @@ const BookExplorer = ({ book, onClose }) => {
           position: 'relative'
         }}
       >
-        <button
+        <Box
+          as='button'
+          type='button'
           data-testid='close-book-explorer'
           onClick={onClose}
           sx={{
@@ -50,22 +52,15 @@ const BookExplorer = ({ book, onClose }) => {
             }
           }}
         >
-          <svg
-            aria-hidden='true'
-            focusable='false'
-            role='img'
-            style={{}}
-            viewBox='0 0 448 512'
-            xmlns='http://www.w3.org/2000/svg'
-          >
+          <svg aria-hidden='true' focusable='false' style={{}} viewBox='0 0 448 512' xmlns='http://www.w3.org/2000/svg'>
             <path
               d='M299.9 191.2c5.1 37.3-4.7 79-35.9 100.7-22.3 15.5-52.8 14.1-70.8 5.7-37.1-17.3-49.5-58.6-46.8-97.2 4.3-60.9 40.9-87.9 75.3-87.5 46.9-.2 71.8 31.8 78.2 78.3zM448 88v336c0 30.9-25.1 56-56 56H56c-30.9 0-56-25.1-56-56V88c0-30.9 25.1-56 56-56h336c30.9 0 56 25.1 56 56zM330 313.2s-.1-34-.1-217.3h-29v40.3c-.8.3-1.2-.5-1.6-1.2-9.6-20.7-35.9-46.3-76-46-51.9.4-87.2 31.2-100.6 77.8-4.3 14.9-5.8 30.1-5.5 45.6 1.7 77.9 45.1 117.8 112.4 115.2 28.9-1.1 54.5-17 69-45.2.5-1 1.1-1.9 1.7-2.9.2.1.4.1.6.2.3 3.8.2 30.7.1 34.5-.2 14.8-2 29.5-7.2 43.5-7.8 21-22.3 34.7-44.5 39.5-17.8 3.9-35.6 3.8-53.2-1.2-21.5-6.1-36.5-19-41.1-41.8-.3-1.6-1.3-1.3-2.3-1.3h-26.8c.8 10.6 3.2 20.3 8.5 29.2 24.2 40.5 82.7 48.5 128.2 37.4 49.9-12.3 67.3-54.9 67.4-106.3z'
               fill='currentColor'
               style={{}}
             />
           </svg>
-        </button>
-        <div
+        </Box>
+        <Box
           sx={{
             display: 'flex',
             flexDirection: ['column', 'row'],
@@ -74,7 +69,7 @@ const BookExplorer = ({ book, onClose }) => {
           }}
         >
           {/* Book Cover */}
-          <div
+          <Box
             sx={{
               flex: '0 0 200px',
               display: 'flex',
@@ -82,9 +77,9 @@ const BookExplorer = ({ book, onClose }) => {
               alignItems: 'center'
             }}
           >
-            <div sx={{ width: '100%', maxWidth: '160px' }}>
+            <Box sx={{ width: '100%', maxWidth: '160px' }}>
               <Book3D thumbnailURL={`${cdnMediaURL}?auto=compress&auto=format`} title={title} />
-            </div>
+            </Box>
             <Link
               to={location.pathname}
               onClick={handleBackClick}
@@ -100,20 +95,24 @@ const BookExplorer = ({ book, onClose }) => {
             >
               ← Back to grid view
             </Link>
-          </div>
+          </Box>
 
           {/* Book Details */}
-          <div sx={{ flex: 1 }}>
+          <Box sx={{ flex: 1 }}>
             <Heading as='h3' sx={{ mb: 0, fontSize: [3, 4] }}>
               {title}
             </Heading>
 
             <Themed.p sx={{ mt: 0, mb: 2, color: 'textMuted' }}>by {authors.join(', ')}</Themed.p>
 
-            <div sx={{ mt: 2, mb: 1 }}>
-              <span sx={{ color: 'textMuted', mr: 2 }}>My Rating:</span>
-              <span sx={{ color: 'primary' }}>{renderStarsForRating(parseInt(rating, 10))}</span>
-            </div>
+            <Box sx={{ mt: 2, mb: 1 }}>
+              <Box as='span' sx={{ color: 'textMuted', mr: 2 }}>
+                My Rating:
+              </Box>
+              <Box as='span' sx={{ color: 'primary' }}>
+                {renderStarsForRating(parseInt(rating, 10))}
+              </Box>
+            </Box>
 
             <Themed.div data-testid='book-explorer-description' sx={{ mt: 2, mb: 3, lineHeight: 'body' }}>
               {parseSafeHtml(description)}
@@ -134,9 +133,9 @@ const BookExplorer = ({ book, onClose }) => {
               Learn more on Google Books &nbsp;
               <ViewExternal platform='Google Books' />
             </Themed.a>
-          </div>
-        </div>
-      </div>
+          </Box>
+        </Box>
+      </Box>
     </Card>
   )
 }

--- a/theme/src/components/widgets/goodreads/book-explorer.spec.js
+++ b/theme/src/components/widgets/goodreads/book-explorer.spec.js
@@ -14,9 +14,13 @@ jest.mock('@gatsbyjs/reach-router', () => ({
 
 // Mock Book3D to avoid WebGL in jsdom
 jest.mock('../../artwork/book-3d', () => {
-  const React = require('react')
+  const { createElement } = require('react')
   return function MockBook3D({ thumbnailURL, title }) {
-    return <img data-testid='book-preview-3d' src={thumbnailURL} alt={title} />
+    return createElement('img', {
+      'data-testid': 'book-preview-3d',
+      src: thumbnailURL,
+      alt: title
+    })
   }
 })
 

--- a/theme/src/components/widgets/goodreads/book-link.js
+++ b/theme/src/components/widgets/goodreads/book-link.js
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 import { jsx } from 'theme-ui'
-import { Card } from '@theme-ui/components'
+import { Box, Card } from '@theme-ui/components'
 import { navigate as gatsbyNavigate } from 'gatsby'
 import { useEffect, useState } from 'react'
 import Book3D from '../../artwork/book-3d'
@@ -77,6 +77,43 @@ const BookLink = ({
     }, 0)
   }
 
+  const flatCoverBusy = flatCoverMediaStatus === 'pending'
+  let flatCoverInner = null
+  if (flatCoverMediaStatus === 'failed') {
+    flatCoverInner = (
+      <Box
+        sx={{
+          p: 2,
+          fontSize: 1,
+          lineHeight: 'snug',
+          textAlign: 'center',
+          color: 'text',
+          wordBreak: 'break-word'
+        }}
+      >
+        {title}
+      </Box>
+    )
+  } else if (flatCoverMediaStatus === 'ready') {
+    flatCoverInner = (
+      <Box
+        as='img'
+        data-testid='book-preview-thumbnail'
+        src={imageUrl}
+        alt={title}
+        loading='lazy'
+        decoding='async'
+        sx={{
+          position: 'absolute',
+          inset: 0,
+          width: '100%',
+          height: '100%',
+          objectFit: 'cover'
+        }}
+      />
+    )
+  }
+
   return (
     <Card
       variant='actionCard'
@@ -91,7 +128,8 @@ const BookLink = ({
         }
       }}
     >
-      <button
+      <Box
+        as='button'
         data-testid='book-link'
         type='button'
         onClick={handleClick}
@@ -115,11 +153,10 @@ const BookLink = ({
         }}
       >
         {flatCover ? (
-          <div sx={{ width: '100%', paddingBottom: '100%', position: 'relative' }}>
-            <div
+          <Box sx={{ width: '100%', paddingBottom: '100%', position: 'relative' }}>
+            <Box
               data-testid='book-preview-flat'
-              role='img'
-              aria-busy={flatCoverMediaStatus === 'pending'}
+              aria-busy={flatCoverBusy}
               aria-label={title}
               sx={{
                 position: 'absolute',
@@ -132,41 +169,13 @@ const BookLink = ({
                 justifyContent: 'center'
               }}
             >
-              {flatCoverMediaStatus === 'failed' ? (
-                <span
-                  sx={{
-                    p: 2,
-                    fontSize: 1,
-                    lineHeight: 'snug',
-                    textAlign: 'center',
-                    color: 'text',
-                    wordBreak: 'break-word'
-                  }}
-                >
-                  {title}
-                </span>
-              ) : flatCoverMediaStatus === 'ready' ? (
-                <img
-                  data-testid='book-preview-thumbnail'
-                  src={imageUrl}
-                  alt=''
-                  loading='lazy'
-                  decoding='async'
-                  sx={{
-                    position: 'absolute',
-                    inset: 0,
-                    width: '100%',
-                    height: '100%',
-                    objectFit: 'cover'
-                  }}
-                />
-              ) : null}
-            </div>
-          </div>
+              {flatCoverInner}
+            </Box>
+          </Box>
         ) : (
           <Book3D thumbnailURL={imageUrl} title={title} introDelay={introDelay} />
         )}
-      </button>
+      </Box>
     </Card>
   )
 }

--- a/theme/src/components/widgets/goodreads/book-link.spec.js
+++ b/theme/src/components/widgets/goodreads/book-link.spec.js
@@ -45,12 +45,16 @@ jest.mock('gatsby', () => ({
 // Mock Book3D so tests don't need a WebGL context.
 // Exposes book-preview-thumbnail so URL-formatting assertions still work.
 jest.mock('../../artwork/book-3d', () => {
-  const React = require('react')
+  const { createElement } = require('react')
   return function MockBook3D({ title, thumbnailURL }) {
-    return (
-      <div data-testid='book-preview-3d' role='img' aria-label={title}>
-        <img data-testid='book-preview-thumbnail' src={thumbnailURL} alt={title} />
-      </div>
+    return createElement(
+      'div',
+      { 'data-testid': 'book-preview-3d' },
+      createElement('img', {
+        'data-testid': 'book-preview-thumbnail',
+        src: thumbnailURL,
+        alt: title
+      })
     )
   }
 })
@@ -154,13 +158,17 @@ describe('Widget/Goodreads/BookLink', () => {
     global.Image = class DelayedMock {
       constructor() {
         this._onLoad = null
+        this._onErr = null
       }
 
       addEventListener(type, fn) {
         if (type === 'load') this._onLoad = fn
       }
 
-      removeEventListener() {}
+      removeEventListener(type, fn) {
+        if (type === 'load' && this._onLoad === fn) this._onLoad = null
+        if (type === 'error' && this._onErr === fn) this._onErr = null
+      }
 
       set src(_value) {
         setTimeout(() => this._onLoad?.(), 100)

--- a/theme/src/components/widgets/goodreads/goodreads-widget.js
+++ b/theme/src/components/widgets/goodreads/goodreads-widget.js
@@ -52,8 +52,7 @@ export default () => {
       url={`https://www.goodreads.com/${goodreadsUsername}`}
       isLoading={isLoading}
     >
-      Visit Profile
-      <span className='read-more-icon'>&rarr;</span>
+      Visit Profile <span className='read-more-icon'>&rarr;</span>
     </CallToAction>
   )
 

--- a/theme/src/components/widgets/goodreads/recently-read-books.js
+++ b/theme/src/components/widgets/goodreads/recently-read-books.js
@@ -15,8 +15,8 @@ import BookLink from './book-link'
 export const HEADLINE = 'Books'
 export const BODY_TEXT = 'Recently read and finished books from Goodreads.'
 
-const BOOKS_PER_PAGE = 10
-const RECENTLY_READ_SKELETON_KEYS = 'abcdefghij'.split('')
+export const BOOKS_PER_PAGE = 10
+const RECENTLY_READ_SKELETON_KEYS = Array.from({ length: BOOKS_PER_PAGE }, (_, index) => index)
 
 const RecentlyReadBooks = ({ books = [], isLoading }) => {
   const { colorMode } = useThemeUI()

--- a/theme/src/components/widgets/goodreads/recently-read-books.js
+++ b/theme/src/components/widgets/goodreads/recently-read-books.js
@@ -1,10 +1,10 @@
 /** @jsx jsx */
 import { jsx, useThemeUI } from 'theme-ui'
-import { Heading } from '@theme-ui/components'
+import { Box, Heading } from '@theme-ui/components'
 import { RectShape } from 'react-placeholder/lib/placeholders'
 import { Themed } from '@theme-ui/mdx'
 import { useLocation, navigate } from '@gatsbyjs/reach-router'
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useEffect, useMemo, useRef, useState, useCallback } from 'react'
 import isDarkMode from '../../../helpers/isDarkMode'
 import Pagination from '../../pagination'
 import useSwipePagination from '../../../hooks/use-swipe-pagination'
@@ -16,6 +16,7 @@ export const HEADLINE = 'Books'
 export const BODY_TEXT = 'Recently read and finished books from Goodreads.'
 
 const BOOKS_PER_PAGE = 10
+const RECENTLY_READ_SKELETON_KEYS = 'abcdefghij'.split('')
 
 const RecentlyReadBooks = ({ books = [], isLoading }) => {
   const { colorMode } = useThemeUI()
@@ -63,6 +64,20 @@ const RecentlyReadBooks = ({ books = [], isLoading }) => {
     onPageChange: setCurrentPage
   })
 
+  const handleCarouselKeyDown = useCallback(
+    event => {
+      if (totalPages <= 1) return
+      if (event.key === 'ArrowRight' || event.key === 'ArrowDown') {
+        event.preventDefault()
+        handlePageChange(currentPage + 1)
+      } else if (event.key === 'ArrowLeft' || event.key === 'ArrowUp') {
+        event.preventDefault()
+        handlePageChange(currentPage - 1)
+      }
+    },
+    [currentPage, handlePageChange, totalPages]
+  )
+
   // Handle scroll position restoration and prevention
   useEffect(() => {
     // Store the current scroll position when the component mounts
@@ -74,9 +89,7 @@ const RecentlyReadBooks = ({ books = [], isLoading }) => {
       setTimeout(() => {
         const goodreadsElement = document.getElementById('goodreads')
         if (goodreadsElement) {
-          // Force a reflow to ensure the element is properly positioned
-          void goodreadsElement.offsetHeight
-          // Use the browser's native hash navigation
+          goodreadsElement.scrollIntoView?.({ block: 'nearest' })
           window.location.hash = 'goodreads'
         }
       }, 100)
@@ -157,9 +170,14 @@ const RecentlyReadBooks = ({ books = [], isLoading }) => {
     })
   }
 
+  let carouselCursor = 'default'
+  if (totalPages > 1) {
+    carouselCursor = isDragging ? 'grabbing' : 'grab'
+  }
+
   return (
     <div className='gallery'>
-      <div sx={{ mb: 4 }}>
+      <Box sx={{ mb: 4 }}>
         <Heading
           as='h3'
           sx={{
@@ -175,7 +193,7 @@ const RecentlyReadBooks = ({ books = [], isLoading }) => {
         {selectedBook ? (
           <BookExplorer book={selectedBook} onClose={handleClose} />
         ) : (
-          <div
+          <Box
             sx={{
               overflow: 'hidden',
               position: 'relative',
@@ -186,36 +204,38 @@ const RecentlyReadBooks = ({ books = [], isLoading }) => {
             }}
           >
             {isLoading ? (
-              <div
+              <Box
                 sx={{
                   display: 'grid',
                   gridGap: [3, 1, 2],
                   gridTemplateColumns: ['repeat(3, 1fr)', 'repeat(4, 1fr)', 'repeat(4, 1fr)', 'repeat(6, 1fr)']
                 }}
               >
-                {Array(BOOKS_PER_PAGE)
-                  .fill()
-                  .map((item, idx) => (
-                    <RectShape
-                      color={darkModeActive ? '#3a3a4a' : '#efefef'}
-                      key={idx}
-                      sx={{
-                        boxShadow: 'md',
-                        minHeight: '140px',
-                        width: '100%'
-                      }}
-                    />
-                  ))}
-              </div>
+                {RECENTLY_READ_SKELETON_KEYS.map(slotKey => (
+                  <RectShape
+                    color={darkModeActive ? '#3a3a4a' : '#efefef'}
+                    key={`recently-read-skeleton-${slotKey}`}
+                    sx={{
+                      boxShadow: 'md',
+                      minHeight: '140px',
+                      width: '100%'
+                    }}
+                  />
+                ))}
+              </Box>
             ) : (
-              <div
+              <Box
                 data-testid='goodreads-carousel'
+                role='region'
+                aria-label='Recently read books'
+                tabIndex={0}
+                onKeyDown={handleCarouselKeyDown}
                 sx={{
                   display: 'flex',
                   width: `${totalPages * 100}%`,
                   transform: getTransform(),
                   transition: isDragging ? 'none' : 'transform 0.3s cubic-bezier(0.4, 0, 0.2, 1)',
-                  cursor: totalPages > 1 ? (isDragging ? 'grabbing' : 'grab') : 'default',
+                  cursor: carouselCursor,
                   userSelect: 'none',
                   touchAction: 'pan-y'
                 }}
@@ -229,7 +249,7 @@ const RecentlyReadBooks = ({ books = [], isLoading }) => {
                 onPointerCancel={handlePointerCancel}
               >
                 {pages.map((pageBooks, pageIndex) => (
-                  <div
+                  <Box
                     key={`goodreads-page-${pageIndex + 1}`}
                     aria-hidden={pageIndex !== currentPage - 1}
                     data-testid={`goodreads-page-${pageIndex + 1}`}
@@ -244,7 +264,7 @@ const RecentlyReadBooks = ({ books = [], isLoading }) => {
                       pb: 1
                     }}
                   >
-                    <div
+                    <Box
                       sx={t => ({
                         display: 'grid',
                         gridGap: [3, 1, 2],
@@ -266,18 +286,18 @@ const RecentlyReadBooks = ({ books = [], isLoading }) => {
                           title={book.title}
                         />
                       ))}
-                    </div>
-                  </div>
+                    </Box>
+                  </Box>
                 ))}
-              </div>
+              </Box>
             )}
-          </div>
+          </Box>
         )}
 
         {!selectedBook && !isLoading && (
           <Pagination currentPage={currentPage} onPageChange={handlePageChange} totalPages={totalPages} />
         )}
-      </div>
+      </Box>
     </div>
   )
 }

--- a/theme/src/components/widgets/goodreads/recently-read-books.spec.js
+++ b/theme/src/components/widgets/goodreads/recently-read-books.spec.js
@@ -3,7 +3,7 @@ import { render, screen, fireEvent, within } from '@testing-library/react'
 import '@testing-library/jest-dom'
 import { Router, LocationProvider } from '@gatsbyjs/reach-router'
 
-import RecentlyReadBooks, { HEADLINE, BODY_TEXT } from './recently-read-books'
+import RecentlyReadBooks, { BOOKS_PER_PAGE, HEADLINE, BODY_TEXT } from './recently-read-books'
 import goodreadsMock from '../../../../__mocks__/goodreads-widget.mock.json'
 
 // Mock LazyLoad component
@@ -52,7 +52,7 @@ describe('Widget/Goodreads/RecentlyReadBooks', () => {
   describe('loading state', () => {
     it('renders a placeholder for each book expected to render', () => {
       const { container } = renderWithRouter(<RecentlyReadBooks books={[]} isLoading={true} default />)
-      expect(container.querySelectorAll('.rect-shape')).toHaveLength(10)
+      expect(container.querySelectorAll('.rect-shape')).toHaveLength(BOOKS_PER_PAGE)
     })
   })
 

--- a/theme/src/components/widgets/goodreads/recently-read-books.spec.js
+++ b/theme/src/components/widgets/goodreads/recently-read-books.spec.js
@@ -144,6 +144,71 @@ describe('Widget/Goodreads/RecentlyReadBooks', () => {
       )
     })
 
+    it('navigates the carousel with arrow keys when there is more than one page', () => {
+      jest.useFakeTimers()
+
+      const paginatedBooks = Array.from({ length: 20 }, (_, idx) => ({
+        ...mockBooks[idx % mockBooks.length],
+        id: `book-${idx + 1}`,
+        title: `Book ${idx + 1}`,
+        thumbnail: `https://example.com/book-${idx + 1}.jpg`
+      }))
+
+      renderWithRouter(<RecentlyReadBooks books={paginatedBooks} isLoading={false} default />)
+
+      const carousel = screen.getByTestId('goodreads-carousel')
+      carousel.focus()
+
+      fireEvent.keyDown(carousel, { key: 'ArrowRight' })
+      expect(screen.getByText('Page 2 of 2')).toBeInTheDocument()
+
+      act(() => {
+        jest.advanceTimersByTime(300)
+      })
+
+      fireEvent.keyDown(carousel, { key: 'ArrowDown' })
+      expect(screen.getByText('Page 2 of 2')).toBeInTheDocument()
+
+      act(() => {
+        jest.advanceTimersByTime(300)
+      })
+
+      fireEvent.keyDown(carousel, { key: 'ArrowLeft' })
+      expect(screen.getByText('Page 1 of 2')).toBeInTheDocument()
+
+      act(() => {
+        jest.advanceTimersByTime(300)
+      })
+
+      fireEvent.click(screen.getByLabelText('Go to page 2'))
+      expect(screen.getByText('Page 2 of 2')).toBeInTheDocument()
+
+      act(() => {
+        jest.advanceTimersByTime(300)
+      })
+
+      fireEvent.keyDown(carousel, { key: 'ArrowUp' })
+      expect(screen.getByText('Page 1 of 2')).toBeInTheDocument()
+    })
+
+    it('ignores arrow keys on the carousel when there is only one page', () => {
+      const paginatedBooks = Array.from({ length: 5 }, (_, idx) => ({
+        ...mockBooks[idx % mockBooks.length],
+        id: `book-${idx + 1}`,
+        title: `Book ${idx + 1}`,
+        thumbnail: `https://example.com/book-${idx + 1}.jpg`
+      }))
+
+      renderWithRouter(<RecentlyReadBooks books={paginatedBooks} isLoading={false} default />)
+
+      const carousel = screen.getByTestId('goodreads-carousel')
+      carousel.focus()
+      fireEvent.keyDown(carousel, { key: 'ArrowRight' })
+
+      expect(within(screen.getByTestId('goodreads-page-1')).getAllByTestId('book-link')).toHaveLength(5)
+      expect(screen.queryByTestId('goodreads-page-2')).not.toBeInTheDocument()
+    })
+
     it('returns to the first page when the books list shrinks', () => {
       const paginatedBooks = Array.from({ length: 20 }, (_, idx) => ({
         ...mockBooks[idx % mockBooks.length],

--- a/theme/src/components/widgets/goodreads/recently-read-books.spec.js
+++ b/theme/src/components/widgets/goodreads/recently-read-books.spec.js
@@ -1,8 +1,7 @@
-import React from 'react'
+import React, { act } from 'react'
 import { render, screen, fireEvent, within } from '@testing-library/react'
 import '@testing-library/jest-dom'
 import { Router, LocationProvider } from '@gatsbyjs/reach-router'
-import { act } from 'react'
 
 import RecentlyReadBooks, { HEADLINE, BODY_TEXT } from './recently-read-books'
 import goodreadsMock from '../../../../__mocks__/goodreads-widget.mock.json'
@@ -13,12 +12,16 @@ jest.mock('../../lazy-load', () => ({ children }) => <>{children}</>)
 // Mock Book3D so tests don't need a WebGL context; expose book-preview-thumbnail
 // so existing assertions continue to work
 jest.mock('../../artwork/book-3d', () => {
-  const React = require('react')
+  const { createElement } = require('react')
   return function MockBook3D({ title, thumbnailURL }) {
-    return (
-      <div data-testid='book-preview-3d' role='img' aria-label={title}>
-        <img data-testid='book-preview-thumbnail' src={thumbnailURL} alt={title} />
-      </div>
+    return createElement(
+      'div',
+      { 'data-testid': 'book-preview-3d' },
+      createElement('img', {
+        'data-testid': 'book-preview-thumbnail',
+        src: thumbnailURL,
+        alt: title
+      })
     )
   }
 })

--- a/theme/src/components/widgets/goodreads/user-profile.js
+++ b/theme/src/components/widgets/goodreads/user-profile.js
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 import { jsx, useThemeUI } from 'theme-ui'
-import { Card, Heading } from '@theme-ui/components'
+import { Box, Card, Heading } from '@theme-ui/components'
 import Placeholder from 'react-placeholder'
 
 import isDarkMode from '../../../helpers/isDarkMode'
@@ -54,7 +54,7 @@ const UserProfile = ({ isLoading, profile }) => {
         Metrics
       </Heading>
 
-      <div
+      <Box
         sx={{
           display: 'grid',
           gridGap: 3,
@@ -64,7 +64,7 @@ const UserProfile = ({ isLoading, profile }) => {
         {metrics.map(({ id, title, value }) => (
           <MetricCard key={id} title={title} value={value} showPlaceholder={isLoading} />
         ))}
-      </div>
+      </Box>
     </Card>
   )
 }

--- a/theme/src/components/widgets/goodreads/user-profile.spec.js
+++ b/theme/src/components/widgets/goodreads/user-profile.spec.js
@@ -1,9 +1,9 @@
 import React from 'react'
 import { render, screen } from '@testing-library/react'
 import '@testing-library/jest-dom'
-import { ThemeUIProvider } from 'theme-ui'
+import { ThemeUIProvider, useThemeUI } from 'theme-ui'
 import UserProfile from './user-profile'
-import { useThemeUI } from 'theme-ui'
+
 import isDarkMode from '../../../helpers/isDarkMode'
 
 // Mock the useThemeUI hook

--- a/theme/src/components/widgets/goodreads/user-status.js
+++ b/theme/src/components/widgets/goodreads/user-status.js
@@ -107,7 +107,7 @@ const UserStatus = ({ isLoading, status, actorName }) => {
               }}
             >
               {bookImageUrl && (
-                <div
+                <Box
                   ref={bookContainerRef}
                   data-testid='user-status-book-tilt-container'
                   sx={{
@@ -117,7 +117,7 @@ const UserStatus = ({ isLoading, status, actorName }) => {
                     transformStyle: 'preserve-3d'
                   }}
                 >
-                  <div
+                  <Box
                     data-testid='user-status-book-tilt-inner'
                     sx={{
                       width: '100%',
@@ -127,8 +127,8 @@ const UserStatus = ({ isLoading, status, actorName }) => {
                     }}
                   >
                     <Book thumbnailURL={bookImageUrl} title={bookTitle} />
-                  </div>
-                </div>
+                  </Box>
+                </Box>
               )}
               <Box sx={{ flex: 1, minWidth: 0 }}>
                 <span>

--- a/theme/src/components/widgets/instagram/__snapshots__/instagram-widget-item.spec.js.snap
+++ b/theme/src/components/widgets/instagram/__snapshots__/instagram-widget-item.spec.js.snap
@@ -3,11 +3,12 @@
 exports[`InstagramWidgetItem matches the snapshot 1`] = `
 <DocumentFragment>
   <button
-    class="instagram-item-button css-1mc8983"
+    class="instagram-item-button css-1vy9swr"
+    type="button"
   >
     <img
       alt="Instagram post: This is a test caption"
-      class="instagram-item-image css-62khl7"
+      class="instagram-item-image css-stq7pq"
       height="280"
       loading="lazy"
       src="https://cdn.example.com/images/fake-instagram-image.jpg?h=234&w=234&fit=crop&crop=faces,focalpoint&auto=compress&auto=enhance&auto=format"

--- a/theme/src/components/widgets/instagram/instagram-widget-item.js
+++ b/theme/src/components/widgets/instagram/instagram-widget-item.js
@@ -1,5 +1,6 @@
 /** @jsx jsx */
 import { jsx } from 'theme-ui'
+import { Box } from '@theme-ui/components'
 import { keyframes } from '@emotion/react'
 import { useState, useEffect, useRef, useCallback } from 'react'
 import { faImages, faVideo } from '@fortawesome/free-solid-svg-icons'
@@ -98,6 +99,13 @@ const InstagramWidgetItem = ({
     }
   }, [hasCarouselImages, isActive, carouselImages])
 
+  const advanceCarouselAfterTransition = useCallback(() => {
+    const currentLength = carouselImagesLengthRef.current
+    setCurrentImageIndex(prev => (currentLength > 0 ? (prev + 1) % currentLength : 0))
+    setIsTransitioning(false)
+    timeoutRef.current = null
+  }, [])
+
   const startCarouselRotation = useCallback(() => {
     // Guard against empty carouselImages array (all children have falsy cdnMediaURL)
     // and single-image carousels (no point rotating)
@@ -105,15 +113,9 @@ const InstagramWidgetItem = ({
 
     intervalRef.current = setInterval(() => {
       setIsTransitioning(true)
-      timeoutRef.current = setTimeout(() => {
-        // Use ref to get current length, avoiding stale closure if children prop changes mid-rotation
-        const currentLength = carouselImagesLengthRef.current
-        setCurrentImageIndex(prev => (currentLength > 0 ? (prev + 1) % currentLength : 0))
-        setIsTransitioning(false)
-        timeoutRef.current = null
-      }, 300) // Crossfade duration
+      timeoutRef.current = setTimeout(advanceCarouselAfterTransition, 300) // Crossfade duration
     }, CAROUSEL_INTERVAL_MS)
-  }, [hasCarouselImages, carouselImages.length])
+  }, [advanceCarouselAfterTransition, hasCarouselImages, carouselImages.length])
 
   const stopCarouselRotation = useCallback(() => {
     if (intervalRef.current) {
@@ -186,7 +188,9 @@ const InstagramWidgetItem = ({
   }, [])
 
   return (
-    <button
+    <Box
+      as='button'
+      type='button'
       key={id}
       onClick={event => handleClick(event, { index, currentImageIndex, photo: { caption, id, src: cdnMediaURL } })}
       onMouseEnter={handleMouseEnter}
@@ -207,7 +211,7 @@ const InstagramWidgetItem = ({
       }}
     >
       {(isCarousel || isVideo) && (
-        <div
+        <Box
           data-testid={isVideo ? 'video-icon' : 'carousel-icon'}
           sx={{
             color: 'white',
@@ -226,12 +230,12 @@ const InstagramWidgetItem = ({
           }}
         >
           <FontAwesomeIcon icon={isVideo ? faVideo : faImages} />
-        </div>
+        </Box>
       )}
 
       {/* Carousel indicator dots */}
       {hasCarouselImages && isActive && (
-        <div
+        <Box
           data-testid='carousel-indicators'
           sx={{
             position: 'absolute',
@@ -243,26 +247,32 @@ const InstagramWidgetItem = ({
             zIndex: 1
           }}
         >
-          {carouselImages.slice(0, 5).map((_, idx) => (
-            <span
-              key={idx}
+          {carouselImages.slice(0, 5).map((imageUrl, dotIndex) => (
+            <Box
+              as='span'
+              key={`${imageUrl || 'instagram-dot'}-${dotIndex}`}
               sx={{
                 width: '6px',
                 height: '6px',
                 borderRadius: '50%',
                 backgroundColor:
-                  idx === currentImageIndex % Math.min(5, carouselImages.length) ? 'white' : 'rgba(255, 255, 255, 0.5)',
+                  dotIndex === currentImageIndex % Math.min(5, carouselImages.length)
+                    ? 'white'
+                    : 'rgba(255, 255, 255, 0.5)',
                 transition: 'background-color 0.2s ease'
               }}
             />
           ))}
           {carouselImages.length > 5 && (
-            <span sx={{ color: 'white', fontSize: '10px', lineHeight: '6px' }}>+{carouselImages.length - 5}</span>
+            <Box as='span' sx={{ color: 'white', fontSize: '10px', lineHeight: '6px' }}>
+              +{carouselImages.length - 5}
+            </Box>
           )}
-        </div>
+        </Box>
       )}
 
-      <img
+      <Box
+        as='img'
         key={currentImageIndex}
         className='instagram-item-image'
         loading='lazy'
@@ -284,7 +294,7 @@ const InstagramWidgetItem = ({
             })
         }}
       />
-    </button>
+    </Box>
   )
 }
 

--- a/theme/src/components/widgets/instagram/instagram-widget.js
+++ b/theme/src/components/widgets/instagram/instagram-widget.js
@@ -1,7 +1,7 @@
 /** @jsx jsx */
 import { jsx, useThemeUI } from 'theme-ui'
 
-import { Grid } from '@theme-ui/components'
+import { Box, Grid } from '@theme-ui/components'
 import { RectShape } from 'react-placeholder/lib/placeholders'
 import { useCallback, useState, useRef, useEffect, useMemo } from 'react'
 import isDarkMode from '../../../helpers/isDarkMode'
@@ -168,23 +168,17 @@ export default () => {
     }
 
     // Start ambient rotation after a short delay (let user settle on page)
-    const startDelay = setTimeout(() => {
-      // Check ref - don't start if gallery is open
+    const advanceAmbientCarousel = () => {
       if (isGalleryOpenRef.current) return
 
-      const firstIdx = getNextCarousel()
-      setAmbientActiveIndex(firstIdx)
+      const nextIdx = getNextCarousel()
+      setAmbientActiveIndex(nextIdx)
       setAmbientTrigger(prev => prev + 1)
+    }
 
-      // Rotate to a new carousel every 3.5 seconds
-      ambientIntervalRef.current = setInterval(() => {
-        // Skip rotation if gallery is open (check ref, not state)
-        if (isGalleryOpenRef.current) return
-
-        const nextIdx = getNextCarousel()
-        setAmbientActiveIndex(nextIdx)
-        setAmbientTrigger(prev => prev + 1)
-      }, 3500)
+    const startDelay = setTimeout(() => {
+      advanceAmbientCarousel()
+      ambientIntervalRef.current = setInterval(advanceAmbientCarousel, 3500)
     }, 2000)
 
     return () => {
@@ -218,8 +212,7 @@ export default () => {
       url={profileURL || `https://www.instagram.com/${metadata?.widgets?.instagram?.username || 'instagram'}`}
       isLoading={isLoading}
     >
-      Visit Profile
-      <span className='read-more-icon'>&rarr;</span>
+      Visit Profile <span className='read-more-icon'>&rarr;</span>
     </CallToAction>
   )
 
@@ -350,6 +343,32 @@ export default () => {
     [dynamicEl]
   )
 
+  let instagramPaginationFooter = null
+  if (isLoading) {
+    instagramPaginationFooter = (
+      <Box sx={{ my: 4, textAlign: 'center' }} aria-hidden>
+        <Box
+          sx={{
+            display: 'inline-block',
+            height: '44px',
+            minWidth: '140px',
+            borderRadius: '8px',
+            bg: darkModeActive ? 'gray.8' : 'gray.2',
+            opacity: 0.5
+          }}
+        />
+      </Box>
+    )
+  } else if (media?.length > MAX_IMAGES.default) {
+    instagramPaginationFooter = (
+      <Box sx={{ my: 4, textAlign: 'center' }}>
+        <ActionButton size='large' onClick={() => setIsShowingMore(!isShowingMore)}>
+          {isShowingMore ? 'Show Less' : 'Show More'}
+        </ActionButton>
+      </Box>
+    )
+  }
+
   return (
     <Widget id='instagram' hasFatalError={hasFatalError}>
       <WidgetHeader aside={callToAction} icon={faInstagram} metrics={metrics} metricsLoading={isLoading}>
@@ -397,27 +416,7 @@ export default () => {
         </Grid>
       </div>
 
-      {/* Reserve space for Show More when loading; show button when loaded and > 8 items */}
-      {isLoading ? (
-        <div sx={{ my: 4, textAlign: 'center' }} aria-hidden>
-          <div
-            sx={{
-              display: 'inline-block',
-              height: '44px',
-              minWidth: '140px',
-              borderRadius: '8px',
-              bg: darkModeActive ? 'gray.8' : 'gray.2',
-              opacity: 0.5
-            }}
-          />
-        </div>
-      ) : media?.length > MAX_IMAGES.default ? (
-        <div sx={{ my: 4, textAlign: 'center' }}>
-          <ActionButton size='large' onClick={() => setIsShowingMore(!isShowingMore)}>
-            {isShowingMore ? 'Show Less' : 'Show More'}
-          </ActionButton>
-        </div>
-      ) : null}
+      {instagramPaginationFooter}
 
       {dynamicEl.length > 0 && (
         <LightGallery

--- a/theme/src/components/widgets/recent-posts/__snapshots__/post-card.spec.js.snap
+++ b/theme/src/components/widgets/recent-posts/__snapshots__/post-card.spec.js.snap
@@ -10,25 +10,25 @@ exports[`PostCard does not render excerpt when explicitly null 1`] = `
       class="css-139dwiw"
     >
       <div
-        class="card-content css-7ttn8j"
+        class="card-content css-oo4jri"
       >
         <div
-          class="card-media css-1usooy4"
+          class="card-media css-14iwub6"
         >
           <div
-            class="css-1kkguim"
+            class="css-mxuynl"
           />
         </div>
         <div
-          class="css-2wrb05"
+          class="css-12mgl9k"
         >
           <h3
-            class="css-10lfs8r"
+            class="css-13fdzae"
           >
             My Blog Post
           </h3>
           <div
-            class="css-1c1541m"
+            class="css-1dq94w2"
           >
             <div
               class="css-hizx0c"
@@ -36,12 +36,12 @@ exports[`PostCard does not render excerpt when explicitly null 1`] = `
               Personal
             </div>
             <span
-              class="css-1vjle4a"
+              class="css-1dmnekb"
             >
               •
             </span>
             <time
-              class="created css-4np19s"
+              class="created css-neecgt"
             >
               1592202624
             </time>
@@ -63,25 +63,25 @@ exports[`PostCard does not render excerpt when explicitly undefined 1`] = `
       class="css-139dwiw"
     >
       <div
-        class="card-content css-7ttn8j"
+        class="card-content css-oo4jri"
       >
         <div
-          class="card-media css-1usooy4"
+          class="card-media css-14iwub6"
         >
           <div
-            class="css-1kkguim"
+            class="css-mxuynl"
           />
         </div>
         <div
-          class="css-2wrb05"
+          class="css-12mgl9k"
         >
           <h3
-            class="css-10lfs8r"
+            class="css-13fdzae"
           >
             My Blog Post
           </h3>
           <div
-            class="css-1c1541m"
+            class="css-1dq94w2"
           >
             <div
               class="css-hizx0c"
@@ -89,12 +89,12 @@ exports[`PostCard does not render excerpt when explicitly undefined 1`] = `
               Personal
             </div>
             <span
-              class="css-1vjle4a"
+              class="css-1dmnekb"
             >
               •
             </span>
             <time
-              class="created css-4np19s"
+              class="created css-neecgt"
             >
               1592202624
             </time>
@@ -116,25 +116,25 @@ exports[`PostCard matches the snapshot without excerpt 1`] = `
       class="css-139dwiw"
     >
       <div
-        class="card-content css-7ttn8j"
+        class="card-content css-oo4jri"
       >
         <div
-          class="card-media css-1usooy4"
+          class="card-media css-14iwub6"
         >
           <div
-            class="css-1kkguim"
+            class="css-mxuynl"
           />
         </div>
         <div
-          class="css-2wrb05"
+          class="css-12mgl9k"
         >
           <h3
-            class="css-10lfs8r"
+            class="css-13fdzae"
           >
             My Blog Post
           </h3>
           <div
-            class="css-1c1541m"
+            class="css-1dq94w2"
           >
             <div
               class="css-hizx0c"
@@ -142,12 +142,12 @@ exports[`PostCard matches the snapshot without excerpt 1`] = `
               Personal
             </div>
             <span
-              class="css-1vjle4a"
+              class="css-1dmnekb"
             >
               •
             </span>
             <time
-              class="created css-4np19s"
+              class="created css-neecgt"
             >
               1592202624
             </time>
@@ -162,29 +162,29 @@ exports[`PostCard matches the snapshot without excerpt 1`] = `
 exports[`PostCard renders SoundCloud embed when soundcloudId is provided 1`] = `
 <DocumentFragment>
   <div
-    class="css-19u1k6h"
+    class="css-m0buio"
   >
     <div
       class="css-11wrqrg"
     >
       <div
-        class="card-content css-7ttn8j"
+        class="card-content css-oo4jri"
       >
         <div
-          class="css-2wrb05"
+          class="css-12mgl9k"
         >
           <a
             class="css-r3e7ui"
             href="/music/a-house-is-not-a-home"
           >
             <h3
-              class="css-u4a60g"
+              class="css-6c2j1y"
             >
               A House Is Not A Home
             </h3>
           </a>
           <div
-            class="css-1wohmj5"
+            class="css-rh6fb4"
           >
             <div
               class="css-hizx0c"
@@ -192,23 +192,23 @@ exports[`PostCard renders SoundCloud embed when soundcloudId is provided 1`] = `
               Music
             </div>
             <span
-              class="css-1vjle4a"
+              class="css-1dmnekb"
             >
               •
             </span>
             <time
-              class="created css-4np19s"
+              class="created css-neecgt"
             >
               2024-05-12
             </time>
           </div>
         </div>
         <div
-          class="card-soundcloud css-12ixrq5"
+          class="card-soundcloud css-pdxy6l"
         >
           <iframe
             allow="autoplay"
-            class="css-1ak6ou3"
+            class="css-1avfx13"
             frameborder="no"
             scrolling="no"
             src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/1820395353&color=%23ff5500&auto_play=false&hide_related=true&show_comments=false&show_user=true&show_reposts=false&show_teaser=false"
@@ -225,29 +225,29 @@ exports[`PostCard renders SoundCloud embed when soundcloudId is provided 1`] = `
 exports[`PostCard renders YouTube embed when youtubeSrc is provided 1`] = `
 <DocumentFragment>
   <div
-    class="css-19u1k6h"
+    class="css-m0buio"
   >
     <div
       class="css-11wrqrg"
     >
       <div
-        class="card-content css-7ttn8j"
+        class="card-content css-oo4jri"
       >
         <div
-          class="css-2wrb05"
+          class="css-12mgl9k"
         >
           <a
             class="css-r3e7ui"
             href="/music/here-and-now"
           >
             <h3
-              class="css-u4a60g"
+              class="css-6c2j1y"
             >
               Here and Now
             </h3>
           </a>
           <div
-            class="css-1wohmj5"
+            class="css-rh6fb4"
           >
             <div
               class="css-hizx0c"
@@ -255,19 +255,19 @@ exports[`PostCard renders YouTube embed when youtubeSrc is provided 1`] = `
               Music
             </div>
             <span
-              class="css-1vjle4a"
+              class="css-1dmnekb"
             >
               •
             </span>
             <time
-              class="created css-4np19s"
+              class="created css-neecgt"
             >
               2025-06-19
             </time>
           </div>
         </div>
         <div
-          class="card-youtube css-tncxj7"
+          class="card-youtube css-1i0uxcs"
         >
           <div
             class="youtube-mock"
@@ -290,29 +290,29 @@ exports[`PostCard renders YouTube embed when youtubeSrc is provided 1`] = `
 exports[`PostCard renders YouTube embed with horizontal layout when both props are provided 1`] = `
 <DocumentFragment>
   <div
-    class="css-19u1k6h"
+    class="css-m0buio"
   >
     <div
       class="css-11wrqrg"
     >
       <div
-        class="card-content css-7ttn8j"
+        class="card-content css-oo4jri"
       >
         <div
-          class="css-2wrb05"
+          class="css-12mgl9k"
         >
           <a
             class="css-r3e7ui"
             href="/music/here-and-now"
           >
             <h3
-              class="css-2ctqs3"
+              class="css-1lycjq0"
             >
               Here and Now
             </h3>
           </a>
           <div
-            class="css-1wohmj5"
+            class="css-rh6fb4"
           >
             <div
               class="css-hizx0c"
@@ -320,19 +320,19 @@ exports[`PostCard renders YouTube embed with horizontal layout when both props a
               Music
             </div>
             <span
-              class="css-1vjle4a"
+              class="css-1dmnekb"
             >
               •
             </span>
             <time
-              class="created css-4np19s"
+              class="created css-neecgt"
             >
               2025-06-19
             </time>
           </div>
         </div>
         <div
-          class="card-youtube css-tncxj7"
+          class="card-youtube css-1i0uxcs"
         >
           <div
             class="youtube-mock"
@@ -362,25 +362,25 @@ exports[`PostCard renders as image-only recap when isRecap prop is true 1`] = `
       class="css-139dwiw"
     >
       <div
-        class="card-content css-7ttn8j"
+        class="card-content css-oo4jri"
       >
         <div
-          class="card-media css-1usooy4"
+          class="card-media css-14iwub6"
         >
           <div
-            class="css-1kkguim"
+            class="css-mxuynl"
           />
         </div>
         <div
-          class="css-2wrb05"
+          class="css-12mgl9k"
         >
           <h3
-            class="css-10lfs8r"
+            class="css-13fdzae"
           >
             My Blog Post
           </h3>
           <div
-            class="css-1c1541m"
+            class="css-1dq94w2"
           >
             <div
               class="css-hizx0c"
@@ -388,12 +388,12 @@ exports[`PostCard renders as image-only recap when isRecap prop is true 1`] = `
               Personal
             </div>
             <span
-              class="css-1vjle4a"
+              class="css-1dmnekb"
             >
               •
             </span>
             <time
-              class="created css-4np19s"
+              class="created css-neecgt"
             >
               1592202624
             </time>
@@ -415,25 +415,25 @@ exports[`PostCard renders banner when thumbnails array is empty 1`] = `
       class="css-139dwiw"
     >
       <div
-        class="card-content css-7ttn8j"
+        class="card-content css-oo4jri"
       >
         <div
-          class="card-media css-1usooy4"
+          class="card-media css-14iwub6"
         >
           <div
-            class="css-1kkguim"
+            class="css-mxuynl"
           />
         </div>
         <div
-          class="css-2wrb05"
+          class="css-12mgl9k"
         >
           <h3
-            class="css-10lfs8r"
+            class="css-13fdzae"
           >
             My Blog Post
           </h3>
           <div
-            class="css-1c1541m"
+            class="css-1dq94w2"
           >
             <div
               class="css-hizx0c"
@@ -441,12 +441,12 @@ exports[`PostCard renders banner when thumbnails array is empty 1`] = `
               Personal
             </div>
             <span
-              class="css-1vjle4a"
+              class="css-1dmnekb"
             >
               •
             </span>
             <time
-              class="created css-4np19s"
+              class="created css-neecgt"
             >
               1592202624
             </time>
@@ -468,25 +468,25 @@ exports[`PostCard renders banner when thumbnails is null 1`] = `
       class="css-139dwiw"
     >
       <div
-        class="card-content css-7ttn8j"
+        class="card-content css-oo4jri"
       >
         <div
-          class="card-media css-1usooy4"
+          class="card-media css-14iwub6"
         >
           <div
-            class="css-1kkguim"
+            class="css-mxuynl"
           />
         </div>
         <div
-          class="css-2wrb05"
+          class="css-12mgl9k"
         >
           <h3
-            class="css-10lfs8r"
+            class="css-13fdzae"
           >
             My Blog Post
           </h3>
           <div
-            class="css-1c1541m"
+            class="css-1dq94w2"
           >
             <div
               class="css-hizx0c"
@@ -494,12 +494,12 @@ exports[`PostCard renders banner when thumbnails is null 1`] = `
               Personal
             </div>
             <span
-              class="css-1vjle4a"
+              class="css-1dmnekb"
             >
               •
             </span>
             <time
-              class="created css-4np19s"
+              class="created css-neecgt"
             >
               1592202624
             </time>
@@ -521,25 +521,25 @@ exports[`PostCard renders excerpt when provided 1`] = `
       class="css-139dwiw"
     >
       <div
-        class="card-content css-7ttn8j"
+        class="card-content css-oo4jri"
       >
         <div
-          class="card-media css-1usooy4"
+          class="card-media css-14iwub6"
         >
           <div
-            class="css-1kkguim"
+            class="css-mxuynl"
           />
         </div>
         <div
-          class="css-2wrb05"
+          class="css-12mgl9k"
         >
           <h3
-            class="css-10lfs8r"
+            class="css-13fdzae"
           >
             My Blog Post
           </h3>
           <div
-            class="css-1wohmj5"
+            class="css-rh6fb4"
           >
             <div
               class="css-hizx0c"
@@ -547,18 +547,18 @@ exports[`PostCard renders excerpt when provided 1`] = `
               Personal
             </div>
             <span
-              class="css-1vjle4a"
+              class="css-1dmnekb"
             >
               •
             </span>
             <time
-              class="created css-4np19s"
+              class="created css-neecgt"
             >
               1592202624
             </time>
           </div>
           <p
-            class="description css-1w28v9e"
+            class="description css-1dabzen"
           >
             This is a sample excerpt for the blog post.
           </p>
@@ -579,23 +579,23 @@ exports[`PostCard renders in horizontal layout when horizontal prop is true 1`] 
       class="css-139dwiw"
     >
       <div
-        class="card-content css-7ttn8j"
+        class="card-content css-oo4jri"
       >
         <div
-          class="css-ca6t5a"
+          class="css-10o3rp4"
         >
           <h3
-            class="css-1ndafw1"
+            class="css-dut502"
           >
             My Blog Post
           </h3>
           <div
             aria-hidden="true"
-            class="card-headline-preview css-iq27yv"
+            class="card-headline-preview css-5q7tak"
           />
         </div>
         <div
-          class="css-1c1541m"
+          class="css-1dq94w2"
         >
           <div
             class="css-hizx0c"
@@ -603,12 +603,12 @@ exports[`PostCard renders in horizontal layout when horizontal prop is true 1`] 
             Personal
           </div>
           <span
-            class="css-1vjle4a"
+            class="css-1dmnekb"
           >
             •
           </span>
           <time
-            class="created css-4np19s"
+            class="created css-neecgt"
           >
             1592202624
           </time>
@@ -629,18 +629,18 @@ exports[`PostCard renders neither banner nor thumbnails when both are missing 1`
       class="css-139dwiw"
     >
       <div
-        class="card-content css-7ttn8j"
+        class="card-content css-oo4jri"
       >
         <div
-          class="css-2wrb05"
+          class="css-12mgl9k"
         >
           <h3
-            class="css-10lfs8r"
+            class="css-13fdzae"
           >
             My Blog Post
           </h3>
           <div
-            class="css-1c1541m"
+            class="css-1dq94w2"
           >
             <div
               class="css-hizx0c"
@@ -648,12 +648,12 @@ exports[`PostCard renders neither banner nor thumbnails when both are missing 1`
               Personal
             </div>
             <span
-              class="css-1vjle4a"
+              class="css-1dmnekb"
             >
               •
             </span>
             <time
-              class="created css-4np19s"
+              class="created css-neecgt"
             >
               1592202624
             </time>
@@ -675,10 +675,10 @@ exports[`PostCard renders thumbnails instead of banner when thumbnails are provi
       class="css-139dwiw"
     >
       <div
-        class="card-content css-7ttn8j"
+        class="card-content css-oo4jri"
       >
         <div
-          class="card-thumbnails css-1usooy4"
+          class="card-thumbnails css-14iwub6"
         >
           <div
             class="css-1ud2rd2"
@@ -714,15 +714,15 @@ exports[`PostCard renders thumbnails instead of banner when thumbnails are provi
           </div>
         </div>
         <div
-          class="css-2wrb05"
+          class="css-12mgl9k"
         >
           <h3
-            class="css-10lfs8r"
+            class="css-13fdzae"
           >
             My Blog Post
           </h3>
           <div
-            class="css-1c1541m"
+            class="css-1dq94w2"
           >
             <div
               class="css-hizx0c"
@@ -730,12 +730,12 @@ exports[`PostCard renders thumbnails instead of banner when thumbnails are provi
               Personal
             </div>
             <span
-              class="css-1vjle4a"
+              class="css-1dmnekb"
             >
               •
             </span>
             <time
-              class="created css-4np19s"
+              class="created css-neecgt"
             >
               1592202624
             </time>
@@ -757,18 +757,18 @@ exports[`PostCard renders without banner when not provided 1`] = `
       class="css-139dwiw"
     >
       <div
-        class="card-content css-7ttn8j"
+        class="card-content css-oo4jri"
       >
         <div
-          class="css-2wrb05"
+          class="css-12mgl9k"
         >
           <h3
-            class="css-10lfs8r"
+            class="css-13fdzae"
           >
             My Blog Post
           </h3>
           <div
-            class="css-1c1541m"
+            class="css-1dq94w2"
           >
             <div
               class="css-hizx0c"
@@ -776,12 +776,12 @@ exports[`PostCard renders without banner when not provided 1`] = `
               Personal
             </div>
             <span
-              class="css-1vjle4a"
+              class="css-1dmnekb"
             >
               •
             </span>
             <time
-              class="created css-4np19s"
+              class="created css-neecgt"
             >
               1592202624
             </time>
@@ -803,28 +803,28 @@ exports[`PostCard renders without category when not provided 1`] = `
       class="css-139dwiw"
     >
       <div
-        class="card-content css-7ttn8j"
+        class="card-content css-oo4jri"
       >
         <div
-          class="card-media css-1usooy4"
+          class="card-media css-14iwub6"
         >
           <div
-            class="css-1kkguim"
+            class="css-mxuynl"
           />
         </div>
         <div
-          class="css-2wrb05"
+          class="css-12mgl9k"
         >
           <h3
-            class="css-10lfs8r"
+            class="css-13fdzae"
           >
             My Blog Post
           </h3>
           <div
-            class="css-1c1541m"
+            class="css-1dq94w2"
           >
             <time
-              class="created css-4np19s"
+              class="created css-neecgt"
             >
               1592202624
             </time>
@@ -846,23 +846,23 @@ exports[`PostCard uses first thumbnail as left preview in horizontal mode (no th
       class="css-139dwiw"
     >
       <div
-        class="card-content css-7ttn8j"
+        class="card-content css-oo4jri"
       >
         <div
-          class="css-ca6t5a"
+          class="css-10o3rp4"
         >
           <h3
-            class="css-1ndafw1"
+            class="css-dut502"
           >
             My Blog Post
           </h3>
           <div
             aria-hidden="true"
-            class="card-headline-preview css-cc19g2"
+            class="card-headline-preview css-13mmkmj"
           />
         </div>
         <div
-          class="css-1c1541m"
+          class="css-1dq94w2"
         >
           <div
             class="css-hizx0c"
@@ -870,12 +870,12 @@ exports[`PostCard uses first thumbnail as left preview in horizontal mode (no th
             Personal
           </div>
           <span
-            class="css-1vjle4a"
+            class="css-1dmnekb"
           >
             •
           </span>
           <time
-            class="created css-4np19s"
+            class="created css-neecgt"
           >
             1592202624
           </time>

--- a/theme/src/components/widgets/recent-posts/post-card.js
+++ b/theme/src/components/widgets/recent-posts/post-card.js
@@ -1,8 +1,7 @@
 /** @jsx jsx */
 import React, { Fragment } from 'react'
-import { jsx } from 'theme-ui'
-import { Themed } from '@theme-ui/mdx'
-import { Card } from '@theme-ui/components'
+import { jsx, Box as ThemeBox } from 'theme-ui'
+import { Heading, Card } from '@theme-ui/components'
 import { Link } from 'gatsby'
 import Category from '../../category'
 import ImageThumbnails from './image-thumbnails'
@@ -40,27 +39,24 @@ const getHorizontalPreviewUrl = (banner, thumbnails) => {
   return null
 }
 
-export default ({
+/** Card body extracted from wrapper so definitions are stable across renders */
+function PostCardInner({
   banner,
   category,
   date,
   excerpt,
   link,
   title,
-  horizontal = false,
-  thumbnails = null,
-  youtubeSrc = null,
-  soundcloudId = null
-}) => {
-  const videoId = getYouTubeVideoId(youtubeSrc)
-  const hasYouTube = !!videoId
-  const hasSoundCloud = !!soundcloudId
-  const hasMediaEmbed = hasYouTube || hasSoundCloud
-
-  const horizontalPreviewUrl = horizontal && !hasMediaEmbed ? getHorizontalPreviewUrl(banner, thumbnails) : null
-
-  // Card content without wrapper - used when YouTube embed is present
-  const CardContent = () => (
+  horizontal,
+  thumbnails,
+  youtubeSrc,
+  soundcloudId,
+  hasMediaEmbed,
+  hasSoundCloud,
+  hasYouTube,
+  horizontalPreviewUrl
+}) {
+  return (
     <Card
       variant='actionCard'
       sx={{
@@ -73,15 +69,9 @@ export default ({
         }
       }}
     >
-      <div
+      <ThemeBox
         className='card-content'
-        sx={{
-          display: 'flex',
-          flexDirection: 'column',
-          width: '100%',
-          height: '100%',
-          flex: 1
-        }}
+        sx={{ display: 'flex', flexDirection: 'column', width: '100%', height: '100%', flex: 1 }}
       >
         {/* Horizontal index: text-first; small image floats left in headline row */}
         {horizontal && !hasMediaEmbed && (
@@ -102,15 +92,15 @@ export default ({
           <Fragment>
             {/* Show thumbnails above text for vertical cards (Recaps) */}
             {thumbnails && thumbnails.length > 0 && (
-              <div className='card-thumbnails' sx={{ flexShrink: 0, mb: 2 }}>
+              <ThemeBox className='card-thumbnails' sx={{ flexShrink: 0, mb: 2 }}>
                 <ImageThumbnails images={thumbnails} maxImages={4} />
-              </div>
+              </ThemeBox>
             )}
 
             {/* Show banner for posts without thumbnails and no media embed */}
             {banner && (!thumbnails || thumbnails.length === 0) && !hasMediaEmbed && (
-              <div className='card-media' sx={{ flexShrink: 0, mb: 2 }}>
-                <div
+              <ThemeBox className='card-media' sx={{ flexShrink: 0, mb: 2 }}>
+                <ThemeBox
                   sx={{
                     backgroundImage: `url(${banner})`,
                     backgroundPosition: 'center',
@@ -123,10 +113,10 @@ export default ({
                     transition: 'all 2.5s ease'
                   }}
                 />
-              </div>
+              </ThemeBox>
             )}
 
-            <div sx={{ flexShrink: 0 }}>
+            <ThemeBox sx={{ flexShrink: 0 }}>
               <HorizontalTextBlock
                 category={category}
                 date={date}
@@ -137,13 +127,13 @@ export default ({
                 link={link}
                 title={title}
               />
-            </div>
+            </ThemeBox>
           </Fragment>
         )}
 
         {/* Horizontal: media embeds stay full-width below the row */}
         {horizontal && hasMediaEmbed && (
-          <div sx={{ flexShrink: 0 }}>
+          <ThemeBox sx={{ flexShrink: 0 }}>
             <HorizontalTextBlock
               category={category}
               date={date}
@@ -154,18 +144,12 @@ export default ({
               link={link}
               title={title}
             />
-          </div>
+          </ThemeBox>
         )}
 
         {/* YouTube embed */}
         {hasYouTube && (
-          <div
-            className='card-youtube'
-            sx={{
-              marginTop: 'auto',
-              width: '100%'
-            }}
-          >
+          <ThemeBox className='card-youtube' sx={{ marginTop: 'auto', width: '100%' }}>
             <YouTube
               compact
               title={title}
@@ -177,12 +161,12 @@ export default ({
                 boxShadow: '0 2px 8px rgba(0, 0, 0, 0.15)'
               }}
             />
-          </div>
+          </ThemeBox>
         )}
 
         {/* SoundCloud embed */}
         {hasSoundCloud && (
-          <div
+          <ThemeBox
             className='card-soundcloud'
             sx={{
               display: 'flex',
@@ -195,7 +179,8 @@ export default ({
               marginTop: 'auto'
             }}
           >
-            <iframe
+            <ThemeBox
+              as='iframe'
               width='100%'
               scrolling='no'
               frameBorder='no'
@@ -209,40 +194,10 @@ export default ({
                 minHeight: '166px'
               }}
             />
-          </div>
+          </ThemeBox>
         )}
-      </div>
+      </ThemeBox>
     </Card>
-  )
-
-  // If media embed is present, don't wrap the whole card in a link
-  if (hasMediaEmbed) {
-    return (
-      <div
-        sx={{
-          display: 'flex',
-          height: '100%',
-          color: 'var(--theme-ui-colors-panel-text)'
-        }}
-      >
-        <CardContent />
-      </div>
-    )
-  }
-
-  // Standard card wrapped in link
-  return (
-    <Link
-      sx={{
-        display: 'flex',
-        height: '100%',
-        color: 'var(--theme-ui-colors-panel-text)',
-        textDecoration: 'none'
-      }}
-      to={link}
-    >
-      <CardContent />
-    </Link>
   )
 }
 
@@ -258,24 +213,37 @@ const HorizontalTextBlock = ({
 }) => {
   const showHeadlineWithPreview = horizontal && !hasMediaEmbed && headlinePreviewUrl
 
-  const titleHeading = (
-    <Themed.h3
-      sx={{
-        mt: 0,
-        mb: 0,
-        fontFamily: 'serif',
-        fontSize: horizontal ? 2 : 3,
-        lineHeight: 1.35,
-        transition: hasMediaEmbed ? 'color 0.2s ease' : undefined
-      }}
-    >
-      {title}
-    </Themed.h3>
-  )
+  const mediaTitleHeadingSx = {
+    mt: 0,
+    mb: 0,
+    fontFamily: 'serif',
+    fontSize: horizontal ? 2 : 3,
+    lineHeight: 1.35,
+    ...(hasMediaEmbed ? { transition: 'color 0.2s ease' } : {})
+  }
 
-  return (
-    <>
-      {hasMediaEmbed ? (
+  const inlinePreviewHeadingSx = {
+    flex: '1 1 0',
+    minWidth: 0,
+    mt: 0,
+    mb: 0,
+    fontFamily: 'serif',
+    fontSize: 2,
+    lineHeight: 1.35,
+    textAlign: 'left'
+  }
+
+  const defaultHeadingSx = {
+    mt: 0,
+    mb: 2,
+    fontFamily: 'serif',
+    fontSize: horizontal ? 2 : 3,
+    lineHeight: 1.3
+  }
+
+  const headline = (() => {
+    if (hasMediaEmbed) {
+      return (
         <Link
           to={link}
           sx={{
@@ -286,10 +254,15 @@ const HorizontalTextBlock = ({
             }
           }}
         >
-          {titleHeading}
+          <Heading as='h3' sx={mediaTitleHeadingSx}>
+            {title}
+          </Heading>
         </Link>
-      ) : showHeadlineWithPreview ? (
-        <div
+      )
+    }
+    if (showHeadlineWithPreview) {
+      return (
+        <ThemeBox
           sx={{
             display: 'flex',
             flexDirection: 'row',
@@ -298,21 +271,10 @@ const HorizontalTextBlock = ({
             mb: 2
           }}
         >
-          <Themed.h3
-            sx={{
-              flex: '1 1 0',
-              minWidth: 0,
-              mt: 0,
-              mb: 0,
-              fontFamily: 'serif',
-              fontSize: 2,
-              lineHeight: 1.35,
-              textAlign: 'left'
-            }}
-          >
+          <Heading as='h3' sx={inlinePreviewHeadingSx}>
             {title}
-          </Themed.h3>
-          <div
+          </Heading>
+          <ThemeBox
             aria-hidden
             className='card-headline-preview'
             sx={{
@@ -330,23 +292,22 @@ const HorizontalTextBlock = ({
               boxShadow: '0 1px 3px rgba(0, 0, 0, 0.08)'
             }}
           />
-        </div>
-      ) : (
-        <Themed.h3
-          sx={{
-            mt: 0,
-            mb: 2,
-            fontFamily: 'serif',
-            fontSize: horizontal ? 2 : 3,
-            lineHeight: 1.3
-          }}
-        >
-          {title}
-        </Themed.h3>
-      )}
+        </ThemeBox>
+      )
+    }
+    return (
+      <Heading as='h3' sx={defaultHeadingSx}>
+        {title}
+      </Heading>
+    )
+  })()
+
+  return (
+    <>
+      {headline}
 
       {(category || date) && (
-        <div
+        <ThemeBox
           sx={{
             display: 'flex',
             alignItems: 'center',
@@ -357,33 +318,21 @@ const HorizontalTextBlock = ({
         >
           {category && <Category type={category} />}
           {category && date && (
-            <span
-              sx={{
-                color: 'textMuted',
-                fontSize: 0,
-                opacity: 0.5
-              }}
-            >
+            <ThemeBox as='span' sx={{ color: 'textMuted', fontSize: 0, opacity: 0.5 }}>
               •
-            </span>
+            </ThemeBox>
           )}
           {date && (
-            <time
-              className='created'
-              sx={{
-                color: 'textMuted',
-                fontFamily: 'sans',
-                fontSize: 0
-              }}
-            >
+            <ThemeBox as='time' className='created' sx={{ color: 'textMuted', fontFamily: 'sans', fontSize: 0 }}>
               {date}
-            </time>
+            </ThemeBox>
           )}
-        </div>
+        </ThemeBox>
       )}
 
       {excerpt && !hasMediaEmbed && (
-        <p
+        <ThemeBox
+          as='p'
           className='description'
           sx={{
             mt: 0,
@@ -394,8 +343,63 @@ const HorizontalTextBlock = ({
           }}
         >
           {excerpt}
-        </p>
+        </ThemeBox>
       )}
     </>
+  )
+}
+
+export default ({
+  banner,
+  category,
+  date,
+  excerpt,
+  link,
+  title,
+  horizontal = false,
+  thumbnails = null,
+  youtubeSrc = null,
+  soundcloudId = null
+}) => {
+  const videoId = getYouTubeVideoId(youtubeSrc)
+  const hasYouTube = !!videoId
+  const hasSoundCloud = !!soundcloudId
+  const hasMediaEmbed = hasYouTube || hasSoundCloud
+
+  const horizontalPreviewUrl = horizontal && !hasMediaEmbed ? getHorizontalPreviewUrl(banner, thumbnails) : null
+
+  const innerProps = {
+    banner,
+    category,
+    date,
+    excerpt,
+    horizontal,
+    link,
+    title,
+    thumbnails,
+    youtubeSrc,
+    soundcloudId,
+    hasSoundCloud,
+    hasMediaEmbed,
+    hasYouTube,
+    horizontalPreviewUrl
+  }
+
+  const outerSx = { display: 'flex', height: '100%', color: 'var(--theme-ui-colors-panel-text)' }
+
+  // If media embed is present, don't wrap the whole card in a link
+  if (hasMediaEmbed) {
+    return (
+      <ThemeBox sx={outerSx}>
+        <PostCardInner {...innerProps} />
+      </ThemeBox>
+    )
+  }
+
+  // Standard card wrapped in link
+  return (
+    <Link sx={{ ...outerSx, textDecoration: 'none' }} to={link}>
+      <PostCardInner {...innerProps} />
+    </Link>
   )
 }

--- a/theme/src/components/widgets/recent-posts/post-card.js
+++ b/theme/src/components/widgets/recent-posts/post-card.js
@@ -1,5 +1,6 @@
 /** @jsx jsx */
 import React, { Fragment } from 'react'
+import PropTypes from 'prop-types'
 import { jsx, Box as ThemeBox } from 'theme-ui'
 import { Heading, Card } from '@theme-ui/components'
 import { Link } from 'gatsby'
@@ -26,6 +27,12 @@ export const buildYouTubeEmbedUrl = url => {
   const separator = url.includes('?') ? '&' : '?'
   return `${url}${separator}rel=0&modestbranding=1`
 }
+
+const nullableString = PropTypes.oneOfType([PropTypes.string, PropTypes.oneOf([null])])
+
+const thumbnailsPropType = PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.string), PropTypes.oneOf([null])])
+
+const previewUrlPropType = PropTypes.oneOfType([PropTypes.string, PropTypes.oneOf([null])])
 
 /** Small float beside headline — wide crop matches OG / banner art */
 const HORIZONTAL_PREVIEW_ASPECT = '1.9 / 1'
@@ -201,6 +208,23 @@ function PostCardInner({
   )
 }
 
+PostCardInner.propTypes = {
+  banner: nullableString,
+  category: PropTypes.string,
+  date: PropTypes.string,
+  excerpt: nullableString,
+  horizontal: PropTypes.bool.isRequired,
+  hasMediaEmbed: PropTypes.bool.isRequired,
+  hasSoundCloud: PropTypes.bool.isRequired,
+  hasYouTube: PropTypes.bool.isRequired,
+  horizontalPreviewUrl: previewUrlPropType,
+  link: PropTypes.string.isRequired,
+  soundcloudId: nullableString,
+  thumbnails: thumbnailsPropType,
+  title: PropTypes.string.isRequired,
+  youtubeSrc: nullableString
+}
+
 const HorizontalTextBlock = ({
   category,
   date,
@@ -349,7 +373,18 @@ const HorizontalTextBlock = ({
   )
 }
 
-export default ({
+HorizontalTextBlock.propTypes = {
+  category: PropTypes.string,
+  date: PropTypes.string,
+  excerpt: nullableString,
+  hasMediaEmbed: PropTypes.bool.isRequired,
+  headlinePreviewUrl: previewUrlPropType,
+  horizontal: PropTypes.bool.isRequired,
+  link: PropTypes.string.isRequired,
+  title: PropTypes.string.isRequired
+}
+
+const PostCard = ({
   banner,
   category,
   date,
@@ -403,3 +438,19 @@ export default ({
     </Link>
   )
 }
+
+PostCard.propTypes = {
+  banner: nullableString,
+  category: PropTypes.string,
+  date: PropTypes.string,
+  excerpt: nullableString,
+  horizontal: PropTypes.bool,
+  isRecap: PropTypes.bool,
+  link: PropTypes.string.isRequired,
+  soundcloudId: nullableString,
+  thumbnails: thumbnailsPropType,
+  title: PropTypes.string.isRequired,
+  youtubeSrc: nullableString
+}
+
+export default PostCard

--- a/theme/src/components/widgets/recent-posts/recent-posts-widget.js
+++ b/theme/src/components/widgets/recent-posts/recent-posts-widget.js
@@ -55,8 +55,7 @@ export default () => {
 
   const callToAction = (
     <CallToAction title='Browse all published content' to='/blog'>
-      Browse All
-      <span className='read-more-icon'>&rarr;</span>
+      Browse All <span className='read-more-icon'>&rarr;</span>
     </CallToAction>
   )
 
@@ -75,7 +74,7 @@ export default () => {
         Latest Posts
       </WidgetHeader>
 
-      <div sx={{ width: '100%', mt: 4 }}>
+      <Box sx={{ width: '100%', mt: 4 }}>
         {/* Latest Recaps Section */}
         {postsBySection.recaps && postsBySection.recaps.length > 0 && (
           <Box sx={{ mb: 4 }}>
@@ -188,7 +187,7 @@ export default () => {
             )}
           </Box>
         )}
-      </div>
+      </Box>
     </Widget>
   )
 }

--- a/theme/src/components/widgets/spotify/__snapshots__/media-item-grid.spec.js.snap
+++ b/theme/src/components/widgets/spotify/__snapshots__/media-item-grid.spec.js.snap
@@ -3,7 +3,7 @@
 exports[`MediaItemGrid matches loading state snapshot 1`] = `
 <DocumentFragment>
   <div
-    class="media-item_grid null css-4004kc"
+    class="media-item_grid null css-uoa9w6"
   >
     <a
       class="media-item_media css-1bdhn1b"
@@ -11,7 +11,7 @@ exports[`MediaItemGrid matches loading state snapshot 1`] = `
       title="Item #1"
     >
       <div
-        class="css-x4b07x"
+        class="css-pcble3"
       >
         <div
           class="media-item_caption css-764hy0"
@@ -22,7 +22,7 @@ exports[`MediaItemGrid matches loading state snapshot 1`] = `
         </div>
         <img
           alt="cover artwork"
-          class="css-karewm"
+          class="css-526are"
           crossorigin="anonymous"
           loading="lazy"
           src="http://placekitten.com/200/200"
@@ -35,7 +35,7 @@ exports[`MediaItemGrid matches loading state snapshot 1`] = `
       title="Item #2"
     >
       <div
-        class="css-x4b07x"
+        class="css-pcble3"
       >
         <div
           class="media-item_caption css-764hy0"
@@ -46,7 +46,7 @@ exports[`MediaItemGrid matches loading state snapshot 1`] = `
         </div>
         <img
           alt="cover artwork"
-          class="css-karewm"
+          class="css-526are"
           crossorigin="anonymous"
           loading="lazy"
           src="http://placekitten.com/300/300"
@@ -60,10 +60,10 @@ exports[`MediaItemGrid matches loading state snapshot 1`] = `
 exports[`MediaItemGrid matches the ready state snapshot state 1`] = `
 <DocumentFragment>
   <div
-    class="media-item_grid null css-4004kc"
+    class="media-item_grid null css-uoa9w6"
   >
     <div
-      class="show-loading-animation"
+      class="show-loading-animation css-1yz7e9k"
     >
       <div
         class="rect-shape css-n8oxh0"
@@ -71,7 +71,7 @@ exports[`MediaItemGrid matches the ready state snapshot state 1`] = `
       />
     </div>
     <div
-      class="show-loading-animation"
+      class="show-loading-animation css-1yz7e9k"
     >
       <div
         class="rect-shape css-n8oxh0"
@@ -79,7 +79,7 @@ exports[`MediaItemGrid matches the ready state snapshot state 1`] = `
       />
     </div>
     <div
-      class="show-loading-animation"
+      class="show-loading-animation css-1yz7e9k"
     >
       <div
         class="rect-shape css-n8oxh0"
@@ -87,7 +87,7 @@ exports[`MediaItemGrid matches the ready state snapshot state 1`] = `
       />
     </div>
     <div
-      class="show-loading-animation"
+      class="show-loading-animation css-1yz7e9k"
     >
       <div
         class="rect-shape css-n8oxh0"
@@ -95,7 +95,7 @@ exports[`MediaItemGrid matches the ready state snapshot state 1`] = `
       />
     </div>
     <div
-      class="show-loading-animation"
+      class="show-loading-animation css-1yz7e9k"
     >
       <div
         class="rect-shape css-n8oxh0"
@@ -103,7 +103,7 @@ exports[`MediaItemGrid matches the ready state snapshot state 1`] = `
       />
     </div>
     <div
-      class="show-loading-animation"
+      class="show-loading-animation css-1yz7e9k"
     >
       <div
         class="rect-shape css-n8oxh0"
@@ -111,7 +111,7 @@ exports[`MediaItemGrid matches the ready state snapshot state 1`] = `
       />
     </div>
     <div
-      class="show-loading-animation"
+      class="show-loading-animation css-1yz7e9k"
     >
       <div
         class="rect-shape css-n8oxh0"
@@ -119,7 +119,7 @@ exports[`MediaItemGrid matches the ready state snapshot state 1`] = `
       />
     </div>
     <div
-      class="show-loading-animation"
+      class="show-loading-animation css-1yz7e9k"
     >
       <div
         class="rect-shape css-n8oxh0"
@@ -127,7 +127,7 @@ exports[`MediaItemGrid matches the ready state snapshot state 1`] = `
       />
     </div>
     <div
-      class="show-loading-animation"
+      class="show-loading-animation css-1yz7e9k"
     >
       <div
         class="rect-shape css-n8oxh0"
@@ -135,7 +135,7 @@ exports[`MediaItemGrid matches the ready state snapshot state 1`] = `
       />
     </div>
     <div
-      class="show-loading-animation"
+      class="show-loading-animation css-1yz7e9k"
     >
       <div
         class="rect-shape css-n8oxh0"
@@ -143,7 +143,7 @@ exports[`MediaItemGrid matches the ready state snapshot state 1`] = `
       />
     </div>
     <div
-      class="show-loading-animation"
+      class="show-loading-animation css-1yz7e9k"
     >
       <div
         class="rect-shape css-n8oxh0"
@@ -151,7 +151,7 @@ exports[`MediaItemGrid matches the ready state snapshot state 1`] = `
       />
     </div>
     <div
-      class="show-loading-animation"
+      class="show-loading-animation css-1yz7e9k"
     >
       <div
         class="rect-shape css-n8oxh0"

--- a/theme/src/components/widgets/spotify/__snapshots__/playlists.spec.js.snap
+++ b/theme/src/components/widgets/spotify/__snapshots__/playlists.spec.js.snap
@@ -2,9 +2,11 @@
 
 exports[`Playlists Component matches snapshot with various playlist scenarios 1`] = `
 <DocumentFragment>
-  <div>
+  <div
+    class="css-1yz7e9k"
+  >
     <div
-      class="css-ccroti"
+      class="css-epkbn4"
     >
       <h3
         class="css-9nh3l5"

--- a/theme/src/components/widgets/spotify/__snapshots__/spotify-widget.spec.js.snap
+++ b/theme/src/components/widgets/spotify/__snapshots__/spotify-widget.spec.js.snap
@@ -62,7 +62,7 @@ exports[`Spotify Widget matches the error state snapshot 1`] = `
             href=""
             title=" on "
           >
-            Browse Playlists
+            Browse Playlists 
             <span
               class="read-more-icon"
             >
@@ -73,10 +73,10 @@ exports[`Spotify Widget matches the error state snapshot 1`] = `
       </div>
     </header>
     <div
-      class="css-sak8bt"
+      class="css-lnnjou"
     >
       <div
-        class="css-ccroti"
+        class="css-epkbn4"
       >
         <h3
           class="css-9nh3l5"
@@ -90,27 +90,29 @@ exports[`Spotify Widget matches the error state snapshot 1`] = `
         Tracks I've played most over the last four weeks.
       </p>
       <div
-        class="css-us3dds"
+        class="css-4kg5kc"
       >
         <div
-          class="css-kdywdz"
+          class="css-vgd83x"
           data-testid="spotify-top-tracks-carousel"
         >
           <div
             aria-hidden="false"
-            class="css-4bo1uy"
+            class="css-1s44svb"
             data-testid="spotify-top-tracks-page-1"
           >
             <div
-              class="media-item_grid null css-5stlgz"
+              class="media-item_grid null css-rt3umk"
             />
           </div>
         </div>
       </div>
     </div>
-    <div>
+    <div
+      class="css-1yz7e9k"
+    >
       <div
-        class="css-ccroti"
+        class="css-epkbn4"
       >
         <h3
           class="css-9nh3l5"
@@ -124,7 +126,7 @@ exports[`Spotify Widget matches the error state snapshot 1`] = `
         My 12 favorite playlists.
       </p>
       <div
-        class="media-item_grid null css-5stlgz"
+        class="media-item_grid null css-rt3umk"
       />
     </div>
   </section>
@@ -176,7 +178,7 @@ exports[`Spotify Widget matches the loaded state snapshot 1`] = `
             href="https://spotify.com/user/test"
             title="Test User on Spotify"
           >
-            Browse Playlists
+            Browse Playlists 
             <span
               class="read-more-icon"
             >
@@ -224,10 +226,10 @@ exports[`Spotify Widget matches the loaded state snapshot 1`] = `
       &lt;p&gt;Test Spotify AI summary.&lt;/p&gt;
     </div>
     <div
-      class="css-sak8bt"
+      class="css-lnnjou"
     >
       <div
-        class="css-ccroti"
+        class="css-epkbn4"
       >
         <h3
           class="css-9nh3l5"
@@ -241,26 +243,26 @@ exports[`Spotify Widget matches the loaded state snapshot 1`] = `
         Tracks I've played most over the last four weeks.
       </p>
       <div
-        class="css-us3dds"
+        class="css-4kg5kc"
       >
         <div
-          class="css-kdywdz"
+          class="css-vgd83x"
           data-testid="spotify-top-tracks-carousel"
         >
           <div
             aria-hidden="false"
-            class="css-4bo1uy"
+            class="css-1s44svb"
             data-testid="spotify-top-tracks-page-1"
           >
             <div
-              class="media-item_grid null css-5stlgz"
+              class="media-item_grid null css-rt3umk"
             >
               <a
                 class="media-item_media css-13fusor"
                 title="Test Track – [object Object]"
               >
                 <div
-                  class="css-x4b07x"
+                  class="css-pcble3"
                 >
                   <div
                     class="media-item_caption css-e7oldi"
@@ -271,7 +273,7 @@ exports[`Spotify Widget matches the loaded state snapshot 1`] = `
                   </div>
                   <img
                     alt="cover artwork"
-                    class="css-karewm"
+                    class="css-526are"
                     crossorigin="anonymous"
                     loading="lazy"
                   />
@@ -282,9 +284,11 @@ exports[`Spotify Widget matches the loaded state snapshot 1`] = `
         </div>
       </div>
     </div>
-    <div>
+    <div
+      class="css-1yz7e9k"
+    >
       <div
-        class="css-ccroti"
+        class="css-epkbn4"
       >
         <h3
           class="css-9nh3l5"
@@ -298,7 +302,7 @@ exports[`Spotify Widget matches the loaded state snapshot 1`] = `
         My 12 favorite playlists.
       </p>
       <div
-        class="media-item_grid null css-5stlgz"
+        class="media-item_grid null css-rt3umk"
       />
     </div>
   </section>
@@ -443,10 +447,10 @@ exports[`Spotify Widget matches the loading state snapshot 1`] = `
       </div>
     </div>
     <div
-      class="css-sak8bt"
+      class="css-lnnjou"
     >
       <div
-        class="css-ccroti"
+        class="css-epkbn4"
       >
         <h3
           class="css-9nh3l5"
@@ -460,13 +464,13 @@ exports[`Spotify Widget matches the loading state snapshot 1`] = `
         Tracks I've played most over the last four weeks.
       </p>
       <div
-        class="css-us3dds"
+        class="css-4kg5kc"
       >
         <div
-          class="media-item_grid null css-5stlgz"
+          class="media-item_grid null css-rt3umk"
         >
           <div
-            class="show-loading-animation"
+            class="show-loading-animation css-1yz7e9k"
           >
             <div
               class="rect-shape css-2us3i8"
@@ -474,7 +478,7 @@ exports[`Spotify Widget matches the loading state snapshot 1`] = `
             />
           </div>
           <div
-            class="show-loading-animation"
+            class="show-loading-animation css-1yz7e9k"
           >
             <div
               class="rect-shape css-2us3i8"
@@ -482,7 +486,7 @@ exports[`Spotify Widget matches the loading state snapshot 1`] = `
             />
           </div>
           <div
-            class="show-loading-animation"
+            class="show-loading-animation css-1yz7e9k"
           >
             <div
               class="rect-shape css-2us3i8"
@@ -490,7 +494,7 @@ exports[`Spotify Widget matches the loading state snapshot 1`] = `
             />
           </div>
           <div
-            class="show-loading-animation"
+            class="show-loading-animation css-1yz7e9k"
           >
             <div
               class="rect-shape css-2us3i8"
@@ -498,7 +502,7 @@ exports[`Spotify Widget matches the loading state snapshot 1`] = `
             />
           </div>
           <div
-            class="show-loading-animation"
+            class="show-loading-animation css-1yz7e9k"
           >
             <div
               class="rect-shape css-2us3i8"
@@ -506,7 +510,7 @@ exports[`Spotify Widget matches the loading state snapshot 1`] = `
             />
           </div>
           <div
-            class="show-loading-animation"
+            class="show-loading-animation css-1yz7e9k"
           >
             <div
               class="rect-shape css-2us3i8"
@@ -514,7 +518,7 @@ exports[`Spotify Widget matches the loading state snapshot 1`] = `
             />
           </div>
           <div
-            class="show-loading-animation"
+            class="show-loading-animation css-1yz7e9k"
           >
             <div
               class="rect-shape css-2us3i8"
@@ -522,7 +526,7 @@ exports[`Spotify Widget matches the loading state snapshot 1`] = `
             />
           </div>
           <div
-            class="show-loading-animation"
+            class="show-loading-animation css-1yz7e9k"
           >
             <div
               class="rect-shape css-2us3i8"
@@ -530,7 +534,7 @@ exports[`Spotify Widget matches the loading state snapshot 1`] = `
             />
           </div>
           <div
-            class="show-loading-animation"
+            class="show-loading-animation css-1yz7e9k"
           >
             <div
               class="rect-shape css-2us3i8"
@@ -538,7 +542,7 @@ exports[`Spotify Widget matches the loading state snapshot 1`] = `
             />
           </div>
           <div
-            class="show-loading-animation"
+            class="show-loading-animation css-1yz7e9k"
           >
             <div
               class="rect-shape css-2us3i8"
@@ -546,7 +550,7 @@ exports[`Spotify Widget matches the loading state snapshot 1`] = `
             />
           </div>
           <div
-            class="show-loading-animation"
+            class="show-loading-animation css-1yz7e9k"
           >
             <div
               class="rect-shape css-2us3i8"
@@ -554,7 +558,7 @@ exports[`Spotify Widget matches the loading state snapshot 1`] = `
             />
           </div>
           <div
-            class="show-loading-animation"
+            class="show-loading-animation css-1yz7e9k"
           >
             <div
               class="rect-shape css-2us3i8"
@@ -564,9 +568,11 @@ exports[`Spotify Widget matches the loading state snapshot 1`] = `
         </div>
       </div>
     </div>
-    <div>
+    <div
+      class="css-1yz7e9k"
+    >
       <div
-        class="css-ccroti"
+        class="css-epkbn4"
       >
         <h3
           class="css-9nh3l5"
@@ -580,10 +586,10 @@ exports[`Spotify Widget matches the loading state snapshot 1`] = `
         My 12 favorite playlists.
       </p>
       <div
-        class="media-item_grid null css-5stlgz"
+        class="media-item_grid null css-rt3umk"
       >
         <div
-          class="show-loading-animation"
+          class="show-loading-animation css-1yz7e9k"
         >
           <div
             class="rect-shape css-2us3i8"
@@ -591,7 +597,7 @@ exports[`Spotify Widget matches the loading state snapshot 1`] = `
           />
         </div>
         <div
-          class="show-loading-animation"
+          class="show-loading-animation css-1yz7e9k"
         >
           <div
             class="rect-shape css-2us3i8"
@@ -599,7 +605,7 @@ exports[`Spotify Widget matches the loading state snapshot 1`] = `
           />
         </div>
         <div
-          class="show-loading-animation"
+          class="show-loading-animation css-1yz7e9k"
         >
           <div
             class="rect-shape css-2us3i8"
@@ -607,7 +613,7 @@ exports[`Spotify Widget matches the loading state snapshot 1`] = `
           />
         </div>
         <div
-          class="show-loading-animation"
+          class="show-loading-animation css-1yz7e9k"
         >
           <div
             class="rect-shape css-2us3i8"
@@ -615,7 +621,7 @@ exports[`Spotify Widget matches the loading state snapshot 1`] = `
           />
         </div>
         <div
-          class="show-loading-animation"
+          class="show-loading-animation css-1yz7e9k"
         >
           <div
             class="rect-shape css-2us3i8"
@@ -623,7 +629,7 @@ exports[`Spotify Widget matches the loading state snapshot 1`] = `
           />
         </div>
         <div
-          class="show-loading-animation"
+          class="show-loading-animation css-1yz7e9k"
         >
           <div
             class="rect-shape css-2us3i8"
@@ -631,7 +637,7 @@ exports[`Spotify Widget matches the loading state snapshot 1`] = `
           />
         </div>
         <div
-          class="show-loading-animation"
+          class="show-loading-animation css-1yz7e9k"
         >
           <div
             class="rect-shape css-2us3i8"
@@ -639,7 +645,7 @@ exports[`Spotify Widget matches the loading state snapshot 1`] = `
           />
         </div>
         <div
-          class="show-loading-animation"
+          class="show-loading-animation css-1yz7e9k"
         >
           <div
             class="rect-shape css-2us3i8"
@@ -647,7 +653,7 @@ exports[`Spotify Widget matches the loading state snapshot 1`] = `
           />
         </div>
         <div
-          class="show-loading-animation"
+          class="show-loading-animation css-1yz7e9k"
         >
           <div
             class="rect-shape css-2us3i8"
@@ -655,7 +661,7 @@ exports[`Spotify Widget matches the loading state snapshot 1`] = `
           />
         </div>
         <div
-          class="show-loading-animation"
+          class="show-loading-animation css-1yz7e9k"
         >
           <div
             class="rect-shape css-2us3i8"
@@ -663,7 +669,7 @@ exports[`Spotify Widget matches the loading state snapshot 1`] = `
           />
         </div>
         <div
-          class="show-loading-animation"
+          class="show-loading-animation css-1yz7e9k"
         >
           <div
             class="rect-shape css-2us3i8"
@@ -671,7 +677,7 @@ exports[`Spotify Widget matches the loading state snapshot 1`] = `
           />
         </div>
         <div
-          class="show-loading-animation"
+          class="show-loading-animation css-1yz7e9k"
         >
           <div
             class="rect-shape css-2us3i8"
@@ -729,7 +735,7 @@ exports[`Spotify Widget renders without AI summary when not available 1`] = `
             href="https://spotify.com/user/test"
             title="Test User on Spotify"
           >
-            Browse Playlists
+            Browse Playlists 
             <span
               class="read-more-icon"
             >
@@ -772,10 +778,10 @@ exports[`Spotify Widget renders without AI summary when not available 1`] = `
       </div>
     </header>
     <div
-      class="css-sak8bt"
+      class="css-lnnjou"
     >
       <div
-        class="css-ccroti"
+        class="css-epkbn4"
       >
         <h3
           class="css-9nh3l5"
@@ -789,26 +795,26 @@ exports[`Spotify Widget renders without AI summary when not available 1`] = `
         Tracks I've played most over the last four weeks.
       </p>
       <div
-        class="css-us3dds"
+        class="css-4kg5kc"
       >
         <div
-          class="css-kdywdz"
+          class="css-vgd83x"
           data-testid="spotify-top-tracks-carousel"
         >
           <div
             aria-hidden="false"
-            class="css-4bo1uy"
+            class="css-1s44svb"
             data-testid="spotify-top-tracks-page-1"
           >
             <div
-              class="media-item_grid null css-5stlgz"
+              class="media-item_grid null css-rt3umk"
             >
               <a
                 class="media-item_media css-13fusor"
                 title="Test Track – [object Object]"
               >
                 <div
-                  class="css-x4b07x"
+                  class="css-pcble3"
                 >
                   <div
                     class="media-item_caption css-e7oldi"
@@ -819,7 +825,7 @@ exports[`Spotify Widget renders without AI summary when not available 1`] = `
                   </div>
                   <img
                     alt="cover artwork"
-                    class="css-karewm"
+                    class="css-526are"
                     crossorigin="anonymous"
                     loading="lazy"
                   />
@@ -830,9 +836,11 @@ exports[`Spotify Widget renders without AI summary when not available 1`] = `
         </div>
       </div>
     </div>
-    <div>
+    <div
+      class="css-1yz7e9k"
+    >
       <div
-        class="css-ccroti"
+        class="css-epkbn4"
       >
         <h3
           class="css-9nh3l5"
@@ -846,7 +854,7 @@ exports[`Spotify Widget renders without AI summary when not available 1`] = `
         My 12 favorite playlists.
       </p>
       <div
-        class="media-item_grid null css-5stlgz"
+        class="media-item_grid null css-rt3umk"
       />
     </div>
   </section>

--- a/theme/src/components/widgets/spotify/__snapshots__/top-tracks.spec.js.snap
+++ b/theme/src/components/widgets/spotify/__snapshots__/top-tracks.spec.js.snap
@@ -3,10 +3,10 @@
 exports[`TopTracks Component handles tracks without a 300px image gracefully 1`] = `
 <DocumentFragment>
   <div
-    class="css-sak8bt"
+    class="css-lnnjou"
   >
     <div
-      class="css-ccroti"
+      class="css-epkbn4"
     >
       <h3
         class="css-9nh3l5"
@@ -20,15 +20,15 @@ exports[`TopTracks Component handles tracks without a 300px image gracefully 1`]
       Tracks I've played most over the last four weeks.
     </p>
     <div
-      class="css-us3dds"
+      class="css-4kg5kc"
     >
       <div
-        class="css-kdywdz"
+        class="css-vgd83x"
         data-testid="spotify-top-tracks-carousel"
       >
         <div
           aria-hidden="false"
-          class="css-4bo1uy"
+          class="css-1s44svb"
           data-testid="spotify-top-tracks-page-1"
         >
           <div
@@ -44,10 +44,10 @@ exports[`TopTracks Component handles tracks without a 300px image gracefully 1`]
 exports[`TopTracks Component renders correctly when loading 1`] = `
 <DocumentFragment>
   <div
-    class="css-sak8bt"
+    class="css-lnnjou"
   >
     <div
-      class="css-ccroti"
+      class="css-epkbn4"
     >
       <h3
         class="css-9nh3l5"
@@ -61,7 +61,7 @@ exports[`TopTracks Component renders correctly when loading 1`] = `
       Tracks I've played most over the last four weeks.
     </p>
     <div
-      class="css-us3dds"
+      class="css-4kg5kc"
     >
       <div
         data-testid="media-item-grid"
@@ -74,10 +74,10 @@ exports[`TopTracks Component renders correctly when loading 1`] = `
 exports[`TopTracks Component renders correctly with no tracks 1`] = `
 <DocumentFragment>
   <div
-    class="css-sak8bt"
+    class="css-lnnjou"
   >
     <div
-      class="css-ccroti"
+      class="css-epkbn4"
     >
       <h3
         class="css-9nh3l5"
@@ -91,15 +91,15 @@ exports[`TopTracks Component renders correctly with no tracks 1`] = `
       Tracks I've played most over the last four weeks.
     </p>
     <div
-      class="css-us3dds"
+      class="css-4kg5kc"
     >
       <div
-        class="css-kdywdz"
+        class="css-vgd83x"
         data-testid="spotify-top-tracks-carousel"
       >
         <div
           aria-hidden="false"
-          class="css-4bo1uy"
+          class="css-1s44svb"
           data-testid="spotify-top-tracks-page-1"
         >
           <div
@@ -115,10 +115,10 @@ exports[`TopTracks Component renders correctly with no tracks 1`] = `
 exports[`TopTracks Component renders correctly with tracks 1`] = `
 <DocumentFragment>
   <div
-    class="css-sak8bt"
+    class="css-lnnjou"
   >
     <div
-      class="css-ccroti"
+      class="css-epkbn4"
     >
       <h3
         class="css-9nh3l5"
@@ -132,15 +132,15 @@ exports[`TopTracks Component renders correctly with tracks 1`] = `
       Tracks I've played most over the last four weeks.
     </p>
     <div
-      class="css-us3dds"
+      class="css-4kg5kc"
     >
       <div
-        class="css-kdywdz"
+        class="css-vgd83x"
         data-testid="spotify-top-tracks-carousel"
       >
         <div
           aria-hidden="false"
-          class="css-4bo1uy"
+          class="css-1s44svb"
           data-testid="spotify-top-tracks-page-1"
         >
           <div

--- a/theme/src/components/widgets/spotify/__snapshots__/track-preview.spec.js.snap
+++ b/theme/src/components/widgets/spotify/__snapshots__/track-preview.spec.js.snap
@@ -9,7 +9,7 @@ exports[`TrackPreview matches the snapshot 1`] = `
   >
     <img
       alt="album cover"
-      class="css-o32fug"
+      class="css-1ixh5q2"
       crossorigin="anonymous"
       loading="lazy"
       src="https://placehold.it/400/400"

--- a/theme/src/components/widgets/spotify/media-item-grid.js
+++ b/theme/src/components/widgets/spotify/media-item-grid.js
@@ -1,34 +1,40 @@
 /** @jsx jsx */
-import { jsx, useThemeUI } from 'theme-ui'
+import { jsx, Box, useThemeUI } from 'theme-ui'
+import { useState } from 'react'
 import { Themed } from '@theme-ui/mdx'
 import Placeholder from 'react-placeholder'
 import { RectShape } from 'react-placeholder/lib/placeholders'
-import { useState } from 'react'
 import isDarkMode from '../../../helpers/isDarkMode'
 
 import { glassmorhismPanel } from '@chronogrove/ui/theme'
+
+const PLACEHOLDER_COUNT = 12
+
+/** Stable keys so skeleton placeholders are not keyed by map index alone */
+const MEDIA_ITEM_GRID_PLACEHOLDER_KEYS = Array.from(
+  { length: PLACEHOLDER_COUNT },
+  (_, i) => `media-item-grid-ph-${String(i).padStart(2, '0')}`
+)
 
 const MediaItemGrid = ({ interactionDisabled = false, isLoading, items = [], onTrackClick }) => {
   const { colorMode } = useThemeUI()
   const darkModeActive = isDarkMode(colorMode)
   const [currentMediaId, setCurrentMediaId] = useState(false)
 
-  const placeholders = Array(12)
-    .fill()
-    .map((item, idx) => (
-      <div className='show-loading-animation' key={idx}>
-        <RectShape
-          color={darkModeActive ? '#3a3a4a' : '#efefef'}
-          sx={{
-            borderRadius: '8px',
-            boxShadow: 'md',
-            paddingBottom: '100%',
-            width: '100%'
-          }}
-          showLoadingAnimation
-        />
-      </div>
-    ))
+  const placeholders = MEDIA_ITEM_GRID_PLACEHOLDER_KEYS.map(key => (
+    <Box key={key} className='show-loading-animation'>
+      <RectShape
+        color={darkModeActive ? '#3a3a4a' : '#efefef'}
+        sx={{
+          borderRadius: '8px',
+          boxShadow: 'md',
+          paddingBottom: '100%',
+          width: '100%'
+        }}
+        showLoadingAnimation
+      />
+    </Box>
+  ))
 
   const handleClick = (e, spotifyURL) => {
     if (interactionDisabled) {
@@ -43,7 +49,7 @@ const MediaItemGrid = ({ interactionDisabled = false, isLoading, items = [], onT
   }
 
   return (
-    <div
+    <Box
       className={`media-item_grid ${currentMediaId ? 'media-item_grid--interacting' : null}`}
       sx={{
         display: 'grid',
@@ -80,14 +86,7 @@ const MediaItemGrid = ({ interactionDisabled = false, isLoading, items = [], onT
                 }
               }}
             >
-              <div
-                sx={{
-                  display: 'flex',
-                  flexDirection: 'column',
-                  height: '100%',
-                  width: '100%'
-                }}
-              >
+              <Box sx={{ display: 'flex', flexDirection: 'column', height: '100%', width: '100%' }}>
                 {name && (
                   <Themed.div
                     className='media-item_caption'
@@ -115,8 +114,9 @@ const MediaItemGrid = ({ interactionDisabled = false, isLoading, items = [], onT
                     <span>{name}</span>
                   </Themed.div>
                 )}
-                <Themed.img
+                <Box
                   alt='cover artwork'
+                  as='img'
                   crossOrigin='anonymous'
                   loading='lazy'
                   src={thumbnailURL}
@@ -127,12 +127,12 @@ const MediaItemGrid = ({ interactionDisabled = false, isLoading, items = [], onT
                     aspectRatio: '1/1'
                   }}
                 />
-              </div>
+              </Box>
             </Themed.a>
           )
         })}
       </Placeholder>
-    </div>
+    </Box>
   )
 }
 

--- a/theme/src/components/widgets/spotify/playlists.js
+++ b/theme/src/components/widgets/spotify/playlists.js
@@ -1,5 +1,5 @@
 /** @jsx jsx */
-import { jsx } from 'theme-ui'
+import { jsx, Box } from 'theme-ui'
 import { Heading } from '@theme-ui/components'
 import MediaItemGrid from './media-item-grid'
 import { Themed } from '@theme-ui/mdx'
@@ -50,17 +50,17 @@ const Playlists = ({ isLoading, playlists = [] }) => {
     .slice(0, 12) // Limit to 12 playlists for now. As of December 2024 the API response includes > 12 playlists.
 
   return (
-    <div>
-      <div sx={{ display: 'flex', flex: 1, alignItems: 'center' }}>
+    <Box>
+      <Box sx={{ display: 'flex', flex: 1, alignItems: 'center' }}>
         <Heading as='h3' sx={{ fontSize: [3, 4] }}>
           Playlists
         </Heading>
-      </div>
+      </Box>
 
       <Themed.p>My 12 favorite playlists.</Themed.p>
 
       <MediaItemGrid isLoading={isLoading} items={items} onTrackClick={handlePlaylistClick} />
-    </div>
+    </Box>
   )
 }
 

--- a/theme/src/components/widgets/spotify/spotify-widget.js
+++ b/theme/src/components/widgets/spotify/spotify-widget.js
@@ -35,8 +35,7 @@ const SpotifyWidget = () => {
 
   const callToAction = (
     <CallToAction title={`${profileDisplayName} on ${providerDisplayName}`} url={profileURL} isLoading={isLoading}>
-      Browse Playlists
-      <span className='read-more-icon'>&rarr;</span>
+      Browse Playlists <span className='read-more-icon'>&rarr;</span>
     </CallToAction>
   )
 

--- a/theme/src/components/widgets/spotify/top-tracks.js
+++ b/theme/src/components/widgets/spotify/top-tracks.js
@@ -1,5 +1,5 @@
 /** @jsx jsx */
-import { jsx } from 'theme-ui'
+import { jsx, Box } from 'theme-ui'
 import { Heading } from '@theme-ui/components'
 import { Themed } from '@theme-ui/mdx'
 import { useEffect, useMemo, useState } from 'react'
@@ -81,16 +81,16 @@ const TopTracks = ({ isLoading, tracks = [] }) => {
   }, [tracksIdentityKey])
 
   return (
-    <div sx={{ mb: 4 }}>
-      <div sx={{ display: 'flex', flex: 1, alignItems: 'center' }}>
+    <Box sx={{ mb: 4 }}>
+      <Box sx={{ display: 'flex', flex: 1, alignItems: 'center' }}>
         <Heading as='h3' sx={{ fontSize: [3, 4] }}>
           Top Tracks
         </Heading>
-      </div>
+      </Box>
 
       <Themed.p>Tracks I&apos;ve played most over the last four weeks.</Themed.p>
 
-      <div
+      <Box
         sx={{
           overflow: 'hidden',
           position: 'relative',
@@ -103,7 +103,7 @@ const TopTracks = ({ isLoading, tracks = [] }) => {
         {isLoading ? (
           <MediaItemGrid isLoading items={[]} onTrackClick={handleTrackClick} />
         ) : (
-          <div
+          <Box
             data-testid='spotify-top-tracks-carousel'
             sx={{
               display: 'flex',
@@ -124,7 +124,7 @@ const TopTracks = ({ isLoading, tracks = [] }) => {
             onPointerCancel={handlePointerCancel}
           >
             {pages.map((pageItems, pageIndex) => (
-              <div
+              <Box
                 key={`spotify-top-tracks-page-${pageIndex + 1}`}
                 aria-hidden={pageIndex !== currentPage - 1}
                 data-testid={`spotify-top-tracks-page-${pageIndex + 1}`}
@@ -143,16 +143,16 @@ const TopTracks = ({ isLoading, tracks = [] }) => {
                   items={pageItems}
                   onTrackClick={handleTrackClick}
                 />
-              </div>
+              </Box>
             ))}
-          </div>
+          </Box>
         )}
-      </div>
+      </Box>
 
       {!isLoading && totalPages > 1 ? (
         <Pagination currentPage={currentPage} onPageChange={handlePageChange} totalPages={totalPages} />
       ) : null}
-    </div>
+    </Box>
   )
 }
 

--- a/theme/src/components/widgets/spotify/top-tracks.spec.js
+++ b/theme/src/components/widgets/spotify/top-tracks.spec.js
@@ -2,11 +2,10 @@
 import React from 'react'
 import { render, fireEvent, waitFor } from '@testing-library/react'
 import '@testing-library/jest-dom'
-import { jsx } from 'theme-ui'
+import { jsx, ThemeUIProvider } from 'theme-ui'
 import TopTracks from './top-tracks'
 import { TestProviderWithState } from '../../../testUtils'
 import { useAudioPlayerStore, resetAudioPlayerStore } from '../../../stores/audio-player-store'
-import { ThemeUIProvider } from 'theme-ui'
 import theme from '@chronogrove/ui/theme'
 
 jest.mock('./media-item-grid', () => jest.fn(() => <div data-testid='media-item-grid' />))

--- a/theme/src/components/widgets/spotify/track-preview.js
+++ b/theme/src/components/widgets/spotify/track-preview.js
@@ -1,5 +1,5 @@
 /** @jsx jsx */
-import { jsx } from 'theme-ui'
+import { jsx, Box } from 'theme-ui'
 import { Themed } from '@theme-ui/mdx'
 
 const TrackPreview = ({ link, name, thumbnailURL }) => (
@@ -10,10 +10,11 @@ const TrackPreview = ({ link, name, thumbnailURL }) => (
       variant: 'styles.TrackPreview'
     }}
   >
-    <img
+    <Box
       alt='album cover'
-      loading='lazy'
+      as='img'
       crossOrigin='anonymous'
+      loading='lazy'
       src={thumbnailURL}
       sx={{
         objectFit: 'cover',

--- a/theme/src/components/widgets/steam/__snapshots__/play-time-chart.spec.js.snap
+++ b/theme/src/components/widgets/steam/__snapshots__/play-time-chart.spec.js.snap
@@ -3,7 +3,7 @@
 exports[`PlayTimeChart Dark Mode Coverage matches snapshot for a game card in dark mode 1`] = `
 <DocumentFragment>
   <div
-    class="css-sak8bt"
+    class="css-lnnjou"
   >
     <div
       class="css-munl51"
@@ -14,28 +14,28 @@ exports[`PlayTimeChart Dark Mode Coverage matches snapshot for a game card in da
         type="button"
       >
         <div
-          class="css-w24l45"
+          class="css-2w7wic"
         >
           <img
             alt="Cities: Skylines header"
-            class="css-17nz09e"
+            class="css-ac7c24"
             src="https://example.com/cities-header.jpg"
           />
           <div
-            class="css-17mv9gi"
+            class="css-18c3nn9"
           >
             1
           </div>
           <div
-            class="steam-game-card_caption css-k8brg5"
+            class="steam-game-card_caption css-18i3ee5"
           >
             <div
-              class="css-h3pxs9"
+              class="css-jae09u"
             >
               Cities: Skylines
             </div>
             <div
-              class="css-1i7ls3l"
+              class="css-bcsjsw"
             >
               757.35h total • 2h recently
             </div>
@@ -48,28 +48,28 @@ exports[`PlayTimeChart Dark Mode Coverage matches snapshot for a game card in da
         type="button"
       >
         <div
-          class="css-w24l45"
+          class="css-2w7wic"
         >
           <img
             alt="ARK: Survival Evolved header"
-            class="css-17nz09e"
+            class="css-ac7c24"
             src="https://example.com/ark-header.jpg"
           />
           <div
-            class="css-17mv9gi"
+            class="css-18c3nn9"
           >
             2
           </div>
           <div
-            class="steam-game-card_caption css-k8brg5"
+            class="steam-game-card_caption css-18i3ee5"
           >
             <div
-              class="css-h3pxs9"
+              class="css-jae09u"
             >
               ARK: Survival Evolved
             </div>
             <div
-              class="css-1i7ls3l"
+              class="css-bcsjsw"
             >
               277.83h total
             </div>
@@ -82,28 +82,28 @@ exports[`PlayTimeChart Dark Mode Coverage matches snapshot for a game card in da
         type="button"
       >
         <div
-          class="css-w24l45"
+          class="css-2w7wic"
         >
           <img
             alt="PUBG: BATTLEGROUNDS header"
-            class="css-17nz09e"
+            class="css-ac7c24"
             src="https://example.com/pubg-header.jpg"
           />
           <div
-            class="css-17mv9gi"
+            class="css-18c3nn9"
           >
             3
           </div>
           <div
-            class="steam-game-card_caption css-k8brg5"
+            class="steam-game-card_caption css-18i3ee5"
           >
             <div
-              class="css-h3pxs9"
+              class="css-jae09u"
             >
               PUBG: BATTLEGROUNDS
             </div>
             <div
-              class="css-1i7ls3l"
+              class="css-bcsjsw"
             >
               200h total • 1h recently
             </div>
@@ -112,24 +112,24 @@ exports[`PlayTimeChart Dark Mode Coverage matches snapshot for a game card in da
       </button>
     </div>
     <div
-      class="css-rcbrnq"
+      class="css-1jvjqv3"
     >
       <div
-        class="css-aq86v7"
+        class="css-12f4tqr"
       >
         Total Hours: 
         <span
-          class="css-1eduwqk"
+          class="css-13epqkc"
         >
           1235.2h
         </span>
       </div>
       <div
-        class="css-aq86v7"
+        class="css-12f4tqr"
       >
         Average: 
         <span
-          class="css-1eduwqk"
+          class="css-13epqkc"
         >
           411.7h per game
         </span>
@@ -142,7 +142,7 @@ exports[`PlayTimeChart Dark Mode Coverage matches snapshot for a game card in da
 exports[`PlayTimeChart Dark Mode Coverage matches snapshot for a hovered game card in dark mode 1`] = `
 <DocumentFragment>
   <div
-    class="css-sak8bt"
+    class="css-lnnjou"
   >
     <div
       class="css-munl51"
@@ -153,28 +153,28 @@ exports[`PlayTimeChart Dark Mode Coverage matches snapshot for a hovered game ca
         type="button"
       >
         <div
-          class="css-w24l45"
+          class="css-2w7wic"
         >
           <img
             alt="Cities: Skylines header"
-            class="css-17nz09e"
+            class="css-ac7c24"
             src="https://example.com/cities-header.jpg"
           />
           <div
-            class="css-17mv9gi"
+            class="css-18c3nn9"
           >
             1
           </div>
           <div
-            class="steam-game-card_caption css-k8brg5"
+            class="steam-game-card_caption css-18i3ee5"
           >
             <div
-              class="css-h3pxs9"
+              class="css-jae09u"
             >
               Cities: Skylines
             </div>
             <div
-              class="css-1i7ls3l"
+              class="css-bcsjsw"
             >
               757.35h total • 2h recently
             </div>
@@ -187,28 +187,28 @@ exports[`PlayTimeChart Dark Mode Coverage matches snapshot for a hovered game ca
         type="button"
       >
         <div
-          class="css-w24l45"
+          class="css-2w7wic"
         >
           <img
             alt="ARK: Survival Evolved header"
-            class="css-17nz09e"
+            class="css-ac7c24"
             src="https://example.com/ark-header.jpg"
           />
           <div
-            class="css-17mv9gi"
+            class="css-18c3nn9"
           >
             2
           </div>
           <div
-            class="steam-game-card_caption css-k8brg5"
+            class="steam-game-card_caption css-18i3ee5"
           >
             <div
-              class="css-h3pxs9"
+              class="css-jae09u"
             >
               ARK: Survival Evolved
             </div>
             <div
-              class="css-1i7ls3l"
+              class="css-bcsjsw"
             >
               277.83h total
             </div>
@@ -221,28 +221,28 @@ exports[`PlayTimeChart Dark Mode Coverage matches snapshot for a hovered game ca
         type="button"
       >
         <div
-          class="css-w24l45"
+          class="css-2w7wic"
         >
           <img
             alt="PUBG: BATTLEGROUNDS header"
-            class="css-17nz09e"
+            class="css-ac7c24"
             src="https://example.com/pubg-header.jpg"
           />
           <div
-            class="css-17mv9gi"
+            class="css-18c3nn9"
           >
             3
           </div>
           <div
-            class="steam-game-card_caption css-k8brg5"
+            class="steam-game-card_caption css-18i3ee5"
           >
             <div
-              class="css-h3pxs9"
+              class="css-jae09u"
             >
               PUBG: BATTLEGROUNDS
             </div>
             <div
-              class="css-1i7ls3l"
+              class="css-bcsjsw"
             >
               200h total • 1h recently
             </div>
@@ -251,24 +251,24 @@ exports[`PlayTimeChart Dark Mode Coverage matches snapshot for a hovered game ca
       </button>
     </div>
     <div
-      class="css-rcbrnq"
+      class="css-1jvjqv3"
     >
       <div
-        class="css-aq86v7"
+        class="css-12f4tqr"
       >
         Total Hours: 
         <span
-          class="css-1eduwqk"
+          class="css-13epqkc"
         >
           1235.2h
         </span>
       </div>
       <div
-        class="css-aq86v7"
+        class="css-12f4tqr"
       >
         Average: 
         <span
-          class="css-1eduwqk"
+          class="css-13epqkc"
         >
           411.7h per game
         </span>
@@ -281,7 +281,7 @@ exports[`PlayTimeChart Dark Mode Coverage matches snapshot for a hovered game ca
 exports[`PlayTimeChart Data Processing filters out games with zero playtime 1`] = `
 <DocumentFragment>
   <div
-    class="css-sak8bt"
+    class="css-lnnjou"
   >
     <div
       class="css-munl51"
@@ -292,28 +292,28 @@ exports[`PlayTimeChart Data Processing filters out games with zero playtime 1`] 
         type="button"
       >
         <div
-          class="css-w24l45"
+          class="css-2w7wic"
         >
           <img
             alt="Cities: Skylines header"
-            class="css-17nz09e"
+            class="css-ac7c24"
             src="https://example.com/cities-header.jpg"
           />
           <div
-            class="css-17mv9gi"
+            class="css-18c3nn9"
           >
             1
           </div>
           <div
-            class="steam-game-card_caption css-k8brg5"
+            class="steam-game-card_caption css-18i3ee5"
           >
             <div
-              class="css-h3pxs9"
+              class="css-jae09u"
             >
               Cities: Skylines
             </div>
             <div
-              class="css-1i7ls3l"
+              class="css-bcsjsw"
             >
               757.35h total • 2h recently
             </div>
@@ -326,28 +326,28 @@ exports[`PlayTimeChart Data Processing filters out games with zero playtime 1`] 
         type="button"
       >
         <div
-          class="css-w24l45"
+          class="css-2w7wic"
         >
           <img
             alt="ARK: Survival Evolved header"
-            class="css-17nz09e"
+            class="css-ac7c24"
             src="https://example.com/ark-header.jpg"
           />
           <div
-            class="css-17mv9gi"
+            class="css-18c3nn9"
           >
             2
           </div>
           <div
-            class="steam-game-card_caption css-k8brg5"
+            class="steam-game-card_caption css-18i3ee5"
           >
             <div
-              class="css-h3pxs9"
+              class="css-jae09u"
             >
               ARK: Survival Evolved
             </div>
             <div
-              class="css-1i7ls3l"
+              class="css-bcsjsw"
             >
               277.83h total
             </div>
@@ -360,28 +360,28 @@ exports[`PlayTimeChart Data Processing filters out games with zero playtime 1`] 
         type="button"
       >
         <div
-          class="css-w24l45"
+          class="css-2w7wic"
         >
           <img
             alt="PUBG: BATTLEGROUNDS header"
-            class="css-17nz09e"
+            class="css-ac7c24"
             src="https://example.com/pubg-header.jpg"
           />
           <div
-            class="css-17mv9gi"
+            class="css-18c3nn9"
           >
             3
           </div>
           <div
-            class="steam-game-card_caption css-k8brg5"
+            class="steam-game-card_caption css-18i3ee5"
           >
             <div
-              class="css-h3pxs9"
+              class="css-jae09u"
             >
               PUBG: BATTLEGROUNDS
             </div>
             <div
-              class="css-1i7ls3l"
+              class="css-bcsjsw"
             >
               200h total • 1h recently
             </div>
@@ -390,24 +390,24 @@ exports[`PlayTimeChart Data Processing filters out games with zero playtime 1`] 
       </button>
     </div>
     <div
-      class="css-rcbrnq"
+      class="css-1jvjqv3"
     >
       <div
-        class="css-aq86v7"
+        class="css-12f4tqr"
       >
         Total Hours: 
         <span
-          class="css-1eduwqk"
+          class="css-13epqkc"
         >
           1235.2h
         </span>
       </div>
       <div
-        class="css-aq86v7"
+        class="css-12f4tqr"
       >
         Average: 
         <span
-          class="css-1eduwqk"
+          class="css-13epqkc"
         >
           411.7h per game
         </span>
@@ -420,7 +420,7 @@ exports[`PlayTimeChart Data Processing filters out games with zero playtime 1`] 
 exports[`PlayTimeChart Data Processing renders correctly with sample data 1`] = `
 <DocumentFragment>
   <div
-    class="css-sak8bt"
+    class="css-lnnjou"
   >
     <div
       class="css-munl51"
@@ -431,28 +431,28 @@ exports[`PlayTimeChart Data Processing renders correctly with sample data 1`] = 
         type="button"
       >
         <div
-          class="css-w24l45"
+          class="css-2w7wic"
         >
           <img
             alt="Cities: Skylines header"
-            class="css-17nz09e"
+            class="css-ac7c24"
             src="https://example.com/cities-header.jpg"
           />
           <div
-            class="css-17mv9gi"
+            class="css-18c3nn9"
           >
             1
           </div>
           <div
-            class="steam-game-card_caption css-k8brg5"
+            class="steam-game-card_caption css-18i3ee5"
           >
             <div
-              class="css-h3pxs9"
+              class="css-jae09u"
             >
               Cities: Skylines
             </div>
             <div
-              class="css-1i7ls3l"
+              class="css-bcsjsw"
             >
               757.35h total • 2h recently
             </div>
@@ -465,28 +465,28 @@ exports[`PlayTimeChart Data Processing renders correctly with sample data 1`] = 
         type="button"
       >
         <div
-          class="css-w24l45"
+          class="css-2w7wic"
         >
           <img
             alt="ARK: Survival Evolved header"
-            class="css-17nz09e"
+            class="css-ac7c24"
             src="https://example.com/ark-header.jpg"
           />
           <div
-            class="css-17mv9gi"
+            class="css-18c3nn9"
           >
             2
           </div>
           <div
-            class="steam-game-card_caption css-k8brg5"
+            class="steam-game-card_caption css-18i3ee5"
           >
             <div
-              class="css-h3pxs9"
+              class="css-jae09u"
             >
               ARK: Survival Evolved
             </div>
             <div
-              class="css-1i7ls3l"
+              class="css-bcsjsw"
             >
               277.83h total
             </div>
@@ -499,28 +499,28 @@ exports[`PlayTimeChart Data Processing renders correctly with sample data 1`] = 
         type="button"
       >
         <div
-          class="css-w24l45"
+          class="css-2w7wic"
         >
           <img
             alt="PUBG: BATTLEGROUNDS header"
-            class="css-17nz09e"
+            class="css-ac7c24"
             src="https://example.com/pubg-header.jpg"
           />
           <div
-            class="css-17mv9gi"
+            class="css-18c3nn9"
           >
             3
           </div>
           <div
-            class="steam-game-card_caption css-k8brg5"
+            class="steam-game-card_caption css-18i3ee5"
           >
             <div
-              class="css-h3pxs9"
+              class="css-jae09u"
             >
               PUBG: BATTLEGROUNDS
             </div>
             <div
-              class="css-1i7ls3l"
+              class="css-bcsjsw"
             >
               200h total • 1h recently
             </div>
@@ -529,24 +529,24 @@ exports[`PlayTimeChart Data Processing renders correctly with sample data 1`] = 
       </button>
     </div>
     <div
-      class="css-rcbrnq"
+      class="css-1jvjqv3"
     >
       <div
-        class="css-aq86v7"
+        class="css-12f4tqr"
       >
         Total Hours: 
         <span
-          class="css-1eduwqk"
+          class="css-13epqkc"
         >
           1235.2h
         </span>
       </div>
       <div
-        class="css-aq86v7"
+        class="css-12f4tqr"
       >
         Average: 
         <span
-          class="css-1eduwqk"
+          class="css-13epqkc"
         >
           411.7h per game
         </span>
@@ -559,7 +559,7 @@ exports[`PlayTimeChart Data Processing renders correctly with sample data 1`] = 
 exports[`PlayTimeChart Edge Cases handles single game scenario 1`] = `
 <DocumentFragment>
   <div
-    class="css-sak8bt"
+    class="css-lnnjou"
   >
     <div
       class="css-munl51"
@@ -570,28 +570,28 @@ exports[`PlayTimeChart Edge Cases handles single game scenario 1`] = `
         type="button"
       >
         <div
-          class="css-w24l45"
+          class="css-2w7wic"
         >
           <img
             alt="Cities: Skylines header"
-            class="css-17nz09e"
+            class="css-ac7c24"
             src="https://example.com/cities-header.jpg"
           />
           <div
-            class="css-17mv9gi"
+            class="css-18c3nn9"
           >
             1
           </div>
           <div
-            class="steam-game-card_caption css-k8brg5"
+            class="steam-game-card_caption css-18i3ee5"
           >
             <div
-              class="css-h3pxs9"
+              class="css-jae09u"
             >
               Cities: Skylines
             </div>
             <div
-              class="css-1i7ls3l"
+              class="css-bcsjsw"
             >
               757.35h total • 2h recently
             </div>
@@ -600,24 +600,24 @@ exports[`PlayTimeChart Edge Cases handles single game scenario 1`] = `
       </button>
     </div>
     <div
-      class="css-rcbrnq"
+      class="css-1jvjqv3"
     >
       <div
-        class="css-aq86v7"
+        class="css-12f4tqr"
       >
         Total Hours: 
         <span
-          class="css-1eduwqk"
+          class="css-13epqkc"
         >
           757.4h
         </span>
       </div>
       <div
-        class="css-aq86v7"
+        class="css-12f4tqr"
       >
         Average: 
         <span
-          class="css-1eduwqk"
+          class="css-13epqkc"
         >
           757.4h per game
         </span>
@@ -630,10 +630,10 @@ exports[`PlayTimeChart Edge Cases handles single game scenario 1`] = `
 exports[`PlayTimeChart Empty States renders empty state when games is null 1`] = `
 <DocumentFragment>
   <div
-    class="css-sak8bt"
+    class="css-lnnjou"
   >
     <div
-      class="css-16q7rgc"
+      class="css-et6zal"
     >
       <p
         class="css-13s56l1"
@@ -648,10 +648,10 @@ exports[`PlayTimeChart Empty States renders empty state when games is null 1`] =
 exports[`PlayTimeChart Empty States renders empty state when games is undefined 1`] = `
 <DocumentFragment>
   <div
-    class="css-sak8bt"
+    class="css-lnnjou"
   >
     <div
-      class="css-16q7rgc"
+      class="css-et6zal"
     >
       <p
         class="css-13s56l1"
@@ -666,10 +666,10 @@ exports[`PlayTimeChart Empty States renders empty state when games is undefined 
 exports[`PlayTimeChart Empty States renders empty state when no games provided 1`] = `
 <DocumentFragment>
   <div
-    class="css-sak8bt"
+    class="css-lnnjou"
   >
     <div
-      class="css-16q7rgc"
+      class="css-et6zal"
     >
       <p
         class="css-13s56l1"
@@ -684,7 +684,7 @@ exports[`PlayTimeChart Empty States renders empty state when no games provided 1
 exports[`PlayTimeChart Light Mode Coverage matches snapshot for a game card in light mode 1`] = `
 <DocumentFragment>
   <div
-    class="css-sak8bt"
+    class="css-lnnjou"
   >
     <div
       class="css-munl51"
@@ -695,28 +695,28 @@ exports[`PlayTimeChart Light Mode Coverage matches snapshot for a game card in l
         type="button"
       >
         <div
-          class="css-w24l45"
+          class="css-2w7wic"
         >
           <img
             alt="Cities: Skylines header"
-            class="css-17nz09e"
+            class="css-ac7c24"
             src="https://example.com/cities-header.jpg"
           />
           <div
-            class="css-17mv9gi"
+            class="css-18c3nn9"
           >
             1
           </div>
           <div
-            class="steam-game-card_caption css-k8brg5"
+            class="steam-game-card_caption css-18i3ee5"
           >
             <div
-              class="css-h3pxs9"
+              class="css-jae09u"
             >
               Cities: Skylines
             </div>
             <div
-              class="css-1i7ls3l"
+              class="css-bcsjsw"
             >
               757.35h total • 2h recently
             </div>
@@ -729,28 +729,28 @@ exports[`PlayTimeChart Light Mode Coverage matches snapshot for a game card in l
         type="button"
       >
         <div
-          class="css-w24l45"
+          class="css-2w7wic"
         >
           <img
             alt="ARK: Survival Evolved header"
-            class="css-17nz09e"
+            class="css-ac7c24"
             src="https://example.com/ark-header.jpg"
           />
           <div
-            class="css-17mv9gi"
+            class="css-18c3nn9"
           >
             2
           </div>
           <div
-            class="steam-game-card_caption css-k8brg5"
+            class="steam-game-card_caption css-18i3ee5"
           >
             <div
-              class="css-h3pxs9"
+              class="css-jae09u"
             >
               ARK: Survival Evolved
             </div>
             <div
-              class="css-1i7ls3l"
+              class="css-bcsjsw"
             >
               277.83h total
             </div>
@@ -763,28 +763,28 @@ exports[`PlayTimeChart Light Mode Coverage matches snapshot for a game card in l
         type="button"
       >
         <div
-          class="css-w24l45"
+          class="css-2w7wic"
         >
           <img
             alt="PUBG: BATTLEGROUNDS header"
-            class="css-17nz09e"
+            class="css-ac7c24"
             src="https://example.com/pubg-header.jpg"
           />
           <div
-            class="css-17mv9gi"
+            class="css-18c3nn9"
           >
             3
           </div>
           <div
-            class="steam-game-card_caption css-k8brg5"
+            class="steam-game-card_caption css-18i3ee5"
           >
             <div
-              class="css-h3pxs9"
+              class="css-jae09u"
             >
               PUBG: BATTLEGROUNDS
             </div>
             <div
-              class="css-1i7ls3l"
+              class="css-bcsjsw"
             >
               200h total • 1h recently
             </div>
@@ -793,24 +793,24 @@ exports[`PlayTimeChart Light Mode Coverage matches snapshot for a game card in l
       </button>
     </div>
     <div
-      class="css-rcbrnq"
+      class="css-1jvjqv3"
     >
       <div
-        class="css-aq86v7"
+        class="css-12f4tqr"
       >
         Total Hours: 
         <span
-          class="css-1eduwqk"
+          class="css-13epqkc"
         >
           1235.2h
         </span>
       </div>
       <div
-        class="css-aq86v7"
+        class="css-12f4tqr"
       >
         Average: 
         <span
-          class="css-1eduwqk"
+          class="css-13epqkc"
         >
           411.7h per game
         </span>
@@ -823,7 +823,7 @@ exports[`PlayTimeChart Light Mode Coverage matches snapshot for a game card in l
 exports[`PlayTimeChart Light Mode Coverage matches snapshot for a hovered game card in light mode 1`] = `
 <DocumentFragment>
   <div
-    class="css-sak8bt"
+    class="css-lnnjou"
   >
     <div
       class="css-munl51"
@@ -834,28 +834,28 @@ exports[`PlayTimeChart Light Mode Coverage matches snapshot for a hovered game c
         type="button"
       >
         <div
-          class="css-w24l45"
+          class="css-2w7wic"
         >
           <img
             alt="Cities: Skylines header"
-            class="css-17nz09e"
+            class="css-ac7c24"
             src="https://example.com/cities-header.jpg"
           />
           <div
-            class="css-17mv9gi"
+            class="css-18c3nn9"
           >
             1
           </div>
           <div
-            class="steam-game-card_caption css-k8brg5"
+            class="steam-game-card_caption css-18i3ee5"
           >
             <div
-              class="css-h3pxs9"
+              class="css-jae09u"
             >
               Cities: Skylines
             </div>
             <div
-              class="css-1i7ls3l"
+              class="css-bcsjsw"
             >
               757.35h total • 2h recently
             </div>
@@ -868,28 +868,28 @@ exports[`PlayTimeChart Light Mode Coverage matches snapshot for a hovered game c
         type="button"
       >
         <div
-          class="css-w24l45"
+          class="css-2w7wic"
         >
           <img
             alt="ARK: Survival Evolved header"
-            class="css-17nz09e"
+            class="css-ac7c24"
             src="https://example.com/ark-header.jpg"
           />
           <div
-            class="css-17mv9gi"
+            class="css-18c3nn9"
           >
             2
           </div>
           <div
-            class="steam-game-card_caption css-k8brg5"
+            class="steam-game-card_caption css-18i3ee5"
           >
             <div
-              class="css-h3pxs9"
+              class="css-jae09u"
             >
               ARK: Survival Evolved
             </div>
             <div
-              class="css-1i7ls3l"
+              class="css-bcsjsw"
             >
               277.83h total
             </div>
@@ -902,28 +902,28 @@ exports[`PlayTimeChart Light Mode Coverage matches snapshot for a hovered game c
         type="button"
       >
         <div
-          class="css-w24l45"
+          class="css-2w7wic"
         >
           <img
             alt="PUBG: BATTLEGROUNDS header"
-            class="css-17nz09e"
+            class="css-ac7c24"
             src="https://example.com/pubg-header.jpg"
           />
           <div
-            class="css-17mv9gi"
+            class="css-18c3nn9"
           >
             3
           </div>
           <div
-            class="steam-game-card_caption css-k8brg5"
+            class="steam-game-card_caption css-18i3ee5"
           >
             <div
-              class="css-h3pxs9"
+              class="css-jae09u"
             >
               PUBG: BATTLEGROUNDS
             </div>
             <div
-              class="css-1i7ls3l"
+              class="css-bcsjsw"
             >
               200h total • 1h recently
             </div>
@@ -932,24 +932,24 @@ exports[`PlayTimeChart Light Mode Coverage matches snapshot for a hovered game c
       </button>
     </div>
     <div
-      class="css-rcbrnq"
+      class="css-1jvjqv3"
     >
       <div
-        class="css-aq86v7"
+        class="css-12f4tqr"
       >
         Total Hours: 
         <span
-          class="css-1eduwqk"
+          class="css-13epqkc"
         >
           1235.2h
         </span>
       </div>
       <div
-        class="css-aq86v7"
+        class="css-12f4tqr"
       >
         Average: 
         <span
-          class="css-1eduwqk"
+          class="css-13epqkc"
         >
           411.7h per game
         </span>
@@ -962,13 +962,13 @@ exports[`PlayTimeChart Light Mode Coverage matches snapshot for a hovered game c
 exports[`PlayTimeChart Loading State renders loading state correctly 1`] = `
 <DocumentFragment>
   <div
-    class="css-sak8bt"
+    class="css-lnnjou"
   >
     <div
-      class="css-nyc2gr"
+      class="css-1g612vj"
     >
       <div
-        class="css-17cb55"
+        class="css-3wu3l6"
       />
       <p
         class="css-gej412"
@@ -983,7 +983,7 @@ exports[`PlayTimeChart Loading State renders loading state correctly 1`] = `
 exports[`PlayTimeChart Theme Integration adapts to dark mode styling 1`] = `
 <DocumentFragment>
   <div
-    class="css-sak8bt"
+    class="css-lnnjou"
   >
     <div
       class="css-munl51"
@@ -994,28 +994,28 @@ exports[`PlayTimeChart Theme Integration adapts to dark mode styling 1`] = `
         type="button"
       >
         <div
-          class="css-w24l45"
+          class="css-2w7wic"
         >
           <img
             alt="Cities: Skylines header"
-            class="css-17nz09e"
+            class="css-ac7c24"
             src="https://example.com/cities-header.jpg"
           />
           <div
-            class="css-17mv9gi"
+            class="css-18c3nn9"
           >
             1
           </div>
           <div
-            class="steam-game-card_caption css-k8brg5"
+            class="steam-game-card_caption css-18i3ee5"
           >
             <div
-              class="css-h3pxs9"
+              class="css-jae09u"
             >
               Cities: Skylines
             </div>
             <div
-              class="css-1i7ls3l"
+              class="css-bcsjsw"
             >
               757.35h total • 2h recently
             </div>
@@ -1028,28 +1028,28 @@ exports[`PlayTimeChart Theme Integration adapts to dark mode styling 1`] = `
         type="button"
       >
         <div
-          class="css-w24l45"
+          class="css-2w7wic"
         >
           <img
             alt="ARK: Survival Evolved header"
-            class="css-17nz09e"
+            class="css-ac7c24"
             src="https://example.com/ark-header.jpg"
           />
           <div
-            class="css-17mv9gi"
+            class="css-18c3nn9"
           >
             2
           </div>
           <div
-            class="steam-game-card_caption css-k8brg5"
+            class="steam-game-card_caption css-18i3ee5"
           >
             <div
-              class="css-h3pxs9"
+              class="css-jae09u"
             >
               ARK: Survival Evolved
             </div>
             <div
-              class="css-1i7ls3l"
+              class="css-bcsjsw"
             >
               277.83h total
             </div>
@@ -1062,28 +1062,28 @@ exports[`PlayTimeChart Theme Integration adapts to dark mode styling 1`] = `
         type="button"
       >
         <div
-          class="css-w24l45"
+          class="css-2w7wic"
         >
           <img
             alt="PUBG: BATTLEGROUNDS header"
-            class="css-17nz09e"
+            class="css-ac7c24"
             src="https://example.com/pubg-header.jpg"
           />
           <div
-            class="css-17mv9gi"
+            class="css-18c3nn9"
           >
             3
           </div>
           <div
-            class="steam-game-card_caption css-k8brg5"
+            class="steam-game-card_caption css-18i3ee5"
           >
             <div
-              class="css-h3pxs9"
+              class="css-jae09u"
             >
               PUBG: BATTLEGROUNDS
             </div>
             <div
-              class="css-1i7ls3l"
+              class="css-bcsjsw"
             >
               200h total • 1h recently
             </div>
@@ -1092,24 +1092,24 @@ exports[`PlayTimeChart Theme Integration adapts to dark mode styling 1`] = `
       </button>
     </div>
     <div
-      class="css-rcbrnq"
+      class="css-1jvjqv3"
     >
       <div
-        class="css-aq86v7"
+        class="css-12f4tqr"
       >
         Total Hours: 
         <span
-          class="css-1eduwqk"
+          class="css-13epqkc"
         >
           1235.2h
         </span>
       </div>
       <div
-        class="css-aq86v7"
+        class="css-12f4tqr"
       >
         Average: 
         <span
-          class="css-1eduwqk"
+          class="css-13epqkc"
         >
           411.7h per game
         </span>
@@ -1122,7 +1122,7 @@ exports[`PlayTimeChart Theme Integration adapts to dark mode styling 1`] = `
 exports[`PlayTimeChart Theme Integration renders correctly in light mode 1`] = `
 <DocumentFragment>
   <div
-    class="css-sak8bt"
+    class="css-lnnjou"
   >
     <div
       class="css-munl51"
@@ -1133,28 +1133,28 @@ exports[`PlayTimeChart Theme Integration renders correctly in light mode 1`] = `
         type="button"
       >
         <div
-          class="css-w24l45"
+          class="css-2w7wic"
         >
           <img
             alt="Cities: Skylines header"
-            class="css-17nz09e"
+            class="css-ac7c24"
             src="https://example.com/cities-header.jpg"
           />
           <div
-            class="css-17mv9gi"
+            class="css-18c3nn9"
           >
             1
           </div>
           <div
-            class="steam-game-card_caption css-k8brg5"
+            class="steam-game-card_caption css-18i3ee5"
           >
             <div
-              class="css-h3pxs9"
+              class="css-jae09u"
             >
               Cities: Skylines
             </div>
             <div
-              class="css-1i7ls3l"
+              class="css-bcsjsw"
             >
               757.35h total • 2h recently
             </div>
@@ -1167,28 +1167,28 @@ exports[`PlayTimeChart Theme Integration renders correctly in light mode 1`] = `
         type="button"
       >
         <div
-          class="css-w24l45"
+          class="css-2w7wic"
         >
           <img
             alt="ARK: Survival Evolved header"
-            class="css-17nz09e"
+            class="css-ac7c24"
             src="https://example.com/ark-header.jpg"
           />
           <div
-            class="css-17mv9gi"
+            class="css-18c3nn9"
           >
             2
           </div>
           <div
-            class="steam-game-card_caption css-k8brg5"
+            class="steam-game-card_caption css-18i3ee5"
           >
             <div
-              class="css-h3pxs9"
+              class="css-jae09u"
             >
               ARK: Survival Evolved
             </div>
             <div
-              class="css-1i7ls3l"
+              class="css-bcsjsw"
             >
               277.83h total
             </div>
@@ -1201,28 +1201,28 @@ exports[`PlayTimeChart Theme Integration renders correctly in light mode 1`] = `
         type="button"
       >
         <div
-          class="css-w24l45"
+          class="css-2w7wic"
         >
           <img
             alt="PUBG: BATTLEGROUNDS header"
-            class="css-17nz09e"
+            class="css-ac7c24"
             src="https://example.com/pubg-header.jpg"
           />
           <div
-            class="css-17mv9gi"
+            class="css-18c3nn9"
           >
             3
           </div>
           <div
-            class="steam-game-card_caption css-k8brg5"
+            class="steam-game-card_caption css-18i3ee5"
           >
             <div
-              class="css-h3pxs9"
+              class="css-jae09u"
             >
               PUBG: BATTLEGROUNDS
             </div>
             <div
-              class="css-1i7ls3l"
+              class="css-bcsjsw"
             >
               200h total • 1h recently
             </div>
@@ -1231,24 +1231,24 @@ exports[`PlayTimeChart Theme Integration renders correctly in light mode 1`] = `
       </button>
     </div>
     <div
-      class="css-rcbrnq"
+      class="css-1jvjqv3"
     >
       <div
-        class="css-aq86v7"
+        class="css-12f4tqr"
       >
         Total Hours: 
         <span
-          class="css-1eduwqk"
+          class="css-13epqkc"
         >
           1235.2h
         </span>
       </div>
       <div
-        class="css-aq86v7"
+        class="css-12f4tqr"
       >
         Average: 
         <span
-          class="css-1eduwqk"
+          class="css-13epqkc"
         >
           411.7h per game
         </span>

--- a/theme/src/components/widgets/steam/__snapshots__/steam-widget.spec.js.snap
+++ b/theme/src/components/widgets/steam/__snapshots__/steam-widget.spec.js.snap
@@ -27,7 +27,7 @@ exports[`SteamWidget renders AI summary if present 1`] = `
       </p>
     </div>
     <div
-      class="css-5abbi3"
+      class="css-1uxgoez"
     >
       <h3
         class="css-9nh3l5"
@@ -41,7 +41,7 @@ exports[`SteamWidget renders AI summary if present 1`] = `
       Games I've played in the last two weeks.
     </p>
     <div
-      class="css-1o4v4vi"
+      class="css-1dx5shc"
     >
       <button
         aria-label="View Half-Life on Steam"
@@ -49,23 +49,23 @@ exports[`SteamWidget renders AI summary if present 1`] = `
         type="button"
       >
         <div
-          class="css-w24l45"
+          class="css-2w7wic"
         >
           <img
             alt="Half-Life header"
-            class="css-17nz09e"
+            class="css-ac7c24"
             src="https://example.com/halflife.jpg"
           />
           <div
-            class="steam-game-card_caption css-k8brg5"
+            class="steam-game-card_caption css-18i3ee5"
           >
             <div
-              class="css-h3pxs9"
+              class="css-jae09u"
             >
               Half-Life
             </div>
             <div
-              class="css-1i7ls3l"
+              class="css-bcsjsw"
             >
               2 hours
             </div>
@@ -78,23 +78,23 @@ exports[`SteamWidget renders AI summary if present 1`] = `
         type="button"
       >
         <div
-          class="css-w24l45"
+          class="css-2w7wic"
         >
           <img
             alt="Portal header"
-            class="css-17nz09e"
+            class="css-ac7c24"
             src="https://example.com/portal.jpg"
           />
           <div
-            class="steam-game-card_caption css-k8brg5"
+            class="steam-game-card_caption css-18i3ee5"
           >
             <div
-              class="css-h3pxs9"
+              class="css-jae09u"
             >
               Portal
             </div>
             <div
-              class="css-1i7ls3l"
+              class="css-bcsjsw"
             >
               45 minutes
             </div>
@@ -103,7 +103,7 @@ exports[`SteamWidget renders AI summary if present 1`] = `
       </button>
     </div>
     <div
-      class="css-5abbi3"
+      class="css-1uxgoez"
     >
       <h3
         class="css-9nh3l5"
@@ -117,7 +117,7 @@ exports[`SteamWidget renders AI summary if present 1`] = `
       My top 10 most played games.
     </p>
     <div
-      class="css-sak8bt"
+      class="css-lnnjou"
     >
       <div
         class="css-munl51"
@@ -128,28 +128,28 @@ exports[`SteamWidget renders AI summary if present 1`] = `
           type="button"
         >
           <div
-            class="css-w24l45"
+            class="css-2w7wic"
           >
             <img
               alt="Cities: Skylines header"
-              class="css-17nz09e"
+              class="css-ac7c24"
               src="https://example.com/cities-icon.jpg"
             />
             <div
-              class="css-17mv9gi"
+              class="css-18c3nn9"
             >
               1
             </div>
             <div
-              class="steam-game-card_caption css-k8brg5"
+              class="steam-game-card_caption css-18i3ee5"
             >
               <div
-                class="css-h3pxs9"
+                class="css-jae09u"
               >
                 Cities: Skylines
               </div>
               <div
-                class="css-1i7ls3l"
+                class="css-bcsjsw"
               >
                 757.35h total • 2 hours recently
               </div>
@@ -162,28 +162,28 @@ exports[`SteamWidget renders AI summary if present 1`] = `
           type="button"
         >
           <div
-            class="css-w24l45"
+            class="css-2w7wic"
           >
             <img
               alt="ARK: Survival Evolved header"
-              class="css-17nz09e"
+              class="css-ac7c24"
               src="https://example.com/ark-icon.jpg"
             />
             <div
-              class="css-17mv9gi"
+              class="css-18c3nn9"
             >
               2
             </div>
             <div
-              class="steam-game-card_caption css-k8brg5"
+              class="steam-game-card_caption css-18i3ee5"
             >
               <div
-                class="css-h3pxs9"
+                class="css-jae09u"
               >
                 ARK: Survival Evolved
               </div>
               <div
-                class="css-1i7ls3l"
+                class="css-bcsjsw"
               >
                 277.83h total
               </div>
@@ -192,34 +192,34 @@ exports[`SteamWidget renders AI summary if present 1`] = `
         </button>
       </div>
       <div
-        class="css-rcbrnq"
+        class="css-1jvjqv3"
       >
         <div
-          class="css-aq86v7"
+          class="css-12f4tqr"
         >
           Total Hours: 
           <span
-            class="css-1eduwqk"
+            class="css-13epqkc"
           >
             1035.2h
           </span>
         </div>
         <div
-          class="css-aq86v7"
+          class="css-12f4tqr"
         >
           Average: 
           <span
-            class="css-1eduwqk"
+            class="css-13epqkc"
           >
             517.6h per game
           </span>
         </div>
       </div>
       <div
-        class="css-1gnkw3u"
+        class="css-1wrm9ji"
       >
         <a
-          class="css-4buc8m"
+          class="css-1vusgb5"
           href="https://steamcommunity.com/id/themeuser/games/?tab=all"
         >
           View complete gaming library
@@ -256,7 +256,7 @@ exports[`SteamWidget renders correctly with sample data 1`] = `
       Steam
     </div>
     <div
-      class="css-5abbi3"
+      class="css-1uxgoez"
     >
       <h3
         class="css-9nh3l5"
@@ -270,7 +270,7 @@ exports[`SteamWidget renders correctly with sample data 1`] = `
       Games I've played in the last two weeks.
     </p>
     <div
-      class="css-1o4v4vi"
+      class="css-1dx5shc"
     >
       <button
         aria-label="View Half-Life on Steam"
@@ -278,23 +278,23 @@ exports[`SteamWidget renders correctly with sample data 1`] = `
         type="button"
       >
         <div
-          class="css-w24l45"
+          class="css-2w7wic"
         >
           <img
             alt="Half-Life header"
-            class="css-17nz09e"
+            class="css-ac7c24"
             src="https://example.com/halflife.jpg"
           />
           <div
-            class="steam-game-card_caption css-k8brg5"
+            class="steam-game-card_caption css-18i3ee5"
           >
             <div
-              class="css-h3pxs9"
+              class="css-jae09u"
             >
               Half-Life
             </div>
             <div
-              class="css-1i7ls3l"
+              class="css-bcsjsw"
             >
               2 hours
             </div>
@@ -307,23 +307,23 @@ exports[`SteamWidget renders correctly with sample data 1`] = `
         type="button"
       >
         <div
-          class="css-w24l45"
+          class="css-2w7wic"
         >
           <img
             alt="Portal header"
-            class="css-17nz09e"
+            class="css-ac7c24"
             src="https://example.com/portal.jpg"
           />
           <div
-            class="steam-game-card_caption css-k8brg5"
+            class="steam-game-card_caption css-18i3ee5"
           >
             <div
-              class="css-h3pxs9"
+              class="css-jae09u"
             >
               Portal
             </div>
             <div
-              class="css-1i7ls3l"
+              class="css-bcsjsw"
             >
               45 minutes
             </div>
@@ -332,7 +332,7 @@ exports[`SteamWidget renders correctly with sample data 1`] = `
       </button>
     </div>
     <div
-      class="css-5abbi3"
+      class="css-1uxgoez"
     >
       <h3
         class="css-9nh3l5"
@@ -346,7 +346,7 @@ exports[`SteamWidget renders correctly with sample data 1`] = `
       My top 10 most played games.
     </p>
     <div
-      class="css-sak8bt"
+      class="css-lnnjou"
     >
       <div
         class="css-munl51"
@@ -357,28 +357,28 @@ exports[`SteamWidget renders correctly with sample data 1`] = `
           type="button"
         >
           <div
-            class="css-w24l45"
+            class="css-2w7wic"
           >
             <img
               alt="Cities: Skylines header"
-              class="css-17nz09e"
+              class="css-ac7c24"
               src="https://example.com/cities-icon.jpg"
             />
             <div
-              class="css-17mv9gi"
+              class="css-18c3nn9"
             >
               1
             </div>
             <div
-              class="steam-game-card_caption css-k8brg5"
+              class="steam-game-card_caption css-18i3ee5"
             >
               <div
-                class="css-h3pxs9"
+                class="css-jae09u"
               >
                 Cities: Skylines
               </div>
               <div
-                class="css-1i7ls3l"
+                class="css-bcsjsw"
               >
                 757.35h total • 2 hours recently
               </div>
@@ -391,28 +391,28 @@ exports[`SteamWidget renders correctly with sample data 1`] = `
           type="button"
         >
           <div
-            class="css-w24l45"
+            class="css-2w7wic"
           >
             <img
               alt="ARK: Survival Evolved header"
-              class="css-17nz09e"
+              class="css-ac7c24"
               src="https://example.com/ark-icon.jpg"
             />
             <div
-              class="css-17mv9gi"
+              class="css-18c3nn9"
             >
               2
             </div>
             <div
-              class="steam-game-card_caption css-k8brg5"
+              class="steam-game-card_caption css-18i3ee5"
             >
               <div
-                class="css-h3pxs9"
+                class="css-jae09u"
               >
                 ARK: Survival Evolved
               </div>
               <div
-                class="css-1i7ls3l"
+                class="css-bcsjsw"
               >
                 277.83h total
               </div>
@@ -421,34 +421,34 @@ exports[`SteamWidget renders correctly with sample data 1`] = `
         </button>
       </div>
       <div
-        class="css-rcbrnq"
+        class="css-1jvjqv3"
       >
         <div
-          class="css-aq86v7"
+          class="css-12f4tqr"
         >
           Total Hours: 
           <span
-            class="css-1eduwqk"
+            class="css-13epqkc"
           >
             1035.2h
           </span>
         </div>
         <div
-          class="css-aq86v7"
+          class="css-12f4tqr"
         >
           Average: 
           <span
-            class="css-1eduwqk"
+            class="css-13epqkc"
           >
             517.6h per game
           </span>
         </div>
       </div>
       <div
-        class="css-1gnkw3u"
+        class="css-1wrm9ji"
       >
         <a
-          class="css-4buc8m"
+          class="css-1vusgb5"
           href="https://steamcommunity.com/id/themeuser/games/?tab=all"
         >
           View complete gaming library
@@ -485,7 +485,7 @@ exports[`SteamWidget renders error state (hasFatalError) 1`] = `
       Steam
     </div>
     <div
-      class="css-5abbi3"
+      class="css-1uxgoez"
     >
       <h3
         class="css-9nh3l5"
@@ -499,10 +499,10 @@ exports[`SteamWidget renders error state (hasFatalError) 1`] = `
       My top 10 most played games.
     </p>
     <div
-      class="css-sak8bt"
+      class="css-lnnjou"
     >
       <div
-        class="css-16q7rgc"
+        class="css-et6zal"
       >
         <p
           class="css-13s56l1"
@@ -560,7 +560,7 @@ exports[`SteamWidget renders loading state 1`] = `
       </div>
     </div>
     <div
-      class="css-5abbi3"
+      class="css-1uxgoez"
     >
       <h3
         class="css-9nh3l5"
@@ -574,11 +574,11 @@ exports[`SteamWidget renders loading state 1`] = `
       Games I've played in the last two weeks.
     </p>
     <div
-      class="css-1o4v4vi"
+      class="css-1dx5shc"
     >
       <div
         aria-hidden="true"
-        class="css-uk8v2r"
+        class="css-11qn5ob"
       >
         <div
           class="show-loading-animation"
@@ -592,7 +592,7 @@ exports[`SteamWidget renders loading state 1`] = `
       </div>
       <div
         aria-hidden="true"
-        class="css-uk8v2r"
+        class="css-11qn5ob"
       >
         <div
           class="show-loading-animation"
@@ -606,7 +606,7 @@ exports[`SteamWidget renders loading state 1`] = `
       </div>
       <div
         aria-hidden="true"
-        class="css-uk8v2r"
+        class="css-11qn5ob"
       >
         <div
           class="show-loading-animation"
@@ -620,7 +620,7 @@ exports[`SteamWidget renders loading state 1`] = `
       </div>
       <div
         aria-hidden="true"
-        class="css-uk8v2r"
+        class="css-11qn5ob"
       >
         <div
           class="show-loading-animation"
@@ -634,7 +634,7 @@ exports[`SteamWidget renders loading state 1`] = `
       </div>
       <div
         aria-hidden="true"
-        class="css-uk8v2r"
+        class="css-11qn5ob"
       >
         <div
           class="show-loading-animation"
@@ -648,7 +648,7 @@ exports[`SteamWidget renders loading state 1`] = `
       </div>
       <div
         aria-hidden="true"
-        class="css-uk8v2r"
+        class="css-11qn5ob"
       >
         <div
           class="show-loading-animation"
@@ -662,7 +662,7 @@ exports[`SteamWidget renders loading state 1`] = `
       </div>
     </div>
     <div
-      class="css-5abbi3"
+      class="css-1uxgoez"
     >
       <h3
         class="css-9nh3l5"
@@ -676,13 +676,13 @@ exports[`SteamWidget renders loading state 1`] = `
       My top 10 most played games.
     </p>
     <div
-      class="css-sak8bt"
+      class="css-lnnjou"
     >
       <div
-        class="css-nyc2gr"
+        class="css-1g612vj"
       >
         <div
-          class="css-17cb55"
+          class="css-3wu3l6"
         />
         <p
           class="css-gej412"
@@ -706,7 +706,7 @@ exports[`SteamWidget renders with empty metrics 1`] = `
       Steam
     </div>
     <div
-      class="css-5abbi3"
+      class="css-1uxgoez"
     >
       <h3
         class="css-9nh3l5"
@@ -720,7 +720,7 @@ exports[`SteamWidget renders with empty metrics 1`] = `
       Games I've played in the last two weeks.
     </p>
     <div
-      class="css-1o4v4vi"
+      class="css-1dx5shc"
     >
       <button
         aria-label="View Half-Life on Steam"
@@ -728,23 +728,23 @@ exports[`SteamWidget renders with empty metrics 1`] = `
         type="button"
       >
         <div
-          class="css-w24l45"
+          class="css-2w7wic"
         >
           <img
             alt="Half-Life header"
-            class="css-17nz09e"
+            class="css-ac7c24"
             src="https://example.com/halflife.jpg"
           />
           <div
-            class="steam-game-card_caption css-k8brg5"
+            class="steam-game-card_caption css-18i3ee5"
           >
             <div
-              class="css-h3pxs9"
+              class="css-jae09u"
             >
               Half-Life
             </div>
             <div
-              class="css-1i7ls3l"
+              class="css-bcsjsw"
             >
               2 hours
             </div>
@@ -757,23 +757,23 @@ exports[`SteamWidget renders with empty metrics 1`] = `
         type="button"
       >
         <div
-          class="css-w24l45"
+          class="css-2w7wic"
         >
           <img
             alt="Portal header"
-            class="css-17nz09e"
+            class="css-ac7c24"
             src="https://example.com/portal.jpg"
           />
           <div
-            class="steam-game-card_caption css-k8brg5"
+            class="steam-game-card_caption css-18i3ee5"
           >
             <div
-              class="css-h3pxs9"
+              class="css-jae09u"
             >
               Portal
             </div>
             <div
-              class="css-1i7ls3l"
+              class="css-bcsjsw"
             >
               45 minutes
             </div>
@@ -782,7 +782,7 @@ exports[`SteamWidget renders with empty metrics 1`] = `
       </button>
     </div>
     <div
-      class="css-5abbi3"
+      class="css-1uxgoez"
     >
       <h3
         class="css-9nh3l5"
@@ -796,7 +796,7 @@ exports[`SteamWidget renders with empty metrics 1`] = `
       My top 10 most played games.
     </p>
     <div
-      class="css-sak8bt"
+      class="css-lnnjou"
     >
       <div
         class="css-munl51"
@@ -807,28 +807,28 @@ exports[`SteamWidget renders with empty metrics 1`] = `
           type="button"
         >
           <div
-            class="css-w24l45"
+            class="css-2w7wic"
           >
             <img
               alt="Cities: Skylines header"
-              class="css-17nz09e"
+              class="css-ac7c24"
               src="https://example.com/cities-icon.jpg"
             />
             <div
-              class="css-17mv9gi"
+              class="css-18c3nn9"
             >
               1
             </div>
             <div
-              class="steam-game-card_caption css-k8brg5"
+              class="steam-game-card_caption css-18i3ee5"
             >
               <div
-                class="css-h3pxs9"
+                class="css-jae09u"
               >
                 Cities: Skylines
               </div>
               <div
-                class="css-1i7ls3l"
+                class="css-bcsjsw"
               >
                 757.35h total • 2 hours recently
               </div>
@@ -841,28 +841,28 @@ exports[`SteamWidget renders with empty metrics 1`] = `
           type="button"
         >
           <div
-            class="css-w24l45"
+            class="css-2w7wic"
           >
             <img
               alt="ARK: Survival Evolved header"
-              class="css-17nz09e"
+              class="css-ac7c24"
               src="https://example.com/ark-icon.jpg"
             />
             <div
-              class="css-17mv9gi"
+              class="css-18c3nn9"
             >
               2
             </div>
             <div
-              class="steam-game-card_caption css-k8brg5"
+              class="steam-game-card_caption css-18i3ee5"
             >
               <div
-                class="css-h3pxs9"
+                class="css-jae09u"
               >
                 ARK: Survival Evolved
               </div>
               <div
-                class="css-1i7ls3l"
+                class="css-bcsjsw"
               >
                 277.83h total
               </div>
@@ -871,34 +871,34 @@ exports[`SteamWidget renders with empty metrics 1`] = `
         </button>
       </div>
       <div
-        class="css-rcbrnq"
+        class="css-1jvjqv3"
       >
         <div
-          class="css-aq86v7"
+          class="css-12f4tqr"
         >
           Total Hours: 
           <span
-            class="css-1eduwqk"
+            class="css-13epqkc"
           >
             1035.2h
           </span>
         </div>
         <div
-          class="css-aq86v7"
+          class="css-12f4tqr"
         >
           Average: 
           <span
-            class="css-1eduwqk"
+            class="css-13epqkc"
           >
             517.6h per game
           </span>
         </div>
       </div>
       <div
-        class="css-1gnkw3u"
+        class="css-1wrm9ji"
       >
         <a
-          class="css-4buc8m"
+          class="css-1vusgb5"
           href="https://steamcommunity.com/id/themeuser/games/?tab=all"
         >
           View complete gaming library
@@ -935,7 +935,7 @@ exports[`SteamWidget renders with empty recentlyPlayedGames and ownedGames 1`] =
       Steam
     </div>
     <div
-      class="css-5abbi3"
+      class="css-1uxgoez"
     >
       <h3
         class="css-9nh3l5"
@@ -949,10 +949,10 @@ exports[`SteamWidget renders with empty recentlyPlayedGames and ownedGames 1`] =
       My top 10 most played games.
     </p>
     <div
-      class="css-sak8bt"
+      class="css-lnnjou"
     >
       <div
-        class="css-16q7rgc"
+        class="css-et6zal"
       >
         <p
           class="css-13s56l1"

--- a/theme/src/components/widgets/steam/play-time-chart.js
+++ b/theme/src/components/widgets/steam/play-time-chart.js
@@ -1,5 +1,5 @@
 /** @jsx jsx */
-import { jsx, useThemeUI } from 'theme-ui'
+import { jsx, Box, useThemeUI } from 'theme-ui'
 import { Themed } from '@theme-ui/mdx'
 import { Grid } from '@theme-ui/components'
 import getTimeSpent from './get-time-spent'
@@ -7,7 +7,14 @@ import isDarkMode from '../../../helpers/isDarkMode'
 import ViewExternal from '../view-external'
 import SteamGameCard from './steam-game-card'
 
-// Accept profileURL as a prop
+/** Subtitle shown under leaderboard cards (recent playtime appended when present). */
+const leaderboardSubtitle = game => {
+  const hours = `${game.hoursPlayed}h total`
+  if (!game.playTime2Weeks) return hours
+  const recentLabel = getTimeSpent(game.playTime2Weeks * 60 * 1000)
+  return `${hours} • ${recentLabel} recently`
+}
+
 const PlayTimeChart = ({ games = [], isLoading = false, profileURL = '' }) => {
   const { colorMode, theme } = useThemeUI()
   const darkModeActive = isDarkMode(colorMode)
@@ -15,7 +22,6 @@ const PlayTimeChart = ({ games = [], isLoading = false, profileURL = '' }) => {
   const primaryRgb = theme?.colors?.primaryRgb ?? (darkModeActive ? '74, 158, 255' : '66, 46, 163')
   const mutedTextColor = darkModeActive ? '#888' : '#666'
 
-  // Prepare data - top 10 games by playtime
   const topGames = (games || [])
     .filter(game => game.playTimeForever > 0)
     .sort((a, b) => b.playTimeForever - a.playTimeForever)
@@ -26,11 +32,10 @@ const PlayTimeChart = ({ games = [], isLoading = false, profileURL = '' }) => {
       rank: index + 1
     }))
 
-  // Loading state
   if (isLoading) {
     return (
-      <div sx={{ mb: 4 }}>
-        <div
+      <Box sx={{ mb: 4 }}>
+        <Box
           sx={{
             display: 'flex',
             flexDirection: 'column',
@@ -39,7 +44,7 @@ const PlayTimeChart = ({ games = [], isLoading = false, profileURL = '' }) => {
             py: 5
           }}
         >
-          <div
+          <Box
             sx={{
               width: '60px',
               height: '60px',
@@ -63,21 +68,15 @@ const PlayTimeChart = ({ games = [], isLoading = false, profileURL = '' }) => {
           >
             Loading Gaming Library...
           </Themed.p>
-        </div>
-      </div>
+        </Box>
+      </Box>
     )
   }
 
-  // Empty state when not loading
   if (!games || games.length === 0) {
     return (
-      <div sx={{ mb: 4 }}>
-        <div
-          sx={{
-            textAlign: 'center',
-            py: 5
-          }}
-        >
+      <Box sx={{ mb: 4 }}>
+        <Box sx={{ textAlign: 'center', py: 5 }}>
           <Themed.p
             sx={{
               fontStyle: 'italic',
@@ -87,13 +86,15 @@ const PlayTimeChart = ({ games = [], isLoading = false, profileURL = '' }) => {
           >
             No gaming data available for library.
           </Themed.p>
-        </div>
-      </div>
+        </Box>
+      </Box>
     )
   }
 
+  const gamesHref = profileURL ? `${profileURL.replace(/\/$/, '')}/games/?tab=all` : null
+
   return (
-    <div sx={{ mb: 4 }}>
+    <Box sx={{ mb: 4 }}>
       <Grid
         sx={{
           gridGap: [3, 2, 2, 3],
@@ -108,18 +109,11 @@ const PlayTimeChart = ({ games = [], isLoading = false, profileURL = '' }) => {
         }}
       >
         {topGames.map(game => (
-          <SteamGameCard
-            key={game.id}
-            game={game}
-            showRank={true}
-            rank={game.rank}
-            subtitle={`${game.hoursPlayed}h total${game.playTime2Weeks ? ` • ${getTimeSpent(game.playTime2Weeks * 60 * 1000)} recently` : ''}`}
-          />
+          <SteamGameCard key={game.id} game={game} showRank rank={game.rank} subtitle={leaderboardSubtitle(game)} />
         ))}
       </Grid>
 
-      {/* Footer Stats */}
-      <div
+      <Box
         sx={{
           mt: 4,
           pt: 3,
@@ -131,30 +125,25 @@ const PlayTimeChart = ({ games = [], isLoading = false, profileURL = '' }) => {
           gap: 3
         }}
       >
-        <div sx={{ color: mutedTextColor, fontSize: '12px' }}>
+        <Box sx={{ color: mutedTextColor, fontSize: '12px' }}>
           Total Hours:{' '}
-          <span sx={{ color: primaryColor, fontWeight: 'bold' }}>
+          <Box as='span' sx={{ color: primaryColor, fontWeight: 'bold' }}>
             {topGames.reduce((sum, game) => sum + game.hoursPlayed, 0).toFixed(1)}h
-          </span>
-        </div>
-        <div sx={{ color: mutedTextColor, fontSize: '12px' }}>
+          </Box>
+        </Box>
+        <Box sx={{ color: mutedTextColor, fontSize: '12px' }}>
           Average:{' '}
-          <span sx={{ color: primaryColor, fontWeight: 'bold' }}>
+          <Box as='span' sx={{ color: primaryColor, fontWeight: 'bold' }}>
             {(topGames.reduce((sum, game) => sum + game.hoursPlayed, 0) / topGames.length).toFixed(1)}h per game
-          </span>
-        </div>
-      </div>
+          </Box>
+        </Box>
+      </Box>
 
-      {/* View All Games Link */}
-      {profileURL && (
-        <div
-          sx={{
-            mt: 3,
-            textAlign: 'center'
-          }}
-        >
-          <a
-            href={`${profileURL.replace(/\/$/, '')}/games/?tab=all`}
+      {gamesHref ? (
+        <Box sx={{ mt: 3, textAlign: 'center' }}>
+          <Box
+            as='a'
+            href={gamesHref}
             sx={{
               color: primaryColor,
               textDecoration: 'none',
@@ -177,10 +166,10 @@ const PlayTimeChart = ({ games = [], isLoading = false, profileURL = '' }) => {
           >
             View complete gaming library
             <ViewExternal />
-          </a>
-        </div>
-      )}
-    </div>
+          </Box>
+        </Box>
+      ) : null}
+    </Box>
   )
 }
 

--- a/theme/src/components/widgets/steam/steam-game-card.js
+++ b/theme/src/components/widgets/steam/steam-game-card.js
@@ -7,8 +7,126 @@ import LazyLoad from '../../lazy-load'
 
 import 'react-placeholder/lib/reactPlaceholder.css'
 
-/** px; must match lazy placeholder + RectShape — img can't use height % inside LazyLoad’s auto-height Box */
+/** px; must match lazy placeholder + RectShape — img can't use height % inside LazyLoad's auto-height Box */
 const STEAM_CARD_IMAGE_HEIGHT = 200
+
+const SteamCardGameMedia = ({ darkModeActive, game, gameImage, isImageZoomed, rank, showRank, subtitle }) => (
+  <Box
+    sx={{
+      position: 'relative',
+      width: '100%',
+      height: STEAM_CARD_IMAGE_HEIGHT,
+      overflow: 'hidden'
+    }}
+  >
+    {gameImage ? (
+      <LazyLoad
+        placeholder={
+          <div className='show-loading-animation' style={{ width: '100%', height: STEAM_CARD_IMAGE_HEIGHT }}>
+            <RectShape
+              color={darkModeActive ? '#3a3a4a' : '#efefef'}
+              style={{
+                width: '100%',
+                height: STEAM_CARD_IMAGE_HEIGHT
+              }}
+            />
+          </div>
+        }
+      >
+        <Box
+          alt={`${game.displayName} header`}
+          as='img'
+          src={gameImage}
+          sx={{
+            display: 'block',
+            width: '100%',
+            height: STEAM_CARD_IMAGE_HEIGHT,
+            objectFit: 'cover',
+            transition: 'transform 0.3s ease',
+            transform: isImageZoomed ? 'scale(1.05)' : 'scale(1)'
+          }}
+        />
+      </LazyLoad>
+    ) : (
+      <div className='show-loading-animation' style={{ width: '100%', height: STEAM_CARD_IMAGE_HEIGHT }}>
+        <RectShape
+          color={darkModeActive ? '#3a3a4a' : '#efefef'}
+          style={{
+            width: '100%',
+            height: STEAM_CARD_IMAGE_HEIGHT
+          }}
+        />
+      </div>
+    )}
+
+    {showRank && rank ? (
+      <Box
+        sx={{
+          position: 'absolute',
+          top: 2,
+          left: 2,
+          zIndex: 2,
+          background: darkModeActive ? 'rgba(20, 20, 31, 0.85)' : 'rgba(255, 255, 255, 0.9)',
+          backdropFilter: 'blur(10px)',
+          WebkitBackdropFilter: 'blur(10px)',
+          border: darkModeActive ? '1px solid rgba(255, 255, 255, 0.2)' : '1px solid rgba(0, 0, 0, 0.1)',
+          color: darkModeActive ? '#fff' : '#000',
+          width: '28px',
+          height: '28px',
+          borderRadius: '50%',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          fontWeight: 'bold',
+          fontSize: '12px',
+          boxShadow: darkModeActive ? '0 4px 16px rgba(0, 0, 0, 0.4)' : '0 4px 16px rgba(0, 0, 0, 0.15)'
+        }}
+      >
+        {rank}
+      </Box>
+    ) : null}
+
+    <Box
+      className='steam-game-card_caption'
+      sx={{
+        alignItems: 'center',
+        background: 'rgba(0, 0, 0, 0.85)',
+        backdropFilter: 'blur(2px)',
+        WebkitBackdropFilter: 'blur(2px)',
+        bottom: 0,
+        color: 'white',
+        display: 'flex',
+        flexDirection: 'column',
+        justifyContent: 'center',
+        left: 0,
+        opacity: 0,
+        padding: 3,
+        pointerEvents: 'none',
+        position: 'absolute',
+        right: 0,
+        textAlign: 'center',
+        top: 0,
+        transition: 'opacity 0.2s ease-in-out',
+        zIndex: 1
+      }}
+    >
+      <Box
+        sx={{
+          fontSize: '14px',
+          fontWeight: 'bold',
+          mb: subtitle ? 1 : 0,
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          whiteSpace: 'nowrap',
+          width: '100%'
+        }}
+      >
+        {game.displayName}
+      </Box>
+      {subtitle ? <Box sx={{ fontSize: '12px', color: 'rgba(255,255,255,0.85)' }}>{subtitle}</Box> : null}
+    </Box>
+  </Box>
+)
 
 const SteamGameCard = ({ game, showRank = false, rank = null, subtitle = null, onClick = null }) => {
   const [isHovered, setIsHovered] = useState(false)
@@ -54,132 +172,15 @@ const SteamGameCard = ({ game, showRank = false, rank = null, subtitle = null, o
         }
       }}
     >
-      {/* Game Image */}
-      <div
-        sx={{
-          position: 'relative',
-          width: '100%',
-          height: STEAM_CARD_IMAGE_HEIGHT,
-          overflow: 'hidden'
-        }}
-      >
-        {gameImage ? (
-          <LazyLoad
-            placeholder={
-              <div className='show-loading-animation' style={{ width: '100%', height: STEAM_CARD_IMAGE_HEIGHT }}>
-                <RectShape
-                  color={darkModeActive ? '#3a3a4a' : '#efefef'}
-                  style={{
-                    width: '100%',
-                    height: STEAM_CARD_IMAGE_HEIGHT
-                  }}
-                />
-              </div>
-            }
-          >
-            <img
-              src={gameImage}
-              alt={`${game.displayName} header`}
-              sx={{
-                display: 'block',
-                width: '100%',
-                height: STEAM_CARD_IMAGE_HEIGHT,
-                objectFit: 'cover',
-                transition: 'transform 0.3s ease',
-                transform: isImageZoomed ? 'scale(1.05)' : 'scale(1)'
-              }}
-            />
-          </LazyLoad>
-        ) : (
-          <div className='show-loading-animation' style={{ width: '100%', height: STEAM_CARD_IMAGE_HEIGHT }}>
-            <RectShape
-              color={darkModeActive ? '#3a3a4a' : '#efefef'}
-              style={{
-                width: '100%',
-                height: STEAM_CARD_IMAGE_HEIGHT
-              }}
-            />
-          </div>
-        )}
-
-        {/* Rank Badge */}
-        {showRank && rank && (
-          <div
-            sx={{
-              position: 'absolute',
-              top: 2,
-              left: 2,
-              zIndex: 2,
-              background: darkModeActive ? 'rgba(20, 20, 31, 0.85)' : 'rgba(255, 255, 255, 0.9)',
-              backdropFilter: 'blur(10px)',
-              WebkitBackdropFilter: 'blur(10px)',
-              border: darkModeActive ? '1px solid rgba(255, 255, 255, 0.2)' : '1px solid rgba(0, 0, 0, 0.1)',
-              color: darkModeActive ? '#fff' : '#000',
-              width: '28px',
-              height: '28px',
-              borderRadius: '50%',
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-              fontWeight: 'bold',
-              fontSize: '12px',
-              boxShadow: darkModeActive ? '0 4px 16px rgba(0, 0, 0, 0.4)' : '0 4px 16px rgba(0, 0, 0, 0.15)'
-            }}
-          >
-            {rank}
-          </div>
-        )}
-
-        {/* Title / subtitle: hidden until hover or focus (Spotify media grid pattern) */}
-        <div
-          className='steam-game-card_caption'
-          sx={{
-            alignItems: 'center',
-            background: 'rgba(0, 0, 0, 0.85)',
-            backdropFilter: 'blur(2px)',
-            WebkitBackdropFilter: 'blur(2px)',
-            bottom: 0,
-            color: 'white',
-            display: 'flex',
-            flexDirection: 'column',
-            justifyContent: 'center',
-            left: 0,
-            opacity: 0,
-            padding: 3,
-            pointerEvents: 'none',
-            position: 'absolute',
-            right: 0,
-            textAlign: 'center',
-            top: 0,
-            transition: 'opacity 0.2s ease-in-out',
-            zIndex: 1
-          }}
-        >
-          <div
-            sx={{
-              fontSize: '14px',
-              fontWeight: 'bold',
-              mb: subtitle ? 1 : 0,
-              overflow: 'hidden',
-              textOverflow: 'ellipsis',
-              whiteSpace: 'nowrap',
-              width: '100%'
-            }}
-          >
-            {game.displayName}
-          </div>
-          {subtitle && (
-            <div
-              sx={{
-                fontSize: '12px',
-                color: 'rgba(255,255,255,0.85)'
-              }}
-            >
-              {subtitle}
-            </div>
-          )}
-        </div>
-      </div>
+      <SteamCardGameMedia
+        darkModeActive={darkModeActive}
+        game={game}
+        gameImage={gameImage}
+        isImageZoomed={isImageZoomed}
+        rank={rank}
+        showRank={showRank}
+        subtitle={subtitle}
+      />
     </Box>
   )
 }

--- a/theme/src/components/widgets/steam/steam-game-card.js
+++ b/theme/src/components/widgets/steam/steam-game-card.js
@@ -1,5 +1,6 @@
 /** @jsx jsx */
 import { jsx, Box, useThemeUI } from 'theme-ui'
+import PropTypes from 'prop-types'
 import { useState } from 'react'
 import { RectShape } from 'react-placeholder/lib/placeholders'
 import isDarkMode from '../../../helpers/isDarkMode'
@@ -9,6 +10,110 @@ import 'react-placeholder/lib/reactPlaceholder.css'
 
 /** px; must match lazy placeholder + RectShape — img can't use height % inside LazyLoad's auto-height Box */
 const STEAM_CARD_IMAGE_HEIGHT = 200
+
+/** @returns {Record<string, unknown>} Theme UI sx for rank pill */
+function steamRankBadgeSx(darkModeActive) {
+  return {
+    position: 'absolute',
+    top: 2,
+    left: 2,
+    zIndex: 2,
+    background: darkModeActive ? 'rgba(20, 20, 31, 0.85)' : 'rgba(255, 255, 255, 0.9)',
+    backdropFilter: 'blur(10px)',
+    WebkitBackdropFilter: 'blur(10px)',
+    border: darkModeActive ? '1px solid rgba(255, 255, 255, 0.2)' : '1px solid rgba(0, 0, 0, 0.1)',
+    color: darkModeActive ? '#fff' : '#000',
+    width: '28px',
+    height: '28px',
+    borderRadius: '50%',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    fontWeight: 'bold',
+    fontSize: '12px',
+    boxShadow: darkModeActive ? '0 4px 16px rgba(0, 0, 0, 0.4)' : '0 4px 16px rgba(0, 0, 0, 0.15)'
+  }
+}
+
+const SteamCardImagePlaceholder = ({ darkModeActive }) => {
+  const color = darkModeActive ? '#3a3a4a' : '#efefef'
+  return (
+    <div className='show-loading-animation' style={{ width: '100%', height: STEAM_CARD_IMAGE_HEIGHT }}>
+      <RectShape
+        color={color}
+        style={{
+          width: '100%',
+          height: STEAM_CARD_IMAGE_HEIGHT
+        }}
+      />
+    </div>
+  )
+}
+
+const SteamCardGameLazyImage = ({ darkModeActive, displayName, gameImage, isImageZoomed }) => (
+  <LazyLoad placeholder={<SteamCardImagePlaceholder darkModeActive={darkModeActive} />}>
+    <Box
+      alt={`${displayName} header`}
+      as='img'
+      src={gameImage}
+      sx={{
+        display: 'block',
+        width: '100%',
+        height: STEAM_CARD_IMAGE_HEIGHT,
+        objectFit: 'cover',
+        transition: 'transform 0.3s ease',
+        transform: isImageZoomed ? 'scale(1.05)' : 'scale(1)'
+      }}
+    />
+  </LazyLoad>
+)
+
+const SteamRankBadge = ({ darkModeActive, rank, showRank }) => {
+  if (!showRank || !rank) return null
+  return <Box sx={steamRankBadgeSx(darkModeActive)}>{rank}</Box>
+}
+
+const SteamGameCaptionOverlay = ({ displayName, subtitle }) => (
+  <Box
+    className='steam-game-card_caption'
+    sx={{
+      alignItems: 'center',
+      background: 'rgba(0, 0, 0, 0.85)',
+      backdropFilter: 'blur(2px)',
+      WebkitBackdropFilter: 'blur(2px)',
+      bottom: 0,
+      color: 'white',
+      display: 'flex',
+      flexDirection: 'column',
+      justifyContent: 'center',
+      left: 0,
+      opacity: 0,
+      padding: 3,
+      pointerEvents: 'none',
+      position: 'absolute',
+      right: 0,
+      textAlign: 'center',
+      top: 0,
+      transition: 'opacity 0.2s ease-in-out',
+      zIndex: 1
+    }}
+  >
+    <Box
+      sx={{
+        fontSize: '14px',
+        fontWeight: 'bold',
+        mb: subtitle ? 1 : 0,
+        overflow: 'hidden',
+        textOverflow: 'ellipsis',
+        whiteSpace: 'nowrap',
+        width: '100%'
+      }}
+    >
+      {displayName}
+    </Box>
+    {subtitle ? <Box sx={{ fontSize: '12px', color: 'rgba(255,255,255,0.85)' }}>{subtitle}</Box> : null}
+  </Box>
+)
 
 const SteamCardGameMedia = ({ darkModeActive, game, gameImage, isImageZoomed, rank, showRank, subtitle }) => (
   <Box
@@ -20,113 +125,31 @@ const SteamCardGameMedia = ({ darkModeActive, game, gameImage, isImageZoomed, ra
     }}
   >
     {gameImage ? (
-      <LazyLoad
-        placeholder={
-          <div className='show-loading-animation' style={{ width: '100%', height: STEAM_CARD_IMAGE_HEIGHT }}>
-            <RectShape
-              color={darkModeActive ? '#3a3a4a' : '#efefef'}
-              style={{
-                width: '100%',
-                height: STEAM_CARD_IMAGE_HEIGHT
-              }}
-            />
-          </div>
-        }
-      >
-        <Box
-          alt={`${game.displayName} header`}
-          as='img'
-          src={gameImage}
-          sx={{
-            display: 'block',
-            width: '100%',
-            height: STEAM_CARD_IMAGE_HEIGHT,
-            objectFit: 'cover',
-            transition: 'transform 0.3s ease',
-            transform: isImageZoomed ? 'scale(1.05)' : 'scale(1)'
-          }}
-        />
-      </LazyLoad>
+      <SteamCardGameLazyImage
+        darkModeActive={darkModeActive}
+        displayName={game.displayName}
+        gameImage={gameImage}
+        isImageZoomed={isImageZoomed}
+      />
     ) : (
-      <div className='show-loading-animation' style={{ width: '100%', height: STEAM_CARD_IMAGE_HEIGHT }}>
-        <RectShape
-          color={darkModeActive ? '#3a3a4a' : '#efefef'}
-          style={{
-            width: '100%',
-            height: STEAM_CARD_IMAGE_HEIGHT
-          }}
-        />
-      </div>
+      <SteamCardImagePlaceholder darkModeActive={darkModeActive} />
     )}
-
-    {showRank && rank ? (
-      <Box
-        sx={{
-          position: 'absolute',
-          top: 2,
-          left: 2,
-          zIndex: 2,
-          background: darkModeActive ? 'rgba(20, 20, 31, 0.85)' : 'rgba(255, 255, 255, 0.9)',
-          backdropFilter: 'blur(10px)',
-          WebkitBackdropFilter: 'blur(10px)',
-          border: darkModeActive ? '1px solid rgba(255, 255, 255, 0.2)' : '1px solid rgba(0, 0, 0, 0.1)',
-          color: darkModeActive ? '#fff' : '#000',
-          width: '28px',
-          height: '28px',
-          borderRadius: '50%',
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-          fontWeight: 'bold',
-          fontSize: '12px',
-          boxShadow: darkModeActive ? '0 4px 16px rgba(0, 0, 0, 0.4)' : '0 4px 16px rgba(0, 0, 0, 0.15)'
-        }}
-      >
-        {rank}
-      </Box>
-    ) : null}
-
-    <Box
-      className='steam-game-card_caption'
-      sx={{
-        alignItems: 'center',
-        background: 'rgba(0, 0, 0, 0.85)',
-        backdropFilter: 'blur(2px)',
-        WebkitBackdropFilter: 'blur(2px)',
-        bottom: 0,
-        color: 'white',
-        display: 'flex',
-        flexDirection: 'column',
-        justifyContent: 'center',
-        left: 0,
-        opacity: 0,
-        padding: 3,
-        pointerEvents: 'none',
-        position: 'absolute',
-        right: 0,
-        textAlign: 'center',
-        top: 0,
-        transition: 'opacity 0.2s ease-in-out',
-        zIndex: 1
-      }}
-    >
-      <Box
-        sx={{
-          fontSize: '14px',
-          fontWeight: 'bold',
-          mb: subtitle ? 1 : 0,
-          overflow: 'hidden',
-          textOverflow: 'ellipsis',
-          whiteSpace: 'nowrap',
-          width: '100%'
-        }}
-      >
-        {game.displayName}
-      </Box>
-      {subtitle ? <Box sx={{ fontSize: '12px', color: 'rgba(255,255,255,0.85)' }}>{subtitle}</Box> : null}
-    </Box>
+    <SteamRankBadge darkModeActive={darkModeActive} rank={rank} showRank={showRank} />
+    <SteamGameCaptionOverlay displayName={game.displayName} subtitle={subtitle} />
   </Box>
 )
+
+SteamCardGameMedia.propTypes = {
+  darkModeActive: PropTypes.bool.isRequired,
+  game: PropTypes.shape({
+    displayName: PropTypes.string.isRequired
+  }).isRequired,
+  gameImage: PropTypes.string.isRequired,
+  isImageZoomed: PropTypes.bool.isRequired,
+  rank: PropTypes.number,
+  showRank: PropTypes.bool.isRequired,
+  subtitle: PropTypes.string
+}
 
 const SteamGameCard = ({ game, showRank = false, rank = null, subtitle = null, onClick = null }) => {
   const [isHovered, setIsHovered] = useState(false)
@@ -177,9 +200,9 @@ const SteamGameCard = ({ game, showRank = false, rank = null, subtitle = null, o
         game={game}
         gameImage={gameImage}
         isImageZoomed={isImageZoomed}
-        rank={rank}
+        rank={rank == null ? undefined : rank}
         showRank={showRank}
-        subtitle={subtitle}
+        subtitle={subtitle == null ? undefined : subtitle}
       />
     </Box>
   )

--- a/theme/src/components/widgets/steam/steam-widget.js
+++ b/theme/src/components/widgets/steam/steam-widget.js
@@ -1,5 +1,5 @@
 /** @jsx jsx */
-import { jsx, useColorMode } from 'theme-ui'
+import { jsx, Box, useColorMode } from 'theme-ui'
 import { faSteam } from '@fortawesome/free-brands-svg-icons'
 import { Heading } from '@theme-ui/components'
 import { Themed } from '@theme-ui/mdx'
@@ -17,13 +17,17 @@ import AiSummarySkeleton from './ai-summary-skeleton'
 import PlayTimeChart from './play-time-chart'
 import SteamGameCard from './steam-game-card'
 
-const RECENTLY_PLAYED_PLACEHOLDER_COUNT = 6
-
 import { pickAiSummarySyncedAtRaw } from '../../../helpers/ai-summary-synced-at'
 import { getSteamWidgetDataSource } from '../../../selectors/metadata'
 import getTimeSpent from './get-time-spent'
 import useSiteMetadata from '../../../hooks/use-site-metadata'
 import useWidgetData from '../../../hooks/use-widget-data'
+
+const RECENTLY_PLAYED_PLACEHOLDER_COUNT = 6
+const STEAM_RECENT_GRID_PLACEHOLDER_KEYS = Array.from(
+  { length: RECENTLY_PLAYED_PLACEHOLDER_COUNT },
+  (_, i) => `steam-recent-sk-${String(i).padStart(2, '0')}`
+)
 
 const SteamWidget = React.memo(() => {
   const [colorMode] = useColorMode()
@@ -45,8 +49,7 @@ const SteamWidget = React.memo(() => {
 
   const callToAction = (
     <CallToAction title={`${profileDisplayName} on Steam`} url={profileURL} isLoading={isLoading}>
-      Visit Profile
-      <span className='read-more-icon'>&rarr;</span>
+      Visit Profile <span className='read-more-icon'>&rarr;</span>
     </CallToAction>
   )
 
@@ -61,15 +64,15 @@ const SteamWidget = React.memo(() => {
 
       {showRecentlyPlayedSection ? (
         <>
-          <div sx={{ display: 'flex', flex: 1, alignItems: 'center', mb: 3 }}>
+          <Box sx={{ display: 'flex', flex: 1, alignItems: 'center', mb: 3 }}>
             <Heading as='h3' sx={{ fontSize: [3, 4] }}>
               Recently-Played Games
             </Heading>
-          </div>
+          </Box>
 
           <Themed.p sx={{ mb: 4 }}>Games I've played in the last two weeks.</Themed.p>
 
-          <div
+          <Box
             sx={{
               display: 'grid',
               gridGap: [3, 2, 2, 3],
@@ -84,9 +87,9 @@ const SteamWidget = React.memo(() => {
             }}
           >
             {isLoading
-              ? Array.from({ length: RECENTLY_PLAYED_PLACEHOLDER_COUNT }).map((_, i) => (
-                  <div
-                    key={i}
+              ? STEAM_RECENT_GRID_PLACEHOLDER_KEYS.map(slotKey => (
+                  <Box
+                    key={slotKey}
                     aria-hidden
                     sx={{
                       variant: 'styles.InstagramItem',
@@ -101,7 +104,7 @@ const SteamWidget = React.memo(() => {
                         style={{ width: '100%', height: '200px', borderRadius: '8px' }}
                       />
                     </div>
-                  </div>
+                  </Box>
                 ))
               : recentlyPlayedGames.map(game => (
                   <SteamGameCard
@@ -111,15 +114,15 @@ const SteamWidget = React.memo(() => {
                     subtitle={getTimeSpent(game.playTime2Weeks * 60 * 1000)}
                   />
                 ))}
-          </div>
+          </Box>
         </>
       ) : null}
 
-      <div sx={{ display: 'flex', flex: 1, alignItems: 'center', mb: 3 }}>
+      <Box sx={{ display: 'flex', flex: 1, alignItems: 'center', mb: 3 }}>
         <Heading as='h3' sx={{ fontSize: [3, 4] }}>
           Leaderboard
         </Heading>
-      </div>
+      </Box>
 
       <Themed.p sx={{ mb: 4 }}>My top 10 most played games.</Themed.p>
 

--- a/theme/src/helpers/safeHtmlParser.js
+++ b/theme/src/helpers/safeHtmlParser.js
@@ -1,60 +1,10 @@
 import React from 'react'
-import parse, { domToReact, Element } from 'html-react-parser'
+import parse, { domToReact, Element as DomElement } from 'html-react-parser'
 
-/**
- * Safely converts HTML entities to React elements
- *
- * @param {string} text - The text containing HTML entities
- * @returns {React.ReactNode} - React elements or the original string
- */
-export const parseSafeHtml = text => {
-  if (!text || typeof text !== 'string') {
-    return text
-  }
+const ALLOWED_TAGS = ['b', 'i', 'em', 'br', 'a', 'p', 'strong']
 
-  const options = {
-    replace: domNode => {
-      if (domNode instanceof Element && domNode.attribs) {
-        const { name, attribs, children } = domNode
-
-        // Whitelist of allowed tags
-        const allowedTags = ['b', 'i', 'em', 'br', 'a', 'p', 'strong']
-
-        // Check if tag is allowed
-        if (!allowedTags.includes(name)) {
-          // For disallowed tags, return false to skip rendering the tag entirely
-          // but still process its children
-          return false
-        }
-
-        // Handle self-closing tags that don't have Themed equivalents
-        if (name === 'br') {
-          return <br key={Math.random()} />
-        }
-
-        // Handle anchor tags with href validation
-        if (name === 'a') {
-          const href = attribs.href
-          if (!href || !isValidUrl(href)) {
-            // If no valid href, just return the text content
-            return domNode.children && domNode.children.length > 0 ? domToReact(domNode.children, options) : null
-          }
-
-          return (
-            <a key={Math.random()} href={href} target='_blank' rel='noopener noreferrer'>
-              {domToReact(children, options)}
-            </a>
-          )
-        }
-
-        // Handle other allowed tags (b, i, em, p, strong) using regular HTML elements
-        const Element = name
-        return <Element key={Math.random()}>{domToReact(children, options)}</Element>
-      }
-    }
-  }
-
-  return parse(text, options)
+function isAllowedTag(name) {
+  return ALLOWED_TAGS.includes(name)
 }
 
 /**
@@ -69,6 +19,65 @@ const isValidUrl = url => {
   } catch {
     return false
   }
+}
+
+/**
+ * Safely converts HTML entities to React elements
+ *
+ * @param {string} text - The text containing HTML entities
+ * @returns {React.ReactNode} - React elements or the original string
+ */
+export const parseSafeHtml = text => {
+  if (!text || typeof text !== 'string') {
+    return text
+  }
+
+  let keySeed = 0
+  const nextKey = prefix => `${prefix}-${++keySeed}`
+
+  const renderAnchor = (domNode, children, nestedOptions, href, key) => {
+    if (!href || !isValidUrl(href)) {
+      return domNode.children?.length ? domToReact(domNode.children, nestedOptions) : null
+    }
+    return (
+      <a key={key} href={href} target='_blank' rel='noopener noreferrer'>
+        {domToReact(children, nestedOptions)}
+      </a>
+    )
+  }
+
+  const renderSemanticTag = (name, domChildren, key, nestedOptions) => {
+    const Tag = name
+    return <Tag key={key}>{domToReact(domChildren, nestedOptions)}</Tag>
+  }
+
+  const options = {
+    replace: domNode => {
+      if (!(domNode instanceof DomElement) || !domNode.attribs) {
+        return undefined
+      }
+
+      const { name, attribs, children } = domNode
+
+      if (!isAllowedTag(name)) {
+        return false
+      }
+
+      const key = nextKey(name)
+
+      if (name === 'br') {
+        return <br key={key} />
+      }
+
+      if (name === 'a') {
+        return renderAnchor(domNode, children, options, attribs.href, key)
+      }
+
+      return renderSemanticTag(name, children, key, options)
+    }
+  }
+
+  return parse(text, options)
 }
 
 export default parseSafeHtml

--- a/theme/src/helpers/safeHtmlParser.js
+++ b/theme/src/helpers/safeHtmlParser.js
@@ -1,10 +1,10 @@
 import React from 'react'
 import parse, { domToReact, Element as DomElement } from 'html-react-parser'
 
-const ALLOWED_TAGS = ['b', 'i', 'em', 'br', 'a', 'p', 'strong']
+const ALLOWED_TAGS = new Set(['b', 'i', 'em', 'br', 'a', 'p', 'strong'])
 
 function isAllowedTag(name) {
-  return ALLOWED_TAGS.includes(name)
+  return ALLOWED_TAGS.has(name)
 }
 
 /**

--- a/theme/src/shortcodes/__snapshots__/spotify.spec.js.snap
+++ b/theme/src/shortcodes/__snapshots__/spotify.spec.js.snap
@@ -2,14 +2,18 @@
 
 exports[`Spotify matches snapshot when valid URL is provided 1`] = `
 <DocumentFragment>
-  <iframe
-    allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture"
-    class="css-12egey"
-    height="152"
-    loading="lazy"
-    src="https://open.spotify.com/embed/track/123"
-    title="Spotify Embed"
-    width="100%"
-  />
+  <div
+    class="css-ery9uj"
+  >
+    <iframe
+      allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture"
+      height="152"
+      loading="lazy"
+      src="https://open.spotify.com/embed/track/123"
+      style="display: block;"
+      title="Spotify Embed"
+      width="100%"
+    />
+  </div>
 </DocumentFragment>
 `;

--- a/theme/src/shortcodes/soundcloud.js
+++ b/theme/src/shortcodes/soundcloud.js
@@ -1,6 +1,5 @@
 /** @jsx jsx */
-import { jsx } from 'theme-ui'
-import { useColorMode } from 'theme-ui'
+import { jsx, useColorMode } from 'theme-ui'
 
 // Use a theme-aware accent color for the SoundCloud player
 const buildSoundCloudEmbedURL = (trackId, isDarkMode) => {

--- a/theme/src/shortcodes/spotify.js
+++ b/theme/src/shortcodes/spotify.js
@@ -1,5 +1,5 @@
 /** @jsx jsx */
-import { jsx } from 'theme-ui'
+import { jsx, Box } from 'theme-ui'
 
 // Build embed URL from share URL so we can render a simple iframe (like SoundCloud).
 // This avoids oEmbed fetch + state, so the iframe is preserved across re-renders and
@@ -11,7 +11,7 @@ const SHARE_URL_REGEX = /^https?:\/\/open\.spotify\.com\/(track|album|playlist|a
 const buildEmbedURL = spotifyURL => {
   if (!spotifyURL || typeof spotifyURL !== 'string') return null
   const trimmed = spotifyURL.trim()
-  const match = trimmed.match(SHARE_URL_REGEX)
+  const match = SHARE_URL_REGEX.exec(trimmed)
   if (!match) return null
   const [, type, id] = match
   return `${SPOTIFY_EMBED_PATH}/${type}/${id}`
@@ -22,18 +22,17 @@ const Spotify = ({ spotifyURL }) => {
   if (!embedURL) return null
 
   return (
-    <iframe
-      allow='autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture'
-      height='152'
-      loading='lazy'
-      src={embedURL}
-      title='Spotify Embed'
-      width='100%'
-      sx={{
-        border: 'none',
-        borderRadius: '12px'
-      }}
-    />
+    <Box sx={{ border: 'none', borderRadius: '12px', overflow: 'hidden', lineHeight: 0 }}>
+      <iframe
+        allow='autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture'
+        height='152'
+        loading='lazy'
+        src={embedURL}
+        style={{ border: 'none', display: 'block' }}
+        title='Spotify Embed'
+        width='100%'
+      />
+    </Box>
   )
 }
 

--- a/theme/src/templates/__snapshots__/media.spec.js.snap
+++ b/theme/src/templates/__snapshots__/media.spec.js.snap
@@ -36,7 +36,13 @@ exports[`Media Post renders correctly with a SoundCloud source 1`] = `
             <a
               class="u-url"
               href="https://example.com/music/mock-media"
-            />
+            >
+              <span
+                class="css-17mbhtg"
+              >
+                https://example.com/music/mock-media
+              </span>
+            </a>
             <span
               class="u-uid"
             >
@@ -136,7 +142,13 @@ exports[`Media Post renders correctly with a YouTube source 1`] = `
             <a
               class="u-url"
               href="https://example.com/music/mock-media"
-            />
+            >
+              <span
+                class="css-17mbhtg"
+              >
+                https://example.com/music/mock-media
+              </span>
+            </a>
             <span
               class="u-uid"
             >
@@ -223,7 +235,13 @@ exports[`Media Post renders correctly with no media sources 1`] = `
             <a
               class="u-url"
               href="https://example.com/music/mock-media"
-            />
+            >
+              <span
+                class="css-17mbhtg"
+              >
+                https://example.com/music/mock-media
+              </span>
+            </a>
             <span
               class="u-uid"
             >

--- a/theme/src/templates/home.js
+++ b/theme/src/templates/home.js
@@ -1,5 +1,5 @@
 /** @jsx jsx */
-import { jsx, Container } from 'theme-ui'
+import { jsx, Container, Box } from 'theme-ui'
 import { graphql } from 'gatsby'
 import { Fragment } from 'react'
 import { SkipNavContent } from '../components/skip-nav'
@@ -25,37 +25,37 @@ const HomeTemplate = () => {
     <Fragment>
       <ScrollToHashWhenReady />
       <AnimatedPageBackground />
-      <div
+      <Box
         sx={{
           position: 'relative',
           zIndex: 1
         }}
       >
         <Layout hideFooter disableMainWrapper transparentBackground>
-          <div sx={homeDashboardPageOuterSx}>
+          <Box sx={homeDashboardPageOuterSx}>
             <Container>
               <HomeDashboardGrid
                 aside={<HomeNavigation />}
                 main={
                   <main role='main'>
                     <SkipNavContent />
-                    <div sx={homeDashboardMainShellSx}>
-                      <div sx={homeDashboardMainInnerMaxWidthSx}>
+                    <Box sx={homeDashboardMainShellSx}>
+                      <Box sx={homeDashboardMainInnerMaxWidthSx}>
                         <section id='top' tabIndex={-1}>
                           <HomeHeaderContent />
                         </section>
                         <HomeWidgets />
-                      </div>
-                    </div>
+                      </Box>
+                    </Box>
                     <Footer />
                     <HCard />
                   </main>
                 }
               />
             </Container>
-          </div>
+          </Box>
         </Layout>
-      </div>
+      </Box>
     </Fragment>
   )
 }

--- a/theme/src/templates/media.js
+++ b/theme/src/templates/media.js
@@ -1,5 +1,5 @@
 /** @jsx jsx */
-import { Container, Flex, jsx } from 'theme-ui'
+import { Container, Flex, jsx, Box } from 'theme-ui'
 import { Themed } from '@theme-ui/mdx'
 import { graphql } from 'gatsby'
 import React, { useEffect } from 'react'
@@ -74,17 +74,31 @@ const MediaTemplate = ({ data: { mdx }, children }) => {
 
             {/* Hidden microformats data */}
             <div style={{ display: 'none' }}>
-              <a className='u-url' href={canonicalUrl} />
+              <a className='u-url' href={canonicalUrl}>
+                <Box
+                  as='span'
+                  sx={{
+                    clip: 'rect(0 0 0 0)',
+                    clipPath: 'inset(50%)',
+                    height: '1px',
+                    overflow: 'hidden',
+                    position: 'absolute',
+                    whiteSpace: 'nowrap',
+                    width: '1px'
+                  }}
+                >
+                  {canonicalUrl}
+                </Box>
+              </a>
               <span className='u-uid'>{mdx.id}</span>
               {description && <div className='p-summary'>{description}</div>}
               {banner && <img className='u-photo' src={banner} alt='' />}
               {category && <span className='p-category'>{category}</span>}
-              {keywords &&
-                keywords.map((keyword, index) => (
-                  <span key={index} className='p-category'>
-                    {keyword}
-                  </span>
-                ))}
+              {keywords?.map(keyword => (
+                <span key={keyword} className='p-category'>
+                  {keyword}
+                </span>
+              ))}
             </div>
 
             <div className='e-content article-content'>{children}</div>

--- a/theme/src/templates/media.js
+++ b/theme/src/templates/media.js
@@ -3,6 +3,7 @@ import { Container, Flex, jsx, Box } from 'theme-ui'
 import { Themed } from '@theme-ui/mdx'
 import { graphql } from 'gatsby'
 import React, { useEffect } from 'react'
+import PropTypes from 'prop-types'
 import Category from '../components/category'
 import Layout from '../components/layout'
 import PageHeader from '../components/blog/page-header'
@@ -107,6 +108,28 @@ const MediaTemplate = ({ data: { mdx }, children }) => {
       </Flex>
     </Layout>
   )
+}
+
+MediaTemplate.propTypes = {
+  children: PropTypes.node,
+  data: PropTypes.shape({
+    mdx: PropTypes.shape({
+      id: PropTypes.string.isRequired,
+      fields: PropTypes.shape({
+        category: PropTypes.string,
+        path: PropTypes.string.isRequired
+      }).isRequired,
+      frontmatter: PropTypes.shape({
+        banner: PropTypes.string,
+        date: PropTypes.string,
+        description: PropTypes.string,
+        keywords: PropTypes.arrayOf(PropTypes.string),
+        soundcloudId: PropTypes.string,
+        title: PropTypes.string.isRequired,
+        youtubeSrc: PropTypes.string
+      }).isRequired
+    }).isRequired
+  }).isRequired
 }
 
 export const Head = ({ data: { mdx } }) => {

--- a/www.chrisvogt.me/package.json
+++ b/www.chrisvogt.me/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "www.chrisvogt.me",
-  "version": "1.22.1",
+  "version": "1.22.2",
   "license": "GPL",
   "scripts": {
     "build": "gatsby build",

--- a/www.chronogrove.com/package.json
+++ b/www.chronogrove.com/package.json
@@ -1,6 +1,6 @@
 {
   "name": "www.chronogrove.com",
-  "version": "1.9.1",
+  "version": "1.9.2",
   "description": "Official demo site for gatsby-theme-chronogrove",
   "scripts": {
     "develop": "gatsby develop",


### PR DESCRIPTION
## Summary

Addresses Sonar-driven refactors across dashboard widgets and shared helpers, plus updated Jest snapshots after Emotion/class and minor DOM changes from those refactors.

## Commits

- **Flickr, GitHub, Goodreads, Instagram** — widget cleanups and related snapshot/test updates
- **Recent posts, Spotify, Steam, safeHtmlParser, shortcodes, templates** — further cleanups (for example `steam-game-card`, `play-time-chart`, Spotify grid/top-tracks/playlists, `post-card`)
- **Tests** — refresh snapshots for Steam/Spotify widget and playlist/track-preview specs so CI/pre-push passes

## How to test

- `pnpm test --filter gatsby-theme-chronogrove`

## Notes

- Snapshot churn is expected when `sx`/structure changes; no functional assertions were failing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk due to broad UI refactors across several widgets that can subtly change behavior (event handling, layout, accessibility) despite being mostly structural and styling-oriented.
> 
> **Overview**
> Performs Sonar-style cleanups across several widgets by standardizing markup on Theme UI `Box` (including `as='button'`/`as='img'`/`as='iframe'`) and explicitly setting button `type`, which changes generated Emotion classnames and updates snapshots.
> 
> Improves stability and maintainability in a few interactive components: GitHub `ContributionGraph` now uses helper functions for day-to-row mapping and legend colors plus stable skeleton keys; Instagram carousel rotation is refactored to avoid stale closures and uses stable indicator keys; Goodreads recently-read carousel adds keyboard navigation (`Arrow*` keys), uses stable skeleton keys, and adjusts initial scroll behavior.
> 
> Refactors `PostCard` to split wrapper vs body (`PostCardInner`) and replaces `Themed` headings/spans/times with Theme UI components for consistent styling, while Spotify grids/playlists/top-tracks adopt `Box` wrappers and stable placeholder keys; tests are updated accordingly (including reusable `mockOffsetWidth` and safer mocked event listener cleanup).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 83f0f85f1b0ba7c9ba02c692faea5ba6a677b667. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->