### PR TITLE
chore: use dataset for data-* DOM writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+## 0.91.4
+
+### `gatsby-theme-chronogrove` — `dataset` for `data-*` DOM writes
+
+- **`instagram-widget.js`**: Album thumbnail markers use **`thumbItem.dataset`** (**`albumStart`**, **`albumEnd`**, **`albumIndex`**) instead of **`setAttribute`**, matching specs and keeping **`global.css`** **`[data-album-*]`** selectors unchanged.
+- **Tests**: **`gatsby-browser.spec.js`**, **`gatsby-ssr.spec.js`**, **`color-mode-debug.spec.js`** seed or assert color mode via **`document.documentElement.dataset.themeUiColorMode`** where appropriate.
+- **Version**: **0.91.4**
+
+### `@chronogrove/ui`
+
+- **`browser-sync.js`**, **`use-document-color-mode-surface.js`**: Apply **`data-theme-ui-color-mode`** with **`htmlElement.dataset.themeUiColorMode`** (aligned with **`resolveThemeUiColorMode`** reads).
+- **`head-inline.js`**: No-flash inline script sets **`htmlElement.dataset.themeUiColorMode`** instead of **`setAttribute`**.
+- **Tests**: **`head-inline.spec.js`**, **`browser-sync.spec.js`**, **`packages/ui/src/gatsby/index.spec.js`**; **`theme/gatsby-ssr.spec.js`** expects the generated script to reference **`dataset.themeUiColorMode`**.
+- **Version**: **0.85.3**
+
+### Files changed
+
+- `CHANGELOG.md`
+- `packages/ui/package.json` (version **0.85.3**)
+- `packages/ui/src/color-mode/browser-sync.js`, **`browser-sync.spec.js`**, **`head-inline.js`**, **`head-inline.spec.js`**, **`use-document-color-mode-surface.js`**
+- `packages/ui/src/gatsby/index.spec.js`
+- `theme/package.json` (version **0.91.4**)
+- `theme/gatsby-browser.spec.js`, **`gatsby-ssr.spec.js`**
+- `theme/src/components/widgets/instagram/instagram-widget.js`
+- `theme/src/helpers/color-mode-debug.spec.js`
+
+---
+
 ## 0.91.3
 
 ### `gatsby-theme-chronogrove` — Security (S5148), Sonar dataset reads (S7761)

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chronogrove/ui",
-  "version": "0.85.2",
+  "version": "0.85.3",
   "description": "Chronogrove Theme UI theme, color mode helpers, and shared UI primitives",
   "license": "MIT",
   "type": "module",

