### PR TITLE
feat(theme): prefer metrics API profile fields for widget CTAs (#606)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## 0.91.6
+
+### `gatsby-theme-chronogrove` — Widget CTAs from metrics profile data (#606)
+
+- **Flickr** (`flickr-widget.js`): **Visit Profile** uses **`profile.displayName`** and **`profile.profileURL`** from the widget payload when present; falls back to **`widgets.flickr.username`** and the canonical Flickr photos URL.
+- **GitHub** (`github-widget.js`): CTA prefers **`user.url`**, **`user.name`**, and **`user.login`** from the API response, with metadata username and constructed **`www.github.com`** URL as fallback.
+- **Goodreads** (`goodreads-widget.js`, `metadata.js`): CTA prefers **`profile.name`** / **`profile.displayName`** and a canonical URL from **`getGoodreadsProfilePageUrl`** (**`profile.profileURL`** first, then legacy **`profile.link`** until [chrisvogt/chronogrove#322](https://github.com/chrisvogt/chronogrove/issues/322)); metadata username URL remains the last fallback.
+- **Docs** (`packages/theme/README.md`): Table documents which **`profile`** / **`user`** fields each widget consumes for CTAs versus site metadata fallbacks.
+- **Tests**: Flickr (metadata vs API profile), GitHub (API `user` fields), Goodreads (**`profileURL`** / **`link`**), **`metadata.spec.js`** for **`getGoodreadsProfilePageUrl`**; Goodreads snapshots updated where the CTA title reflects API **`profile.name`**.
+- **Versions**: **`gatsby-theme-chronogrove` 0.91.6**; **`www.chrisvogt.me` 1.22.5**; **`www.chronogrove.com` 1.9.5** (**`@chronogrove/ui`** unchanged).
+
+### Files changed (high level)
+
+- `CHANGELOG.md`
+- `packages/theme/package.json` (version **0.91.6**)
+- `packages/theme/README.md`
+- `packages/theme/src/selectors/metadata.js`, **`metadata.spec.js`**
+- `packages/theme/src/components/widgets/flickr/flickr-widget.js`, **`flickr-widget.spec.js`**
+- `packages/theme/src/components/widgets/github/github-widget.js`, **`github-widget.spec.js`**
+- `packages/theme/src/components/widgets/goodreads/goodreads-widget.js`, **`goodreads-widget.spec.js`**, **`__snapshots__/goodreads-widget.spec.js.snap`**
+- `websites/www.chrisvogt.me/package.json`, **`websites/www.chronogrove.com/package.json`**
+
+---
+
 ## 0.91.5
 
 ### Repository layout — `packages/theme`, `websites/*`, theme-local scripts

--- a/packages/theme/README.md
+++ b/packages/theme/README.md
@@ -225,6 +225,22 @@ Configure social media widgets for your dashboard:
 }
 ```
 
+#### Metrics API profile fields (`profile` / `user`)
+
+[`useWidgetData`](src/hooks/use-widget-data.js) normalizes `{ payload: {...} }` responses to the inner object. Dashboard **Visit Profile / Browse** CTAs prefer **canonical names and URLs** from that payload when present, and otherwise fall back to `siteMetadata.widgets.*` (configured usernames).
+
+| Widget        | CTA prefers (from metrics payload)                                                                                                          | Metadata fallback                                                                   |
+| ------------- | ------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
+| **Flickr**    | `profile.displayName`, `profile.profileURL`                                                                                                 | `widgets.flickr.username` → `https://www.flickr.com/photos/{username}`              |
+| **Instagram** | `profile.displayName`, `profile.profileURL`                                                                                                 | `widgets.instagram.username` → `https://www.instagram.com/{username}`               |
+| **GitHub**    | `user.url`, `user.name` / `user.login` (tooltip label)                                                                                      | `widgets.github.username` → `https://www.github.com/{username}`                     |
+| **Goodreads** | `profile.name` / `profile.displayName`; **`profile.profileURL`** (canonical; legacy `profile.link` supported until API normalization ships) | `widgets.goodreads.username` → `https://www.goodreads.com/{username}`               |
+| **Spotify**   | `profile.displayName`, `profile.profileURL`, `provider.displayName`                                                                         | _(CTA builds from payload; omitting profile leaves empty strings until data loads)_ |
+| **Steam**     | `profile.displayName`, `profile.profileURL`                                                                                                 | _(no alternate URL in widget; keyed by synced profile)_                             |
+| **Discogs**   | `profile.profileURL`                                                                                                                        | `https://www.discogs.com` if URL missing                                            |
+
+Implementations mirror [chrisvogt/metrics](https://github.com/chrisvogt/metrics) widget responses; omitting optional fields preserves backward compatibility.
+
 ## 📝 Content
 
 ### Blog Posts

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-theme-chronogrove",
   "description": "A personal website and digital garden theme for GatsbyJS.",
-  "version": "0.91.5",
+  "version": "0.91.6",
   "author": "Chris Vogt <mail@chrisvogt.me> (https://www.chrisvogt.me)",
   "main": "index.js",
   "license": "MIT",

--- a/packages/theme/src/components/widgets/flickr/flickr-widget.js
+++ b/packages/theme/src/components/widgets/flickr/flickr-widget.js
@@ -50,6 +50,10 @@ export default () => {
   // Extract data from the query result
   const photos = data?.collections?.photos
   const metrics = data?.metrics
+  const profileDisplayName = data?.profile?.displayName
+  const profileURL = data?.profile?.profileURL
+  const ctaLabel = profileDisplayName || flickrUsername || 'Flickr'
+  const ctaUrl = profileURL ?? (flickrUsername ? `https://www.flickr.com/photos/${flickrUsername}` : undefined)
 
   const [isShowingMore, setIsShowingMore] = useState(false)
 
@@ -77,11 +81,7 @@ export default () => {
   }, [isLoading, isShowingMore])
 
   const callToAction = (
-    <CallToAction
-      title={`${flickrUsername} on Flickr`}
-      url={`https://www.flickr.com/photos/${flickrUsername}`}
-      isLoading={isLoading}
-    >
+    <CallToAction title={`${ctaLabel} on Flickr`} url={ctaUrl} isLoading={isLoading}>
       Visit Profile <span className='read-more-icon'>&rarr;</span>
     </CallToAction>
   )

--- a/packages/theme/src/components/widgets/flickr/flickr-widget.spec.js
+++ b/packages/theme/src/components/widgets/flickr/flickr-widget.spec.js
@@ -264,7 +264,7 @@ describe('FlickrWidget', () => {
     expect(container.querySelector('section')).toBeInTheDocument()
   })
 
-  it('renders CallToAction with correct Flickr profile URL', () => {
+  it('renders CallToAction with correct Flickr profile URL when API omits profile', () => {
     useWidgetData.mockReturnValue(mockSuccessState)
 
     render(
@@ -275,6 +275,29 @@ describe('FlickrWidget', () => {
     const callToAction = screen.getByText('Visit Profile')
     expect(callToAction).toBeInTheDocument()
     expect(callToAction.closest('a')).toHaveAttribute('href', 'https://www.flickr.com/photos/test_username')
+    expect(callToAction.closest('a')).toHaveAttribute('title', 'test_username on Flickr')
+  })
+
+  it('prefers metrics API profile.displayName / profile.profileURL for the Visit Profile CTA', () => {
+    useWidgetData.mockReturnValue({
+      ...mockSuccessState,
+      data: {
+        ...mockSuccessState.data,
+        profile: {
+          displayName: 'Synced Screen Name',
+          profileURL: 'https://www.flickr.com/people/real-nsid/'
+        }
+      }
+    })
+
+    render(
+      <TestProviderWithQuery>
+        <FlickrWidget />
+      </TestProviderWithQuery>
+    )
+    const callToAction = screen.getByText('Visit Profile')
+    expect(callToAction.closest('a')).toHaveAttribute('href', 'https://www.flickr.com/people/real-nsid/')
+    expect(callToAction.closest('a')).toHaveAttribute('title', 'Synced Screen Name on Flickr')
   })
 
   it('renders correct number of images based on show more/less state', () => {

--- a/packages/theme/src/components/widgets/github/github-widget.js
+++ b/packages/theme/src/components/widgets/github/github-widget.js
@@ -49,10 +49,13 @@ const GitHubWidget = () => {
   const pinnedItems = user?.pinnedItems?.nodes
   const contributionCalendar = user?.contributionsCollection?.contributionCalendar
 
+  const profileURL = user?.url
+  const profileLabel = user?.name || user?.login || githubUsername
+
   const callToAction = (
     <CallToAction
-      title={`${githubUsername} on GitHub`}
-      url={`https://www.github.com/${githubUsername}`}
+      title={`${profileLabel} on GitHub`}
+      url={profileURL || `https://www.github.com/${githubUsername}`}
       isLoading={isLoading}
     >
       Visit Profile <span className='read-more-icon'>&rarr;</span>

--- a/packages/theme/src/components/widgets/github/github-widget.spec.js
+++ b/packages/theme/src/components/widgets/github/github-widget.spec.js
@@ -138,4 +138,28 @@ describe('GitHub Widget', () => {
     expect(screen.getByText('Last Pull Request')).toBeInTheDocument()
     expect(screen.getByText('Contribution Graph')).toBeInTheDocument()
   })
+
+  it('uses user.url / user.name for the Visit Profile CTA when the API supplies them', () => {
+    useWidgetData.mockReturnValue({
+      ...mockSuccessState,
+      data: {
+        user: {
+          ...mockSuccessState.data.user,
+          url: 'https://github.com/octocat',
+          name: 'The Octocat',
+          login: 'octocat'
+        }
+      }
+    })
+
+    render(
+      <TestProviderWithQuery>
+        <GitHubWidget />
+      </TestProviderWithQuery>
+    )
+
+    const cta = screen.getByText('Visit Profile')
+    expect(cta.closest('a')).toHaveAttribute('href', 'https://github.com/octocat')
+    expect(cta.closest('a')).toHaveAttribute('title', 'The Octocat on GitHub')
+  })
 })

--- a/packages/theme/src/components/widgets/goodreads/__snapshots__/goodreads-widget.spec.js.snap
+++ b/packages/theme/src/components/widgets/goodreads/__snapshots__/goodreads-widget.spec.js.snap
@@ -280,7 +280,7 @@ exports[`Goodreads Widget renders with data and AI summary 1`] = `
           <a
             class="css-bgnrb"
             href="https://www.goodreads.com/mockusername"
-            title="mockusername on Goodreads"
+            title="Test User on Goodreads"
           >
             Visit Profile 
             <span
@@ -386,7 +386,7 @@ exports[`Goodreads Widget renders without AI summary when not available 1`] = `
           <a
             class="css-bgnrb"
             href="https://www.goodreads.com/mockusername"
-            title="mockusername on Goodreads"
+            title="Test User on Goodreads"
           >
             Visit Profile 
             <span

--- a/packages/theme/src/components/widgets/goodreads/goodreads-widget.js
+++ b/packages/theme/src/components/widgets/goodreads/goodreads-widget.js
@@ -3,7 +3,11 @@ import { jsx } from 'theme-ui'
 import { faGoodreads } from '@fortawesome/free-brands-svg-icons'
 
 import { pickAiSummarySyncedAtRaw } from '../../../helpers/ai-summary-synced-at'
-import { getGoodreadsUsername, getGoodreadsWidgetDataSource } from '../../../selectors/metadata'
+import {
+  getGoodreadsProfilePageUrl,
+  getGoodreadsUsername,
+  getGoodreadsWidgetDataSource
+} from '../../../selectors/metadata'
 import useSiteMetadata from '../../../hooks/use-site-metadata'
 import useWidgetData from '../../../hooks/use-widget-data'
 
@@ -39,8 +43,10 @@ export default () => {
     metrics.push({ displayName: 'Books Read', id: 'read-count', value: data.profile.readCount })
   }
 
-  // Profile display name
-  const profileDisplayName = data?.profile?.name
+  // Profile display name (metrics API); name or displayName, else site metadata username
+  const profileDisplayName = data?.profile?.name || data?.profile?.displayName
+  const profileURL = getGoodreadsProfilePageUrl(data?.profile)
+  const ctaLabel = profileDisplayName || goodreadsUsername || 'Goodreads'
 
   // Status comes from updates collection, finding first userstatus or review
   const updates = data?.collections?.updates || []
@@ -48,8 +54,11 @@ export default () => {
 
   const callToAction = (
     <CallToAction
-      title={`${goodreadsUsername} on Goodreads`}
-      url={`https://www.goodreads.com/${goodreadsUsername}`}
+      title={`${ctaLabel} on Goodreads`}
+      url={
+        profileURL ??
+        (goodreadsUsername ? `https://www.goodreads.com/${goodreadsUsername}` : 'https://www.goodreads.com')
+      }
       isLoading={isLoading}
     >
       Visit Profile <span className='read-more-icon'>&rarr;</span>

--- a/packages/theme/src/components/widgets/goodreads/goodreads-widget.spec.js
+++ b/packages/theme/src/components/widgets/goodreads/goodreads-widget.spec.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import '@testing-library/jest-dom'
 import GoodreadsWidget from './goodreads-widget'
 import { TestProviderWithQuery } from '../../../testUtils'
@@ -214,6 +214,51 @@ describe('Goodreads Widget', () => {
     )
 
     expect(getByTestId('user-status')).toBeInTheDocument()
+  })
+
+  it('prefers metrics API profile.profileURL for the Visit Profile CTA', () => {
+    useWidgetData.mockReturnValue({
+      ...mockSuccessState,
+      data: {
+        ...mockSuccessState.data,
+        profile: {
+          ...mockSuccessState.data.profile,
+          profileURL: 'https://www.goodreads.com/user/show/999-synced-profile'
+        }
+      }
+    })
+
+    render(
+      <TestProviderWithQuery>
+        <GoodreadsWidget />
+      </TestProviderWithQuery>
+    )
+
+    const cta = screen.getByText('Visit Profile')
+    expect(cta.closest('a')).toHaveAttribute('href', 'https://www.goodreads.com/user/show/999-synced-profile')
+    expect(cta.closest('a')).toHaveAttribute('title', 'Test User on Goodreads')
+  })
+
+  it('uses profile.link for Visit Profile when profileURL is omitted (live API shape)', () => {
+    useWidgetData.mockReturnValue({
+      ...mockSuccessState,
+      data: {
+        ...mockSuccessState.data,
+        profile: {
+          ...mockSuccessState.data.profile,
+          link: 'https://www.goodreads.com/user/show/10454947-chris-vogt'
+        }
+      }
+    })
+
+    render(
+      <TestProviderWithQuery>
+        <GoodreadsWidget />
+      </TestProviderWithQuery>
+    )
+
+    const cta = screen.getByText('Visit Profile')
+    expect(cta.closest('a')).toHaveAttribute('href', 'https://www.goodreads.com/user/show/10454947-chris-vogt')
   })
 
   it('handles missing profile metrics gracefully', () => {

--- a/packages/theme/src/selectors/metadata.js
+++ b/packages/theme/src/selectors/metadata.js
@@ -18,6 +18,14 @@ export const getGoodreadsUsername = metadata => metadata?.widgets?.goodreads?.us
 
 export const getGoodreadsWidgetDataSource = metadata => metadata?.widgets?.goodreads?.widgetDataSource
 
+/**
+ * Public Goodreads profile URL from a widget payload `profile` object.
+ * Prefer `profileURL` (same field name as other Chronogrove widgets); older responses may only set `link`.
+ * @param {{ profileURL?: string, link?: string } | null | undefined} profile
+ * @returns {string | undefined}
+ */
+export const getGoodreadsProfilePageUrl = profile => profile?.profileURL || profile?.link || undefined
+
 export const getHeadline = metadata => metadata?.headline
 
 export const getImageURL = metadata => metadata?.imageURL

--- a/packages/theme/src/selectors/metadata.spec.js
+++ b/packages/theme/src/selectors/metadata.spec.js
@@ -4,6 +4,7 @@ import {
   getDescription,
   getGithubUsername,
   getGithubWidgetDataSource,
+  getGoodreadsProfilePageUrl,
   getGoodreadsUsername,
   getGoodreadsWidgetDataSource,
   getHeadline,
@@ -82,6 +83,28 @@ describe('Metadata Selectors', () => {
   it('selects the goodreads widget data source', () => {
     const result = getGoodreadsWidgetDataSource(metadata)
     expect(result).toEqual(metadata.widgets.goodreads.widgetDataSource)
+  })
+
+  describe('getGoodreadsProfilePageUrl', () => {
+    it('prefers profileURL over link', () => {
+      expect(
+        getGoodreadsProfilePageUrl({
+          profileURL: 'https://www.goodreads.com/user/show/1-a',
+          link: 'https://www.goodreads.com/user/show/1-b'
+        })
+      ).toBe('https://www.goodreads.com/user/show/1-a')
+    })
+
+    it('falls back to link when profileURL is absent', () => {
+      expect(getGoodreadsProfilePageUrl({ link: 'https://www.goodreads.com/user/show/legacy' })).toBe(
+        'https://www.goodreads.com/user/show/legacy'
+      )
+    })
+
+    it('returns undefined when profile is missing or empty', () => {
+      expect(getGoodreadsProfilePageUrl(undefined)).toBeUndefined()
+      expect(getGoodreadsProfilePageUrl({})).toBeUndefined()
+    })
   })
 
   it('selects the twitter username', () => {

--- a/websites/www.chrisvogt.me/package.json
+++ b/websites/www.chrisvogt.me/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "www.chrisvogt.me",
-  "version": "1.22.4",
+  "version": "1.22.5",
   "license": "GPL",
   "scripts": {
     "build": "gatsby build",

--- a/websites/www.chronogrove.com/package.json
+++ b/websites/www.chronogrove.com/package.json
@@ -1,6 +1,6 @@
 {
   "name": "www.chronogrove.com",
-  "version": "1.9.4",
+  "version": "1.9.5",
   "description": "Official demo site for gatsby-theme-chronogrove",
   "scripts": {
     "develop": "gatsby develop",


### PR DESCRIPTION
## Summary

Uses canonical **profile / user** fields from Chronogrove widget payloads for dashboard **Visit Profile** (and related) CTAs where available, with unchanged **site metadata** fallbacks.

## Changes

- **Flickr**: `profile.displayName`, `profile.profileURL`; fallback to `widgets.flickr.username` and photos URL pattern.
- **GitHub**: `user.url`, `user.name`, `user.login`; fallback to configured username / `www.github.com/{username}`.
- **Goodreads**: `getGoodreadsProfilePageUrl` — `profile.profileURL` then legacy `profile.link` ([chronogrove#322](https://github.com/chrisvogt/chronogrove/issues/322) tracks API normalization).
- **Docs**: README table of per-widget profile fields used for CTAs.
- **Versions**: Theme **0.91.6**; `www.chrisvogt.me` **1.22.5**; demo **1.9.5** (`CHANGELOG.md`).

## Tests

- Flickr, GitHub, Goodreads specs; `metadata.spec.js`; Goodreads snapshots updated where CTA title reflects API profile name.

Closes https://github.com/chrisvogt/gatsby-theme-chronogrove/issues/606


Made with [Cursor](https://cursor.com)