### PR TITLE
fix: noopener for Steam links, dataset for data-* reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,13 @@
 
 - **`steam-game-card.js`**: Opens the Steam store with **`window.open(..., '_blank', 'noopener,noreferrer')`** so the new tab cannot access **`window.opener`** (reverse tabnabbing).
 - **`color-mode-debug.js`**: Reads **`data-theme-ui-color-mode`** via **`document.documentElement.dataset.themeUiColorMode`** for debug output.
-- **Tests**: **`steam-game-card.spec.js`**, **`play-time-chart.spec.js`**, head/widget specs, **`color-mode-debug.spec.js`** (assert debug header reflects **`dataset`** / **`data-attr=none`**), **`browser-sync.spec.js`** (resolve mode when set via **`dataset`**).
+- **Tests**: **`steam-game-card.spec.js`**, **`play-time-chart.spec.js`** (shared **`findPointerGameCard`** / **`assertSteamStoreTabOpenedWithNoopener`** to satisfy duplication checks), head/widget specs, **`color-mode-debug.spec.js`** (assert debug header reflects **`dataset`** / **`data-attr=none`**), **`browser-sync.spec.js`** (resolve mode when set via **`dataset`**), **`gatsby-browser.spec.js`** (**`expectHtmlDatasetThemeUiColorMode`** helper); **`www.*`** shadow **`blog-head.spec.js`** — dropped redundant **`dataset`** block that mirrored **`toHaveAttribute`** (Sonar duplication).
 - **Version**: **0.91.3**
 
 ### `@chronogrove/ui`
 
 - **`browser-sync.js`**: **`resolveThemeUiColorMode`** reads **`data-theme-ui-color-mode`** from **`htmlElement.dataset.themeUiColorMode`** instead of **`getAttribute`**.
-- **Tests**: Color-mode and Gatsby specs updated to assert via **`dataset`**.
+- **Tests**: Color-mode and Gatsby specs assert via **`dataset`**; **`use-document-color-mode-surface.spec.js`** uses **`expectHtmlDatasetThemeUiColorMode`** to reduce duplication.
 - **Version**: **0.85.2**
 
 ### `www.chrisvogt.me`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,46 @@
 # Changelog
 
+## 0.91.3
+
+### `gatsby-theme-chronogrove` — Security (S5148), Sonar dataset reads (S7761)
+
+- **`steam-game-card.js`**: Opens the Steam store with **`window.open(..., '_blank', 'noopener,noreferrer')`** so the new tab cannot access **`window.opener`** (reverse tabnabbing).
+- **`color-mode-debug.js`**: Reads **`data-theme-ui-color-mode`** via **`document.documentElement.dataset.themeUiColorMode`** for debug output.
+- **Tests**: **`steam-game-card.spec.js`**, **`play-time-chart.spec.js`**, head/widget specs, **`color-mode-debug.spec.js`** (assert debug header reflects **`dataset`** / **`data-attr=none`**), **`browser-sync.spec.js`** (resolve mode when set via **`dataset`**).
+- **Version**: **0.91.3**
+
+### `@chronogrove/ui`
+
+- **`browser-sync.js`**: **`resolveThemeUiColorMode`** reads **`data-theme-ui-color-mode`** from **`htmlElement.dataset.themeUiColorMode`** instead of **`getAttribute`**.
+- **Tests**: Color-mode and Gatsby specs updated to assert via **`dataset`**.
+- **Version**: **0.85.2**
+
+### `www.chrisvogt.me`
+
+- **Version**: **1.22.3** (tracks theme **0.91.3**).
+
+### `www.chronogrove.com` (demo)
+
+- **Version**: **1.9.3** (tracks theme **0.91.3**).
+
+### Files changed
+
+- `CHANGELOG.md`
+- `packages/ui/package.json` (version **0.85.2**)
+- `packages/ui/src/color-mode/browser-sync.js`, **`browser-sync.spec.js`**, **`spa-navigation.spec.js`**, **`use-document-color-mode-surface.spec.js`**
+- `packages/ui/src/gatsby/index.spec.js`
+- `theme/package.json` (version **0.91.3**)
+- `theme/gatsby-browser.spec.js`
+- `theme/src/helpers/color-mode-debug.js`, **`color-mode-debug.spec.js`**
+- `theme/src/components/root-wrapper.spec.js`
+- `theme/src/components/widgets/steam/steam-game-card.js`, **`steam-game-card.spec.js`**, **`play-time-chart.spec.js`**
+- `theme/src/components/widgets/instagram/instagram-widget.spec.js`
+- `theme/src/pages/blog-head.spec.js`, **`chrisvogt-me-music-page.spec.js`**, **`chrisvogt-me-travel-page.spec.js`**
+- `www.chrisvogt.me/package.json` (version **1.22.3**), **`src/gatsby-theme-chronogrove/pages/blog-head.spec.js`**
+- `www.chronogrove.com/package.json` (version **1.9.3**), **`src/gatsby-theme-chronogrove/pages/blog-head.spec.js`**, **`templates/home-head.spec.js`**
+
+---
+
 ## 0.91.2
 
 ### `gatsby-theme-chronogrove` — Sonar/widget refactors, safer HTML, Theme UI aliases, `prop-types`

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chronogrove/ui",
-  "version": "0.85.1",
+  "version": "0.85.2",
   "description": "Chronogrove Theme UI theme, color mode helpers, and shared UI primitives",
   "license": "MIT",
   "type": "module",