--- a/packages/ui/src/color-mode/browser-sync.js
+++ b/packages/ui/src/color-mode/browser-sync.js
@@ -52,7 +52,7 @@ export function syncThemeUiColorMode(storageKey = THEME_UI_COLOR_MODE_STORAGE_KE
     .filter(className => className.startsWith('theme-ui-'))
     .forEach(className => htmlElement.classList.remove(className))
   htmlElement.classList.add(`theme-ui-${mode}`)
-  htmlElement.setAttribute('data-theme-ui-color-mode', mode)
+  htmlElement.dataset.themeUiColorMode = mode
   // Match `buildHtmlBackgroundInlineScript`: inline background must follow toggles; otherwise the
   // initial head script’s color sticks and wins over Theme UI’s `--theme-ui-colors-background`.
   htmlElement.style.backgroundColor = mode === 'dark' ? SURFACE.darkBackgroundHex : SURFACE.defaultBackgroundHex

--- a/packages/ui/src/color-mode/browser-sync.spec.js
+++ b/packages/ui/src/color-mode/browser-sync.spec.js
@@ -27,7 +27,7 @@ describe('resolveThemeUiColorMode', () => {
   })
 
   it('reads from data-theme-ui-color-mode on documentElement', () => {
-    document.documentElement.setAttribute('data-theme-ui-color-mode', 'dark')
+    document.documentElement.dataset.themeUiColorMode = 'dark'
     expect(resolveThemeUiColorMode()).toBe('dark')
   })
 

--- a/packages/ui/src/color-mode/head-inline.js
+++ b/packages/ui/src/color-mode/head-inline.js
@@ -113,7 +113,7 @@ export function buildThemeUiNoFlashInlineScript(options) {
           htmlElement.classList.remove(classesToRemove[j]);
         }
         htmlElement.classList.add('theme-ui-' + mode);
-        htmlElement.setAttribute('data-theme-ui-color-mode', mode);
+        htmlElement.dataset.themeUiColorMode = mode;
       } catch (e) {}
     })();
   `

--- a/packages/ui/src/color-mode/head-inline.spec.js
+++ b/packages/ui/src/color-mode/head-inline.spec.js
@@ -16,7 +16,7 @@ describe('head-inline scripts', () => {
     expect(s).toContain('theme-ui-color-mode')
     expect(s).toContain('localStorage.getItem')
     expect(s).not.toContain('__cgGetCookie')
-    expect(s).toContain('data-theme-ui-color-mode')
+    expect(s).toContain('dataset.themeUiColorMode')
   })
 
   it('embeds cookie merge when crossDomainColorMode.registrableDomain is set', () => {

--- a/packages/ui/src/color-mode/use-document-color-mode-surface.js
+++ b/packages/ui/src/color-mode/use-document-color-mode-surface.js
@@ -24,7 +24,7 @@ export function applyDocumentColorModeSurface(colorMode, theme, surface) {
     .filter(className => className.startsWith('theme-ui-'))
     .forEach(className => htmlElement.classList.remove(className))
   htmlElement.classList.add(`theme-ui-${normalizedColorMode}`)
-  htmlElement.setAttribute('data-theme-ui-color-mode', normalizedColorMode)
+  htmlElement.dataset.themeUiColorMode = normalizedColorMode
   htmlElement.style.backgroundColor = bgColorRaw
 }
 

--- a/packages/ui/src/gatsby/index.spec.js
+++ b/packages/ui/src/gatsby/index.spec.js
@@ -30,7 +30,7 @@ describe('@chronogrove/ui/gatsby', () => {
       const colorModeScriptTag = colorModeScriptContainer.querySelector('script')
       expect(colorModeScriptTag).toHaveTextContent(/localStorage\.getItem\(__cgKey\)/)
       expect(colorModeScriptTag.textContent).not.toContain('__cgGetCookie')
-      expect(colorModeScriptTag).toHaveTextContent(/data-theme-ui-color-mode/)
+      expect(colorModeScriptTag).toHaveTextContent(/dataset\.themeUiColorMode/)
 
       const { container: htmlBgScriptContainer } = render(head[1])
       const htmlBgScriptTag = htmlBgScriptContainer.querySelector('script')

--- a/theme/gatsby-browser.spec.js
+++ b/theme/gatsby-browser.spec.js
@@ -195,7 +195,7 @@ describe('gatsby-browser', () => {
 
   describe('onRouteUpdate', () => {
     it('prefers localStorage over DOM so route transitions do not perpetuate wrong paint', () => {
-      document.documentElement.setAttribute('data-theme-ui-color-mode', 'dark')
+      document.documentElement.dataset.themeUiColorMode = 'dark'
       document.documentElement.classList.add('theme-ui-dark')
       window.localStorage.setItem('theme-ui-color-mode', 'default')
 
@@ -211,7 +211,7 @@ describe('gatsby-browser', () => {
 
     it('falls back to DOM when localStorage is empty', () => {
       window.localStorage.removeItem('theme-ui-color-mode')
-      document.documentElement.setAttribute('data-theme-ui-color-mode', 'dark')
+      document.documentElement.dataset.themeUiColorMode = 'dark'
       document.documentElement.classList.add('theme-ui-dark')
 
       onRouteUpdate({
@@ -302,7 +302,7 @@ describe('gatsby-browser', () => {
     it('removes stale theme-ui classes before applying the resolved mode', () => {
       window.localStorage.setItem('theme-ui-color-mode', 'default')
       document.documentElement.className = 'theme-ui-dark theme-ui-default app-shell'
-      document.documentElement.setAttribute('data-theme-ui-color-mode', 'dark')
+      document.documentElement.dataset.themeUiColorMode = 'dark'
 
       onRouteUpdate({
         location: { pathname: '/current', hash: '' },

--- a/theme/gatsby-ssr.spec.js
+++ b/theme/gatsby-ssr.spec.js
@@ -33,7 +33,7 @@ describe('gatsby-ssr', () => {
     expect(colorModeScriptTag).toHaveTextContent(/localStorage\.getItem\(__cgKey\)/)
     expect(colorModeScriptTag).toHaveTextContent(/localStorage\.setItem\(__cgKey,/)
     expect(colorModeScriptTag).toHaveTextContent(/prefers-color-scheme/)
-    expect(colorModeScriptTag).toHaveTextContent(/data-theme-ui-color-mode/)
+    expect(colorModeScriptTag).toHaveTextContent(/dataset\.themeUiColorMode/)
 
     const { container: htmlBgScriptContainer } = render(headComponents[3])
     const htmlBgScriptTag = htmlBgScriptContainer.querySelector('script')

--- a/theme/package.json
+++ b/theme/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-theme-chronogrove",
   "description": "A personal website and digital garden theme for GatsbyJS.",
-  "version": "0.91.3",
+  "version": "0.91.4",
   "author": "Chris Vogt <mail@chrisvogt.me> (https://www.chrisvogt.me)",
   "main": "index.js",
   "license": "MIT",

--- a/theme/src/components/widgets/instagram/instagram-widget.js
+++ b/theme/src/components/widgets/instagram/instagram-widget.js
@@ -333,12 +333,12 @@ export default () => {
 
       // Apply data attributes for CSS styling
       if (slide.isAlbumStart) {
-        thumbItem.setAttribute('data-album-start', 'true')
+        thumbItem.dataset.albumStart = 'true'
       }
       if (slide.isAlbumEnd) {
-        thumbItem.setAttribute('data-album-end', 'true')
+        thumbItem.dataset.albumEnd = 'true'
       }
-      thumbItem.setAttribute('data-album-index', slide.albumIndex)
+      thumbItem.dataset.albumIndex = String(slide.albumIndex)
     },
     [dynamicEl]
   )

--- a/theme/src/helpers/color-mode-debug.spec.js
+++ b/theme/src/helpers/color-mode-debug.spec.js
@@ -115,7 +115,7 @@ describe('color-mode-debug', () => {
 
     it('logs when debug is enabled', () => {
       globalThis.window.__THEME_UI_COLOR_MODE_DEBUG__ = true
-      document.documentElement.setAttribute('data-theme-ui-color-mode', 'default')
+      document.documentElement.dataset.themeUiColorMode = 'default'
 
       logColorModeState('default', { colors: { text: '#111', background: '#fdf8f5' } }, 'Test')
 


### PR DESCRIPTION
## Summary

Align `data-*` writes with the `dataset` API for Theme UI color mode (`@chronogrove/ui`) and Instagram album thumbnail markers (`gatsby-theme-chronogrove`). Reads already used `dataset.themeUiColorMode` in places like `browser-sync.js`; writes now match.

## Changes

- **`@chronogrove/ui`**: `browser-sync.js`, `use-document-color-mode-surface.js`, and no-flash inline script in `head-inline.js` set `htmlElement.dataset.themeUiColorMode` instead of `setAttribute('data-theme-ui-color-mode', …)`.
- **Theme**: `instagram-widget.js` sets album markers via `thumbItem.dataset` (`albumStart`, `albumEnd`, `albumIndex`); CSS `[data-album-*]` selectors unchanged.
- **Tests**: Updated specs that seed or assert inline script / HTML behavior.

## Versions

- `@chronogrove/ui`: **0.85.2 → 0.85.3**
- `gatsby-theme-chronogrove`: **0.91.3 → 0.91.4**

See `CHANGELOG.md` (`## 0.91.4`).

Made with [Cursor](https://cursor.com)