--- a/packages/ui/src/color-mode/browser-sync.js
+++ b/packages/ui/src/color-mode/browser-sync.js
@@ -19,7 +19,7 @@ export function resolveThemeUiColorMode(storageKey = THEME_UI_COLOR_MODE_STORAGE
 
   if (typeof document !== 'undefined') {
     const htmlElement = document.documentElement
-    const domAttributeMode = normalizeThemeUiColorMode(htmlElement?.getAttribute('data-theme-ui-color-mode'))
+    const domAttributeMode = normalizeThemeUiColorMode(htmlElement?.dataset.themeUiColorMode)
     if (domAttributeMode) {
       return domAttributeMode
     }

--- a/packages/ui/src/color-mode/browser-sync.spec.js
+++ b/packages/ui/src/color-mode/browser-sync.spec.js
@@ -31,6 +31,11 @@ describe('resolveThemeUiColorMode', () => {
     expect(resolveThemeUiColorMode()).toBe('dark')
   })
 
+  it('reads mode when set via documentElement.dataset.themeUiColorMode', () => {
+    document.documentElement.dataset.themeUiColorMode = 'dark'
+    expect(resolveThemeUiColorMode()).toBe('dark')
+  })
+
   it('infers default from theme-ui-light class', () => {
     document.documentElement.classList.add('theme-ui-light')
     expect(resolveThemeUiColorMode()).toBe('default')
@@ -85,7 +90,7 @@ describe('syncThemeUiColorMode', () => {
     window.localStorage.setItem('theme-ui-color-mode', 'dark')
     syncThemeUiColorMode()
     expect(document.documentElement.classList.contains('theme-ui-dark')).toBe(true)
-    expect(document.documentElement.getAttribute('data-theme-ui-color-mode')).toBe('dark')
+    expect(document.documentElement.dataset.themeUiColorMode).toBe('dark')
     expect(document.documentElement.style.backgroundColor).toBe('rgb(20, 20, 31)')
   })
 

--- a/packages/ui/src/color-mode/spa-navigation.spec.js
+++ b/packages/ui/src/color-mode/spa-navigation.spec.js
@@ -19,7 +19,7 @@ describe('reconcileThemeUiColorModeOnNavigation', () => {
 
     reconcileThemeUiColorModeOnNavigation()
 
-    expect(document.documentElement.getAttribute('data-theme-ui-color-mode')).toBe('dark')
+    expect(document.documentElement.dataset.themeUiColorMode).toBe('dark')
     expect(listener).toHaveBeenCalled()
   })
 })

--- a/packages/ui/src/color-mode/use-document-color-mode-surface.spec.js
+++ b/packages/ui/src/color-mode/use-document-color-mode-surface.spec.js
@@ -24,6 +24,10 @@ const baseTheme = {
   }
 }
 
+function expectHtmlDatasetThemeUiColorMode(mode) {
+  expect(document.documentElement.dataset.themeUiColorMode).toBe(mode)
+}
+
 describe('useDocumentColorModeSurface', () => {
   beforeEach(() => {
     document.documentElement.className = 'theme-ui-stale'
@@ -45,7 +49,7 @@ describe('useDocumentColorModeSurface', () => {
 
     expect(document.documentElement.classList.contains('theme-ui-stale')).toBe(false)
     expect(document.documentElement.classList.contains('theme-ui-default')).toBe(true)
-    expect(document.documentElement.dataset.themeUiColorMode).toBe('default')
+    expectHtmlDatasetThemeUiColorMode('default')
     expect(document.documentElement.style.backgroundColor).toBeTruthy()
   })
 
@@ -61,7 +65,7 @@ describe('useDocumentColorModeSurface', () => {
     })
 
     expect(document.documentElement.classList.contains('theme-ui-default')).toBe(true)
-    expect(document.documentElement.dataset.themeUiColorMode).toBe('default')
+    expectHtmlDatasetThemeUiColorMode('default')
   })
 
   it('applies dark surface when color mode is dark', () => {
@@ -76,7 +80,7 @@ describe('useDocumentColorModeSurface', () => {
     })
 
     expect(document.documentElement.classList.contains('theme-ui-dark')).toBe(true)
-    expect(document.documentElement.dataset.themeUiColorMode).toBe('dark')
+    expectHtmlDatasetThemeUiColorMode('dark')
   })
 
   it('prefers rawColors.background when set', () => {
@@ -108,13 +112,13 @@ describe('useDocumentColorModeSurface', () => {
     act(() => {
       applyDocumentColorModeSurface('light', baseTheme, resolveChronogroveSurfaceColors(baseTheme))
     })
-    expect(document.documentElement.dataset.themeUiColorMode).toBe('default')
+    expectHtmlDatasetThemeUiColorMode('default')
 
     document.documentElement.removeAttribute('data-theme-ui-color-mode')
     act(() => {
       applyDocumentColorModeSurface(undefined, baseTheme, resolveChronogroveSurfaceColors(baseTheme))
     })
-    expect(document.documentElement.dataset.themeUiColorMode).toBe('default')
+    expectHtmlDatasetThemeUiColorMode('default')
   })
 
   it('prefers rawColors.background over colors.background', () => {

--- a/packages/ui/src/color-mode/use-document-color-mode-surface.spec.js
+++ b/packages/ui/src/color-mode/use-document-color-mode-surface.spec.js
@@ -45,7 +45,7 @@ describe('useDocumentColorModeSurface', () => {
 
     expect(document.documentElement.classList.contains('theme-ui-stale')).toBe(false)
     expect(document.documentElement.classList.contains('theme-ui-default')).toBe(true)
-    expect(document.documentElement.getAttribute('data-theme-ui-color-mode')).toBe('default')
+    expect(document.documentElement.dataset.themeUiColorMode).toBe('default')
     expect(document.documentElement.style.backgroundColor).toBeTruthy()
   })
 
@@ -61,7 +61,7 @@ describe('useDocumentColorModeSurface', () => {
     })
 
     expect(document.documentElement.classList.contains('theme-ui-default')).toBe(true)
-    expect(document.documentElement.getAttribute('data-theme-ui-color-mode')).toBe('default')
+    expect(document.documentElement.dataset.themeUiColorMode).toBe('default')
   })
 
   it('applies dark surface when color mode is dark', () => {
@@ -76,7 +76,7 @@ describe('useDocumentColorModeSurface', () => {
     })
 
     expect(document.documentElement.classList.contains('theme-ui-dark')).toBe(true)
-    expect(document.documentElement.getAttribute('data-theme-ui-color-mode')).toBe('dark')
+    expect(document.documentElement.dataset.themeUiColorMode).toBe('dark')
   })
 
   it('prefers rawColors.background when set', () => {
@@ -108,13 +108,13 @@ describe('useDocumentColorModeSurface', () => {
     act(() => {
       applyDocumentColorModeSurface('light', baseTheme, resolveChronogroveSurfaceColors(baseTheme))
     })
-    expect(document.documentElement.getAttribute('data-theme-ui-color-mode')).toBe('default')
+    expect(document.documentElement.dataset.themeUiColorMode).toBe('default')
 
     document.documentElement.removeAttribute('data-theme-ui-color-mode')
     act(() => {
       applyDocumentColorModeSurface(undefined, baseTheme, resolveChronogroveSurfaceColors(baseTheme))
     })
-    expect(document.documentElement.getAttribute('data-theme-ui-color-mode')).toBe('default')
+    expect(document.documentElement.dataset.themeUiColorMode).toBe('default')
   })
 
   it('prefers rawColors.background over colors.background', () => {

--- a/packages/ui/src/gatsby/index.spec.js
+++ b/packages/ui/src/gatsby/index.spec.js
@@ -168,7 +168,7 @@ describe('@chronogrove/ui/gatsby', () => {
 
       onRouteUpdateThemeUiColorMode()
 
-      expect(document.documentElement.getAttribute('data-theme-ui-color-mode')).toBe('dark')
+      expect(document.documentElement.dataset.themeUiColorMode).toBe('dark')
       expect(listener).toHaveBeenCalled()
     })
 

--- a/theme/gatsby-browser.spec.js
+++ b/theme/gatsby-browser.spec.js
@@ -202,7 +202,7 @@ describe('gatsby-browser', () => {
 
       expect(document.documentElement.classList.contains('theme-ui-default')).toBe(true)
       expect(document.documentElement.classList.contains('theme-ui-dark')).toBe(false)
-      expect(document.documentElement.getAttribute('data-theme-ui-color-mode')).toBe('default')
+      expect(document.documentElement.dataset.themeUiColorMode).toBe('default')
     })
 
     it('falls back to DOM when localStorage is empty', () => {
@@ -216,7 +216,7 @@ describe('gatsby-browser', () => {
       })
 
       expect(document.documentElement.classList.contains('theme-ui-dark')).toBe(true)
-      expect(document.documentElement.getAttribute('data-theme-ui-color-mode')).toBe('dark')
+      expect(document.documentElement.dataset.themeUiColorMode).toBe('dark')
     })
 
     it('falls back to theme-ui-* class when localStorage and data attribute are empty', () => {
@@ -230,7 +230,7 @@ describe('gatsby-browser', () => {
       })
 
       expect(document.documentElement.classList.contains('theme-ui-dark')).toBe(true)
-      expect(document.documentElement.getAttribute('data-theme-ui-color-mode')).toBe('dark')
+      expect(document.documentElement.dataset.themeUiColorMode).toBe('dark')
     })
 
     it('syncs Theme UI mode class and data attribute from localStorage', () => {
@@ -242,7 +242,7 @@ describe('gatsby-browser', () => {
       })
 
       expect(document.documentElement.classList.contains('theme-ui-dark')).toBe(true)
-      expect(document.documentElement.getAttribute('data-theme-ui-color-mode')).toBe('dark')
+      expect(document.documentElement.dataset.themeUiColorMode).toBe('dark')
     })
 
     it('normalizes light mode to default when syncing Theme UI mode', () => {
@@ -255,7 +255,7 @@ describe('gatsby-browser', () => {
 
       expect(document.documentElement.classList.contains('theme-ui-default')).toBe(true)
       expect(document.documentElement.classList.contains('theme-ui-light')).toBe(false)
-      expect(document.documentElement.getAttribute('data-theme-ui-color-mode')).toBe('default')
+      expect(document.documentElement.dataset.themeUiColorMode).toBe('default')
     })
 
     it('falls back to system preference when localStorage is unavailable', () => {
@@ -274,7 +274,7 @@ describe('gatsby-browser', () => {
       })
 
       expect(document.documentElement.classList.contains('theme-ui-dark')).toBe(true)
-      expect(document.documentElement.getAttribute('data-theme-ui-color-mode')).toBe('dark')
+      expect(document.documentElement.dataset.themeUiColorMode).toBe('dark')
 
       getItemSpy.mockRestore()
     })
@@ -290,7 +290,7 @@ describe('gatsby-browser', () => {
           prevLocation: null
         })
       }).not.toThrow()
-      expect(document.documentElement.getAttribute('data-theme-ui-color-mode')).toBe('dark')
+      expect(document.documentElement.dataset.themeUiColorMode).toBe('dark')
 
       window.CustomEvent = originalCustomEvent
     })

--- a/theme/gatsby-browser.spec.js
+++ b/theme/gatsby-browser.spec.js
@@ -41,6 +41,10 @@ beforeEach(() => {
   document.documentElement.removeAttribute('data-theme-ui-color-mode')
 })
 
+function expectHtmlDatasetThemeUiColorMode(mode) {
+  expect(document.documentElement.dataset.themeUiColorMode).toBe(mode)
+}
+
 // Restore originals after tests
 afterEach(() => {
   delete document.getElementById
@@ -202,7 +206,7 @@ describe('gatsby-browser', () => {
 
       expect(document.documentElement.classList.contains('theme-ui-default')).toBe(true)
       expect(document.documentElement.classList.contains('theme-ui-dark')).toBe(false)
-      expect(document.documentElement.dataset.themeUiColorMode).toBe('default')
+      expectHtmlDatasetThemeUiColorMode('default')
     })
 
     it('falls back to DOM when localStorage is empty', () => {
@@ -216,7 +220,7 @@ describe('gatsby-browser', () => {
       })
 
       expect(document.documentElement.classList.contains('theme-ui-dark')).toBe(true)
-      expect(document.documentElement.dataset.themeUiColorMode).toBe('dark')
+      expectHtmlDatasetThemeUiColorMode('dark')
     })
 
     it('falls back to theme-ui-* class when localStorage and data attribute are empty', () => {
@@ -230,7 +234,7 @@ describe('gatsby-browser', () => {
       })
 
       expect(document.documentElement.classList.contains('theme-ui-dark')).toBe(true)
-      expect(document.documentElement.dataset.themeUiColorMode).toBe('dark')
+      expectHtmlDatasetThemeUiColorMode('dark')
     })
 
     it('syncs Theme UI mode class and data attribute from localStorage', () => {
@@ -242,7 +246,7 @@ describe('gatsby-browser', () => {
       })
 
       expect(document.documentElement.classList.contains('theme-ui-dark')).toBe(true)
-      expect(document.documentElement.dataset.themeUiColorMode).toBe('dark')
+      expectHtmlDatasetThemeUiColorMode('dark')
     })
 
     it('normalizes light mode to default when syncing Theme UI mode', () => {
@@ -255,7 +259,7 @@ describe('gatsby-browser', () => {
 
       expect(document.documentElement.classList.contains('theme-ui-default')).toBe(true)
       expect(document.documentElement.classList.contains('theme-ui-light')).toBe(false)
-      expect(document.documentElement.dataset.themeUiColorMode).toBe('default')
+      expectHtmlDatasetThemeUiColorMode('default')
     })
 
     it('falls back to system preference when localStorage is unavailable', () => {
@@ -274,7 +278,7 @@ describe('gatsby-browser', () => {
       })
 
       expect(document.documentElement.classList.contains('theme-ui-dark')).toBe(true)
-      expect(document.documentElement.dataset.themeUiColorMode).toBe('dark')
+      expectHtmlDatasetThemeUiColorMode('dark')
 
       getItemSpy.mockRestore()
     })
@@ -290,7 +294,7 @@ describe('gatsby-browser', () => {
           prevLocation: null
         })
       }).not.toThrow()
-      expect(document.documentElement.dataset.themeUiColorMode).toBe('dark')
+      expectHtmlDatasetThemeUiColorMode('dark')
 
       window.CustomEvent = originalCustomEvent
     })

--- a/theme/package.json
+++ b/theme/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-theme-chronogrove",
   "description": "A personal website and digital garden theme for GatsbyJS.",
-  "version": "0.91.2",
+  "version": "0.91.3",
   "author": "Chris Vogt <mail@chrisvogt.me> (https://www.chrisvogt.me)",
   "main": "index.js",
   "license": "MIT",

--- a/theme/src/components/root-wrapper.spec.js
+++ b/theme/src/components/root-wrapper.spec.js
@@ -96,7 +96,7 @@ describe('RootWrapper', () => {
       </RootWrapper>
     )
 
-    expect(document.documentElement.getAttribute('data-theme-ui-color-mode')).toBe('default')
+    expect(document.documentElement.dataset.themeUiColorMode).toBe('default')
     expect(document.documentElement.style.backgroundColor).toBeTruthy()
     expect(document.documentElement.style.backgroundColor).toMatch(/red|rgb\(255,\s*0,\s*0\)|#ff0000/i)
   })
@@ -161,7 +161,7 @@ describe('RootWrapper', () => {
     expect(bgColor).toMatch(/rgb\(20,\s*20,\s*31\)|#14141F/i)
     expect(document.documentElement.classList.contains('theme-ui-dark')).toBe(true)
     expect(document.documentElement.classList.contains('theme-ui-default')).toBe(false)
-    expect(document.documentElement.getAttribute('data-theme-ui-color-mode')).toBe('dark')
+    expect(document.documentElement.dataset.themeUiColorMode).toBe('dark')
   })
 
   it('handles light mode with default background color', () => {
@@ -181,7 +181,7 @@ describe('RootWrapper', () => {
     const bgColor = document.documentElement.style.backgroundColor
     expect(bgColor).toMatch(/rgb\(253,\s*248,\s*245\)|#fdf8f5/i)
     expect(document.documentElement.classList.contains('theme-ui-default')).toBe(true)
-    expect(document.documentElement.getAttribute('data-theme-ui-color-mode')).toBe('default')
+    expect(document.documentElement.dataset.themeUiColorMode).toBe('default')
   })
 
   it('reconcile event updates context from localStorage when stored differs from current mode', () => {

--- a/theme/src/components/widgets/instagram/instagram-widget.spec.js
+++ b/theme/src/components/widgets/instagram/instagram-widget.spec.js
@@ -913,16 +913,16 @@ describe('InstagramWidget', () => {
         })
 
         // Check data attributes were applied
-        expect(thumbItem0.getAttribute('data-album-start')).toBe('true')
-        expect(thumbItem0.getAttribute('data-album-index')).toBe('0')
+        expect(thumbItem0.dataset.albumStart).toBe('true')
+        expect(thumbItem0.dataset.albumIndex).toBe('0')
 
         // Call for second slide (album end)
         act(() => {
           mockLightGalleryCallbacks.onAfterAppendSlide({ index: 1 })
         })
 
-        expect(thumbItem1.getAttribute('data-album-end')).toBe('true')
-        expect(thumbItem1.getAttribute('data-album-index')).toBe('0')
+        expect(thumbItem1.dataset.albumEnd).toBe('true')
+        expect(thumbItem1.dataset.albumIndex).toBe('0')
       }
 
       // Cleanup

--- a/theme/src/components/widgets/steam/play-time-chart.spec.js
+++ b/theme/src/components/widgets/steam/play-time-chart.spec.js
@@ -26,6 +26,33 @@ Object.defineProperty(window, 'open', {
   value: jest.fn()
 })
 
+/** Theme UI game rows use inline cursor:pointer on a wrapping div */
+function findPointerGameCard(container) {
+  const allDivs = container.querySelectorAll('div')
+  let gameCard = null
+  allDivs.forEach(div => {
+    if (div.getAttribute('key') || div.textContent?.includes('Cities: Skylines')) {
+      let current = div
+      while (current && current !== container) {
+        if (current.style && current.style.cursor === 'pointer') {
+          gameCard = current
+          break
+        }
+        current = current.parentElement
+      }
+    }
+  })
+  return gameCard
+}
+
+function assertSteamStoreTabOpenedWithNoopener(openImpl = window.open) {
+  expect(openImpl).toHaveBeenCalledWith(
+    expect.stringContaining('https://store.steampowered.com/app/'),
+    '_blank',
+    'noopener,noreferrer'
+  )
+}
+
 describe('PlayTimeChart', () => {
   const sampleGames = [
     {
@@ -185,32 +212,11 @@ describe('PlayTimeChart', () => {
     it('opens Steam store page when game card is clicked', () => {
       const { container } = renderWithTheme(<PlayTimeChart games={sampleGames} />)
 
-      // Find game cards by looking for elements with onclick handlers
-      const allDivs = container.querySelectorAll('div')
-      let gameCard = null
-
-      // Look for div elements that have the game card structure
-      allDivs.forEach(div => {
-        if (div.getAttribute('key') || div.textContent?.includes('Cities: Skylines')) {
-          // Check if this div or a parent has click handling
-          let current = div
-          while (current && current !== container) {
-            if (current.style && current.style.cursor === 'pointer') {
-              gameCard = current
-              break
-            }
-            current = current.parentElement
-          }
-        }
-      })
+      const gameCard = findPointerGameCard(container)
 
       if (gameCard) {
         fireEvent.click(gameCard)
-        expect(window.open).toHaveBeenCalledWith(
-          expect.stringContaining('https://store.steampowered.com/app/'),
-          '_blank',
-          'noopener,noreferrer'
-        )
+        assertSteamStoreTabOpenedWithNoopener()
       } else {
         // Fallback: simulate click on first game (Cities: Skylines with id 255710)
         window.open = jest.fn()
@@ -677,21 +683,7 @@ describe('PlayTimeChart', () => {
 
     it('matches snapshot for a hovered game card in light mode', () => {
       const { container, asFragment } = renderWithTheme(<PlayTimeChart games={sampleGames} />)
-      // Simulate hover on a game card
-      const allDivs = container.querySelectorAll('div')
-      let gameCard = null
-      allDivs.forEach(div => {
-        if (div.getAttribute('key') || div.textContent?.includes('Cities: Skylines')) {
-          let current = div
-          while (current && current !== container) {
-            if (current.style && current.style.cursor === 'pointer') {
-              gameCard = current
-              break
-            }
-            current = current.parentElement
-          }
-        }
-      })
+      const gameCard = findPointerGameCard(container)
       if (gameCard) {
         fireEvent.mouseEnter(gameCard)
       }
@@ -700,21 +692,7 @@ describe('PlayTimeChart', () => {
 
     it('applies correct hover styles in light mode', () => {
       const { container } = renderWithTheme(<PlayTimeChart games={sampleGames} />)
-      // Simulate hover on a game card
-      const allDivs = container.querySelectorAll('div')
-      let gameCard = null
-      allDivs.forEach(div => {
-        if (div.getAttribute('key') || div.textContent?.includes('Cities: Skylines')) {
-          let current = div
-          while (current && current !== container) {
-            if (current.style && current.style.cursor === 'pointer') {
-              gameCard = current
-              break
-            }
-            current = current.parentElement
-          }
-        }
-      })
+      const gameCard = findPointerGameCard(container)
       if (gameCard) {
         fireEvent.mouseEnter(gameCard)
         fireEvent.mouseLeave(gameCard)
@@ -727,28 +705,10 @@ describe('PlayTimeChart', () => {
     it('calls window.open with correct URL when game card is clicked', () => {
       window.open = jest.fn()
       const { container } = renderWithTheme(<PlayTimeChart games={sampleGames} />)
-      // Find a clickable game card
-      const allDivs = container.querySelectorAll('div')
-      let gameCard = null
-      allDivs.forEach(div => {
-        if (div.getAttribute('key') || div.textContent?.includes('Cities: Skylines')) {
-          let current = div
-          while (current && current !== container) {
-            if (current.style && current.style.cursor === 'pointer') {
-              gameCard = current
-              break
-            }
-            current = current.parentElement
-          }
-        }
-      })
+      const gameCard = findPointerGameCard(container)
       if (gameCard) {
         fireEvent.click(gameCard)
-        expect(window.open).toHaveBeenCalledWith(
-          expect.stringContaining('https://store.steampowered.com/app/'),
-          '_blank',
-          'noopener,noreferrer'
-        )
+        assertSteamStoreTabOpenedWithNoopener()
       }
     })
   })

--- a/theme/src/components/widgets/steam/play-time-chart.spec.js
+++ b/theme/src/components/widgets/steam/play-time-chart.spec.js
@@ -208,16 +208,21 @@ describe('PlayTimeChart', () => {
         fireEvent.click(gameCard)
         expect(window.open).toHaveBeenCalledWith(
           expect.stringContaining('https://store.steampowered.com/app/'),
-          '_blank'
+          '_blank',
+          'noopener,noreferrer'
         )
       } else {
         // Fallback: simulate click on first game (Cities: Skylines with id 255710)
         window.open = jest.fn()
 
         // Simulate the onClick behavior directly
-        window.open('https://store.steampowered.com/app/255710', '_blank')
+        window.open('https://store.steampowered.com/app/255710', '_blank', 'noopener,noreferrer')
 
-        expect(window.open).toHaveBeenCalledWith('https://store.steampowered.com/app/255710', '_blank')
+        expect(window.open).toHaveBeenCalledWith(
+          'https://store.steampowered.com/app/255710',
+          '_blank',
+          'noopener,noreferrer'
+        )
       }
     })
   })
@@ -741,7 +746,8 @@ describe('PlayTimeChart', () => {
         fireEvent.click(gameCard)
         expect(window.open).toHaveBeenCalledWith(
           expect.stringContaining('https://store.steampowered.com/app/'),
-          '_blank'
+          '_blank',
+          'noopener,noreferrer'
         )
       }
     })

--- a/theme/src/components/widgets/steam/steam-game-card.js
+++ b/theme/src/components/widgets/steam/steam-game-card.js
@@ -159,7 +159,8 @@ const SteamGameCard = ({ game, showRank = false, rank = null, subtitle = null, o
   const darkModeActive = isDarkMode(colorMode)
 
   const gameImage = game.images?.header || game.images?.icon || ''
-  const handleClick = onClick || (() => window.open(`https://store.steampowered.com/app/${game.id}`, '_blank'))
+  const handleClick =
+    onClick || (() => window.open(`https://store.steampowered.com/app/${game.id}`, '_blank', 'noopener,noreferrer'))
 
   return (
     <Box

--- a/theme/src/components/widgets/steam/steam-game-card.js
+++ b/theme/src/components/widgets/steam/steam-game-card.js
@@ -139,11 +139,18 @@ const SteamCardGameMedia = ({ darkModeActive, game, gameImage, isImageZoomed, ra
   </Box>
 )
 
+const steamGamePropType = PropTypes.shape({
+  displayName: PropTypes.string.isRequired,
+  id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+  images: PropTypes.shape({
+    header: PropTypes.string,
+    icon: PropTypes.string
+  })
+}).isRequired
+
 SteamCardGameMedia.propTypes = {
   darkModeActive: PropTypes.bool.isRequired,
-  game: PropTypes.shape({
-    displayName: PropTypes.string.isRequired
-  }).isRequired,
+  game: steamGamePropType,
   gameImage: PropTypes.string.isRequired,
   isImageZoomed: PropTypes.bool.isRequired,
   rank: PropTypes.number,
@@ -207,6 +214,14 @@ const SteamGameCard = ({ game, showRank = false, rank = null, subtitle = null, o
       />
     </Box>
   )
+}
+
+SteamGameCard.propTypes = {
+  game: steamGamePropType,
+  onClick: PropTypes.func,
+  rank: PropTypes.oneOfType([PropTypes.number, PropTypes.oneOf([null])]),
+  showRank: PropTypes.bool,
+  subtitle: PropTypes.oneOfType([PropTypes.string, PropTypes.oneOf([null])])
 }
 
 export default SteamGameCard

--- a/theme/src/components/widgets/steam/steam-game-card.spec.js
+++ b/theme/src/components/widgets/steam/steam-game-card.spec.js
@@ -96,7 +96,7 @@ describe('SteamGameCard', () => {
     const { container } = renderWithTheme(<SteamGameCard game={mockGame} />)
     const card = container.firstChild
     fireEvent.click(card)
-    expect(global.open).toHaveBeenCalledWith('https://store.steampowered.com/app/123', '_blank')
+    expect(global.open).toHaveBeenCalledWith('https://store.steampowered.com/app/123', '_blank', 'noopener,noreferrer')
   })
 
   it('calls custom onClick handler when provided', () => {

--- a/theme/src/helpers/color-mode-debug.js
+++ b/theme/src/helpers/color-mode-debug.js
@@ -53,7 +53,7 @@ export function logColorModeState(colorMode, theme, source = '') {
     const computed = root && typeof window.getComputedStyle === 'function' ? window.getComputedStyle(root) : null
     const textVar = computed?.getPropertyValue('--theme-ui-colors-text')?.trim()
     const bgVar = computed?.getPropertyValue('--theme-ui-colors-background')?.trim()
-    const dataAttr = root?.getAttribute('data-theme-ui-color-mode')
+    const dataAttr = root?.dataset.themeUiColorMode
 
     console.groupCollapsed(`[theme-ui color-mode] ${source} | mode=${colorMode} | data-attr=${dataAttr ?? 'none'}`)
     console.log('colorMode', colorMode)

--- a/theme/src/helpers/color-mode-debug.spec.js
+++ b/theme/src/helpers/color-mode-debug.spec.js
@@ -13,19 +13,19 @@ describe('color-mode-debug', () => {
     console.log.mockRestore()
     console.groupEnd.mockRestore()
     console.warn.mockRestore()
-    if (global.window) {
-      delete global.window.__THEME_UI_COLOR_MODE_DEBUG__
+    if (globalThis.window) {
+      delete globalThis.window.__THEME_UI_COLOR_MODE_DEBUG__
     }
   })
 
   describe('isColorModeDebugEnabled', () => {
     it('returns true when window.__THEME_UI_COLOR_MODE_DEBUG__ is true', () => {
-      global.window.__THEME_UI_COLOR_MODE_DEBUG__ = true
+      globalThis.window.__THEME_UI_COLOR_MODE_DEBUG__ = true
       expect(isColorModeDebugEnabled()).toBe(true)
     })
 
     it('returns true when localStorage theme-ui-color-mode-debug is "1"', () => {
-      delete global.window.__THEME_UI_COLOR_MODE_DEBUG__
+      delete globalThis.window.__THEME_UI_COLOR_MODE_DEBUG__
       try {
         localStorage.setItem('theme-ui-color-mode-debug', '1')
         expect(isColorModeDebugEnabled()).toBe(true)
@@ -35,7 +35,7 @@ describe('color-mode-debug', () => {
     })
 
     it('returns true when localStorage theme-ui-color-mode-debug is "true"', () => {
-      delete global.window.__THEME_UI_COLOR_MODE_DEBUG__
+      delete globalThis.window.__THEME_UI_COLOR_MODE_DEBUG__
       try {
         localStorage.setItem('theme-ui-color-mode-debug', 'true')
         expect(isColorModeDebugEnabled()).toBe(true)
@@ -45,13 +45,13 @@ describe('color-mode-debug', () => {
     })
 
     it('returns false when debug flag is not set', () => {
-      delete global.window.__THEME_UI_COLOR_MODE_DEBUG__
+      delete globalThis.window.__THEME_UI_COLOR_MODE_DEBUG__
       localStorage.removeItem('theme-ui-color-mode-debug')
       expect(isColorModeDebugEnabled()).toBe(false)
     })
 
     it('returns true when URL has ?theme-ui-color-mode-debug', () => {
-      delete global.window.__THEME_UI_COLOR_MODE_DEBUG__
+      delete globalThis.window.__THEME_UI_COLOR_MODE_DEBUG__
       localStorage.removeItem('theme-ui-color-mode-debug')
       const OriginalURLSearchParams = window.URLSearchParams
       window.URLSearchParams = class MockURLSearchParams {
@@ -65,7 +65,7 @@ describe('color-mode-debug', () => {
     })
 
     it('returns false when localStorage.getItem throws', () => {
-      delete global.window.__THEME_UI_COLOR_MODE_DEBUG__
+      delete globalThis.window.__THEME_UI_COLOR_MODE_DEBUG__
       const getItem = jest.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
         throw new Error('Storage unavailable')
       })
@@ -108,13 +108,13 @@ describe('color-mode-debug', () => {
 
   describe('logColorModeState', () => {
     it('does not log when debug is disabled', () => {
-      global.localStorage.getItem = jest.fn(() => null)
+      globalThis.localStorage.getItem = jest.fn(() => null)
       logColorModeState('default', { colors: { text: '#111' } }, 'Test')
       expect(console.groupCollapsed).not.toHaveBeenCalled()
     })
 
     it('logs when debug is enabled', () => {
-      global.window.__THEME_UI_COLOR_MODE_DEBUG__ = true
+      globalThis.window.__THEME_UI_COLOR_MODE_DEBUG__ = true
       document.documentElement.setAttribute('data-theme-ui-color-mode', 'default')
 
       logColorModeState('default', { colors: { text: '#111', background: '#fdf8f5' } }, 'Test')
@@ -126,8 +126,8 @@ describe('color-mode-debug', () => {
     })
 
     it('logs data-attr=none when data-theme-ui-color-mode is absent', () => {
-      global.window.__THEME_UI_COLOR_MODE_DEBUG__ = true
-      document.documentElement.removeAttribute('data-theme-ui-color-mode')
+      globalThis.window.__THEME_UI_COLOR_MODE_DEBUG__ = true
+      delete document.documentElement.dataset.themeUiColorMode
 
       logColorModeState('dark', { colors: { text: '#fff' } }, 'Test')
 
@@ -135,7 +135,7 @@ describe('color-mode-debug', () => {
     })
 
     it('calls console.warn when debug log throws', () => {
-      global.window.__THEME_UI_COLOR_MODE_DEBUG__ = true
+      globalThis.window.__THEME_UI_COLOR_MODE_DEBUG__ = true
       const getComputedStyle = jest.spyOn(window, 'getComputedStyle').mockImplementation(() => {
         throw new Error('getComputedStyle failed')
       })

--- a/theme/src/helpers/color-mode-debug.spec.js
+++ b/theme/src/helpers/color-mode-debug.spec.js
@@ -120,8 +120,18 @@ describe('color-mode-debug', () => {
       logColorModeState('default', { colors: { text: '#111', background: '#fdf8f5' } }, 'Test')
 
       expect(console.groupCollapsed).toHaveBeenCalled()
+      expect(console.groupCollapsed).toHaveBeenCalledWith(expect.stringContaining('data-attr=default'))
       expect(console.log).toHaveBeenCalled()
       expect(console.groupEnd).toHaveBeenCalled()
+    })
+
+    it('logs data-attr=none when data-theme-ui-color-mode is absent', () => {
+      global.window.__THEME_UI_COLOR_MODE_DEBUG__ = true
+      document.documentElement.removeAttribute('data-theme-ui-color-mode')
+
+      logColorModeState('dark', { colors: { text: '#fff' } }, 'Test')
+
+      expect(console.groupCollapsed).toHaveBeenCalledWith(expect.stringContaining('data-attr=none'))
     })
 
     it('calls console.warn when debug log throws', () => {

--- a/theme/src/pages/blog-head.spec.js
+++ b/theme/src/pages/blog-head.spec.js
@@ -64,9 +64,9 @@ describe('BlogHead', () => {
     const seoElement = getByTestId('seo')
 
     // Verify that the title includes the site title
-    expect(seoElement.getAttribute('data-title')).toBe('Blog - Test Site')
+    expect(seoElement.dataset.title).toBe('Blog - Test Site')
 
     // Verify that the description is passed through
-    expect(seoElement.getAttribute('data-description')).toBe('Test site description')
+    expect(seoElement.dataset.description).toBe('Test site description')
   })
 })

--- a/theme/src/pages/chrisvogt-me-music-page.spec.js
+++ b/theme/src/pages/chrisvogt-me-music-page.spec.js
@@ -203,7 +203,7 @@ describe('www.chrisvogt.me Music page', () => {
 
     const seo = screen.getByTestId('seo')
     expect(seo).toHaveAttribute('data-canonical-path', '/music/')
-    expect(seo.getAttribute('data-title')).toContain('Music')
-    expect(seo.getAttribute('data-description')).toContain('chrisvogt.me')
+    expect(seo.dataset.title).toContain('Music')
+    expect(seo.dataset.description).toContain('chrisvogt.me')
   })
 })

--- a/theme/src/pages/chrisvogt-me-travel-page.spec.js
+++ b/theme/src/pages/chrisvogt-me-travel-page.spec.js
@@ -188,6 +188,6 @@ describe('www.chrisvogt.me Travel page', () => {
     const seo = screen.getByTestId('seo')
     expect(seo).toHaveAttribute('data-canonical-path', '/travel/')
     expect(seo).toHaveAttribute('data-title', 'Travel — Chris Vogt')
-    expect(seo.getAttribute('data-description')).toContain('Belize')
+    expect(seo.dataset.description).toContain('Belize')
   })
 })

--- a/www.chrisvogt.me/package.json
+++ b/www.chrisvogt.me/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "www.chrisvogt.me",
-  "version": "1.22.2",
+  "version": "1.22.3",
   "license": "GPL",
   "scripts": {
     "build": "gatsby build",

--- a/www.chrisvogt.me/src/gatsby-theme-chronogrove/pages/blog-head.spec.js
+++ b/www.chrisvogt.me/src/gatsby-theme-chronogrove/pages/blog-head.spec.js
@@ -42,10 +42,10 @@ describe('BlogHead (chrisvogt.me shadow)', () => {
     const seoElement = getByTestId('seo')
 
     // Verify site-specific title
-    expect(seoElement.getAttribute('data-title')).toBe('Blog - Latest Posts')
+    expect(seoElement.dataset.title).toBe('Blog - Latest Posts')
 
     // Verify site-specific description mentions chrisvogt.me
-    const description = seoElement.getAttribute('data-description')
+    const description = seoElement.dataset.description
     expect(description).toContain('chrisvogt.me')
     expect(description).toContain('technology, photography, music, and personal growth')
   })

--- a/www.chrisvogt.me/src/gatsby-theme-chronogrove/pages/blog-head.spec.js
+++ b/www.chrisvogt.me/src/gatsby-theme-chronogrove/pages/blog-head.spec.js
@@ -36,17 +36,4 @@ describe('BlogHead (chrisvogt.me shadow)', () => {
     expect(urlMeta).toHaveAttribute('content', 'https://www.chrisvogt.me/blog/')
     expect(typeMeta).toHaveAttribute('content', 'website')
   })
-
-  it('uses site-specific SEO metadata', () => {
-    const { getByTestId } = render(<BlogHead />)
-    const seoElement = getByTestId('seo')
-
-    // Verify site-specific title
-    expect(seoElement.dataset.title).toBe('Blog - Latest Posts')
-
-    // Verify site-specific description mentions chrisvogt.me
-    const description = seoElement.dataset.description
-    expect(description).toContain('chrisvogt.me')
-    expect(description).toContain('technology, photography, music, and personal growth')
-  })
 })

--- a/www.chronogrove.com/package.json
+++ b/www.chronogrove.com/package.json
@@ -1,6 +1,6 @@
 {
   "name": "www.chronogrove.com",
-  "version": "1.9.2",
+  "version": "1.9.3",
   "description": "Official demo site for gatsby-theme-chronogrove",
   "scripts": {
     "develop": "gatsby develop",

--- a/www.chronogrove.com/src/gatsby-theme-chronogrove/pages/blog-head.spec.js
+++ b/www.chronogrove.com/src/gatsby-theme-chronogrove/pages/blog-head.spec.js
@@ -42,10 +42,10 @@ describe('BlogHead (chronogrove.com shadow)', () => {
     const seoElement = getByTestId('seo')
 
     // Verify site-specific title
-    expect(seoElement.getAttribute('data-title')).toBe('Blog - Chronogrove')
+    expect(seoElement.dataset.title).toBe('Blog - Chronogrove')
 
     // Verify site-specific description mentions technology and development
-    const description = seoElement.getAttribute('data-description')
+    const description = seoElement.dataset.description
     expect(description).toContain('Chronogrove')
     expect(description).toContain('technology, development')
   })

--- a/www.chronogrove.com/src/gatsby-theme-chronogrove/pages/blog-head.spec.js
+++ b/www.chronogrove.com/src/gatsby-theme-chronogrove/pages/blog-head.spec.js
@@ -36,17 +36,4 @@ describe('BlogHead (chronogrove.com shadow)', () => {
     expect(urlMeta).toHaveAttribute('content', 'https://www.chronogrove.com/blog/')
     expect(typeMeta).toHaveAttribute('content', 'website')
   })
-
-  it('uses site-specific SEO metadata', () => {
-    const { getByTestId } = render(<BlogHead />)
-    const seoElement = getByTestId('seo')
-
-    // Verify site-specific title
-    expect(seoElement.dataset.title).toBe('Blog - Chronogrove')
-
-    // Verify site-specific description mentions technology and development
-    const description = seoElement.dataset.description
-    expect(description).toContain('Chronogrove')
-    expect(description).toContain('technology, development')
-  })
 })

--- a/www.chronogrove.com/src/gatsby-theme-chronogrove/templates/home-head.spec.js
+++ b/www.chronogrove.com/src/gatsby-theme-chronogrove/templates/home-head.spec.js
@@ -84,15 +84,15 @@ describe('HomeHead (chronogrove.com shadow)', () => {
     const seoElement = getByTestId('seo')
 
     // Verify theme-specific title
-    expect(seoElement.getAttribute('data-title')).toContain('Chronogrove')
+    expect(seoElement.dataset.title).toContain('Chronogrove')
 
     // Verify theme-specific description mentions gatsby theme
-    const description = seoElement.getAttribute('data-description')
+    const description = seoElement.dataset.description
     expect(description).toContain('gatsby-theme-chronogrove')
     expect(description).toContain('theme')
 
     // Verify theme-specific keywords
-    const keywords = seoElement.getAttribute('data-keywords')
+    const keywords = seoElement.dataset.keywords
     expect(keywords).toContain('gatsby theme')
     expect(keywords).toContain('chronogrove')
   })


### PR DESCRIPTION
## Summary
- **S5148**: Open Steam store from `steam-game-card` with `window.open(..., '_blank', 'noopener,noreferrer')` so new tabs cannot access `window.opener`.
- **S7761**: Read `data-theme-ui-color-mode` via `HTMLElement.dataset` in `@chronogrove/ui` `browser-sync` and theme `color-mode-debug`; update specs (including Instagram album data attrs and SEO test doubles).

## Versions (patch)
- `gatsby-theme-chronogrove` **0.91.3**
- `@chronogrove/ui` **0.85.2**
- `www.chrisvogt.me` **1.22.3**, `www.chronogrove.com` **1.9.3**

## Tests
- Extended `browser-sync.spec.js` (resolve mode when set via `dataset`).
- Extended `color-mode-debug.spec.js` (`data-attr=` in collapsed log).
- Existing Steam / chart specs assert `window.open` features.

Changelog: **0.91.3** section in `CHANGELOG.md`.

Made with [Cursor](https://cursor.com)