### PR TITLE
refactor(theme): reduce Sonar complexity; tests use dataset for color mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+## 0.91.7
+
+### `gatsby-theme-chronogrove` — Sonar maintainability (complexity, tests)
+
+- **Home navigation** (`home-navigation.js`): Extracted hash-link click handling and icon resolution from **`HomeNavRailLink`** to satisfy cognitive complexity limits.
+- **Discogs** (`discogs-modal.js`): Focus, keyboard navigation, and body scroll-lock are **`useDiscogsModal*`** hooks; cover and tracklist markup live in **`DiscogsModalCoverSection`** and **`DiscogsModalTracklistSection`**.
+- **Vinyl collection** (`vinyl-collection.js`): Breakpoint index, pagination page list, and grid hover-clear timing use module helpers (**`vinylBreakpointIndexForWidth`**, **`buildVinylCollectionPages`**, **`scheduleVinylGridHoverClear`**) to reduce complexity and nested callbacks.
+- **AI summary** (`ai-summary-synced-at.js`): Firestore-style **`seconds`** handling moved to **`tryFormatAiSummaryFirestoreSeconds`**.
+- **Tests**: Theme and UI color-mode specs clear **`data-theme-ui-color-mode`** with **`delete document.documentElement.dataset.themeUiColorMode`** instead of **`removeAttribute`**.
+- **Versions**: **`gatsby-theme-chronogrove` 0.91.7**; **`www.chrisvogt.me` 1.22.6**; **`@chronogrove/ui`** unchanged (spec-only edits).
+
+### `www.chrisvogt.me`
+
+- **Career path** (`CareerPathVisualization.js`): Label placement and collision adjustment moved to module helpers. **`CareerPathVisualization.spec.js`** builds the D3 mock with a short chain instead of deeply nested **`jest.fn`** wrappers.
+
+### Files changed (high level)
+
+- `CHANGELOG.md`
+- `packages/theme/package.json` (version **0.91.7**)
+- `packages/theme/gatsby-browser.spec.js`, `packages/theme/src/components/root-wrapper.spec.js`
+- `packages/theme/src/components/home-navigation.js`
+- `packages/theme/src/components/widgets/discogs/discogs-modal.js`, `vinyl-collection.js`
+- `packages/theme/src/helpers/ai-summary-synced-at.js`
+- `packages/ui/src/color-mode/browser-sync.spec.js`, `spa-navigation.spec.js`, `use-document-color-mode-surface.spec.js`, `packages/ui/src/gatsby/index.spec.js`
+- `websites/www.chrisvogt.me/package.json` (version **1.22.6**), `components/CareerPathVisualization.js`, `components/CareerPathVisualization.spec.js`
+
+---
+
 ## 0.91.6
 
 ### `gatsby-theme-chronogrove` — Widget CTAs from metrics profile data (#606)

--- a/packages/theme/gatsby-browser.spec.js
+++ b/packages/theme/gatsby-browser.spec.js
@@ -38,7 +38,7 @@ beforeEach(() => {
   })
   window.localStorage.removeItem('theme-ui-color-mode')
   document.documentElement.className = ''
-  document.documentElement.removeAttribute('data-theme-ui-color-mode')
+  delete document.documentElement.dataset.themeUiColorMode
 })
 
 function expectHtmlDatasetThemeUiColorMode(mode) {
@@ -225,7 +225,7 @@ describe('gatsby-browser', () => {
 
     it('falls back to theme-ui-* class when localStorage and data attribute are empty', () => {
       window.localStorage.removeItem('theme-ui-color-mode')
-      document.documentElement.removeAttribute('data-theme-ui-color-mode')
+      delete document.documentElement.dataset.themeUiColorMode
       document.documentElement.classList.add('theme-ui-dark')
 
       onRouteUpdate({

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-theme-chronogrove",
   "description": "A personal website and digital garden theme for GatsbyJS.",
-  "version": "0.91.6",
+  "version": "0.91.7",
   "author": "Chris Vogt <mail@chrisvogt.me> (https://www.chrisvogt.me)",
   "main": "index.js",
   "license": "MIT",

--- a/packages/theme/src/components/home-navigation.js
+++ b/packages/theme/src/components/home-navigation.js
@@ -41,6 +41,25 @@ function homeNavIconSlugToReactIcon(slug) {
   return `fa${slug.charAt(0).toUpperCase() + slug.slice(1)}`
 }
 
+function handleHomeNavRailHashClick(e, { id, href }) {
+  e.preventDefault()
+  window.history.pushState(null, '', href)
+  if (id === 'home' || href === '#top') {
+    window.scrollTo({ top: 0, left: 0, behavior: 'smooth' })
+    const topSection = document.getElementById('top')
+    if (topSection && typeof topSection.focus === 'function') {
+      topSection.focus({ preventScroll: true })
+    }
+  } else {
+    scrollToElementWhenReady(href)
+  }
+}
+
+function resolveHomeNavRailIcon(icon) {
+  const key = icon?.reactIcon
+  return key && icons[key] ? icons[key] : null
+}
+
 // Badge sizes
 const BADGE_ACTIVE = 44
 const BADGE_IDLE = 34
@@ -86,7 +105,7 @@ function HomeNavRailLink({
   text
 }) {
   const isActive = activeSection === id
-  const IconComponent = icon?.reactIcon && icons[icon.reactIcon] ? icons[icon.reactIcon] : null
+  const IconComponent = resolveHomeNavRailIcon(icon)
   const badgeSize = isActive ? BADGE_ACTIVE : BADGE_IDLE
 
   const itemContent = (
@@ -173,23 +192,7 @@ function HomeNavRailLink({
   }
 
   return isHashLink(href) ? (
-    <a
-      {...commonProps}
-      href={href}
-      onClick={e => {
-        e.preventDefault()
-        window.history.pushState(null, '', href)
-        if (id === 'home' || href === '#top') {
-          window.scrollTo({ top: 0, left: 0, behavior: 'smooth' })
-          const topSection = document.getElementById('top')
-          if (topSection && typeof topSection.focus === 'function') {
-            topSection.focus({ preventScroll: true })
-          }
-        } else {
-          scrollToElementWhenReady(href)
-        }
-      }}
-    >
+    <a {...commonProps} href={href} onClick={e => handleHomeNavRailHashClick(e, { id, href })}>
       {itemContent}
     </a>
   ) : (

--- a/packages/theme/src/components/root-wrapper.spec.js
+++ b/packages/theme/src/components/root-wrapper.spec.js
@@ -46,7 +46,7 @@ describe('RootWrapper', () => {
       provider: 'soundcloud'
     })
     document.documentElement.className = ''
-    document.documentElement.removeAttribute('data-theme-ui-color-mode')
+    delete document.documentElement.dataset.themeUiColorMode
     document.documentElement.style.backgroundColor = ''
     try {
       window.localStorage.removeItem('theme-ui-color-mode')

--- a/packages/theme/src/components/widgets/discogs/discogs-modal.js
+++ b/packages/theme/src/components/widgets/discogs/discogs-modal.js
@@ -20,32 +20,35 @@ function formatCollectionAddedLocal(ms) {
   }
 }
 
-const DiscogsModal = ({ isOpen, onClose, release, orderedReleases, onSelectRelease }) => {
-  const { colorMode } = useThemeUI()
-  const darkMode = isDarkMode(colorMode)
-  const modalRef = useRef(null)
-  const previousActiveElement = useRef(null)
-  const [imageLoaded, setImageLoaded] = useState(false)
+function discogsModalTargetIgnoresArrowKeys(el) {
+  const tag = el?.tagName
+  if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return true
+  return Boolean(el?.closest?.('[contenteditable="true"]'))
+}
 
-  // Reset image load state when release/cover changes
-  const coverImageUrl = release?.basicInformation?.cdnCoverUrl || release?.basicInformation?.coverImage
-  useEffect(() => {
-    setImageLoaded(false)
-  }, [coverImageUrl])
+function canBrowseDiscogsReleasesWithArrows(onSelectRelease, orderedReleases, release) {
+  return (
+    typeof onSelectRelease === 'function' &&
+    Array.isArray(orderedReleases) &&
+    orderedReleases.length >= 2 &&
+    Boolean(release)
+  )
+}
 
-  // Focus dialog when opening; restore focus only when closing (not when release changes while open)
+function useDiscogsModalFocus(isOpen, modalRef, previousActiveElementRef) {
   useEffect(() => {
     if (isOpen) {
-      previousActiveElement.current = document.activeElement
+      previousActiveElementRef.current = document.activeElement
       queueMicrotask(() => {
         modalRef.current?.focus()
       })
     } else {
-      previousActiveElement.current?.focus?.()
+      previousActiveElementRef.current?.focus?.()
     }
   }, [isOpen])
+}
 
-  // Escape, ArrowLeft / ArrowRight (browse collection in current sort order)
+function useDiscogsModalKeyboard(isOpen, onClose, release, orderedReleases, onSelectRelease) {
   useEffect(() => {
     if (!isOpen) return
 
@@ -57,18 +60,11 @@ const DiscogsModal = ({ isOpen, onClose, release, orderedReleases, onSelectRelea
 
       if (e.key !== 'ArrowLeft' && e.key !== 'ArrowRight') return
 
-      if (
-        typeof onSelectRelease !== 'function' ||
-        !Array.isArray(orderedReleases) ||
-        orderedReleases.length < 2 ||
-        !release
-      ) {
+      if (!canBrowseDiscogsReleasesWithArrows(onSelectRelease, orderedReleases, release)) {
         return
       }
 
-      const el = e.target
-      const tag = el?.tagName
-      if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT' || el?.closest?.('[contenteditable="true"]')) {
+      if (discogsModalTargetIgnoresArrowKeys(e.target)) {
         return
       }
 
@@ -86,8 +82,9 @@ const DiscogsModal = ({ isOpen, onClose, release, orderedReleases, onSelectRelea
     document.addEventListener('keydown', onKeyDown)
     return () => document.removeEventListener('keydown', onKeyDown)
   }, [isOpen, onClose, release, orderedReleases, onSelectRelease])
+}
 
-  // Prevent body scroll when modal is open
+function useDiscogsModalBodyScrollLock(isOpen) {
   useEffect(() => {
     if (isOpen) {
       document.body.style.overflow = 'hidden'
@@ -99,6 +96,164 @@ const DiscogsModal = ({ isOpen, onClose, release, orderedReleases, onSelectRelea
       document.body.style.overflow = 'unset'
     }
   }, [isOpen])
+}
+
+function DiscogsModalCoverSection({ coverImageUrl, title, darkMode, imageLoaded, setImageLoaded, insetSurface }) {
+  if (!coverImageUrl) {
+    return (
+      <div
+        sx={{
+          width: '100%',
+          height: '100%',
+          backgroundColor: insetSurface,
+          borderRadius: 2,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          color: darkMode ? '#a0aec0' : '#718096',
+          fontSize: 1
+        }}
+      >
+        No Image Available
+      </div>
+    )
+  }
+
+  return (
+    <Fragment>
+      {!imageLoaded && (
+        <div
+          className='show-loading-animation'
+          sx={{
+            position: 'absolute',
+            inset: 0,
+            borderRadius: 2,
+            overflow: 'hidden'
+          }}
+        >
+          <RectShape
+            color={darkMode ? '#3a3a4a' : '#efefef'}
+            style={{
+              width: '100%',
+              height: '100%',
+              borderRadius: '8px'
+            }}
+          />
+        </div>
+      )}
+      <Themed.img
+        src={coverImageUrl}
+        alt={`${title} album cover`}
+        onLoad={() => setImageLoaded(true)}
+        sx={{
+          position: 'relative',
+          maxWidth: '100%',
+          maxHeight: '100%',
+          width: 'auto',
+          height: 'auto',
+          borderRadius: 2,
+          boxShadow: 'lg',
+          objectFit: 'contain',
+          opacity: imageLoaded ? 1 : 0,
+          transition: 'opacity 0.2s ease-in-out'
+        }}
+      />
+    </Fragment>
+  )
+}
+
+function DiscogsModalTracklistSection({
+  tracklist,
+  darkMode,
+  listPanelBorder,
+  insetSurface,
+  insetHeaderBg,
+  insetRule
+}) {
+  if (!tracklist?.length) return null
+
+  return (
+    <div sx={{ mt: 4 }}>
+      <Themed.h3 sx={{ margin: 0, fontSize: 3, mb: 3 }}>Tracklist</Themed.h3>
+      <div
+        sx={{
+          backgroundColor: insetSurface,
+          borderRadius: 2,
+          overflow: 'hidden',
+          border: '1px solid',
+          borderColor: listPanelBorder
+        }}
+      >
+        <div
+          sx={{
+            display: 'grid',
+            gridTemplateColumns: 'auto minmax(0, 1fr) auto',
+            gap: 2,
+            padding: 3,
+            backgroundColor: insetHeaderBg,
+            borderBottom: '1px solid',
+            borderBottomColor: insetRule,
+            fontSize: 1,
+            fontWeight: 'bold',
+            color: darkMode ? '#a0aec0' : '#718096'
+          }}
+        >
+          <div>Position</div>
+          <div sx={{ minWidth: 0 }}>Title</div>
+          <div>Duration</div>
+        </div>
+        {tracklist.map((track, index) => (
+          <div
+            key={`${String(track.position ?? '—')}-${String(track.title ?? '')}-${index}`}
+            sx={{
+              display: 'grid',
+              gridTemplateColumns: 'auto minmax(0, 1fr) auto',
+              gap: 2,
+              padding: 3,
+              borderBottom: index < tracklist.length - 1 ? '1px solid' : 'none',
+              borderBottomColor: insetRule,
+              fontSize: 1,
+              minWidth: 0,
+              '&:hover': {
+                backgroundColor: darkMode ? 'rgba(255,255,255,0.05)' : 'rgba(0,0,0,0.035)'
+              }
+            }}
+          >
+            <div sx={{ fontWeight: 'bold', color: darkMode ? '#e2e8f0' : '#2d3748' }}>{track.position || '—'}</div>
+            <div
+              sx={{
+                color: darkMode ? '#e2e8f0' : '#2d3748',
+                minWidth: 0,
+                overflowWrap: 'break-word',
+                wordBreak: 'break-word'
+              }}
+            >
+              {track.title || 'Unknown Title'}
+            </div>
+            <div sx={{ color: darkMode ? '#a0aec0' : '#718096', textAlign: 'right' }}>{track.duration || '—'}</div>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+const DiscogsModal = ({ isOpen, onClose, release, orderedReleases, onSelectRelease }) => {
+  const { colorMode } = useThemeUI()
+  const darkMode = isDarkMode(colorMode)
+  const modalRef = useRef(null)
+  const previousActiveElement = useRef(null)
+  const [imageLoaded, setImageLoaded] = useState(false)
+
+  // Reset image load state when release/cover changes
+  const coverImageUrl = release?.basicInformation?.cdnCoverUrl || release?.basicInformation?.coverImage
+  useEffect(() => {
+    setImageLoaded(false)
+  }, [coverImageUrl])
+
+  useDiscogsModalFocus(isOpen, modalRef, previousActiveElement)
+  useDiscogsModalKeyboard(isOpen, onClose, release, orderedReleases, onSelectRelease)
+  useDiscogsModalBodyScrollLock(isOpen)
 
   if (!isOpen || !release) return null
 
@@ -300,64 +455,14 @@ const DiscogsModal = ({ isOpen, onClose, release, orderedReleases, onSelectRelea
                 flexShrink: 0
               }}
             >
-              {coverImageUrl ? (
-                <Fragment>
-                  {/* Skeleton shown until image loads */}
-                  {!imageLoaded && (
-                    <div
-                      className='show-loading-animation'
-                      sx={{
-                        position: 'absolute',
-                        inset: 0,
-                        borderRadius: 2,
-                        overflow: 'hidden'
-                      }}
-                    >
-                      <RectShape
-                        color={darkMode ? '#3a3a4a' : '#efefef'}
-                        style={{
-                          width: '100%',
-                          height: '100%',
-                          borderRadius: '8px'
-                        }}
-                      />
-                    </div>
-                  )}
-                  <Themed.img
-                    src={coverImageUrl}
-                    alt={`${title} album cover`}
-                    onLoad={() => setImageLoaded(true)}
-                    sx={{
-                      position: 'relative',
-                      maxWidth: '100%',
-                      maxHeight: '100%',
-                      width: 'auto',
-                      height: 'auto',
-                      borderRadius: 2,
-                      boxShadow: 'lg',
-                      objectFit: 'contain',
-                      opacity: imageLoaded ? 1 : 0,
-                      transition: 'opacity 0.2s ease-in-out'
-                    }}
-                  />
-                </Fragment>
-              ) : (
-                <div
-                  sx={{
-                    width: '100%',
-                    height: '100%',
-                    backgroundColor: insetSurface,
-                    borderRadius: 2,
-                    display: 'flex',
-                    alignItems: 'center',
-                    justifyContent: 'center',
-                    color: darkMode ? '#a0aec0' : '#718096',
-                    fontSize: 1
-                  }}
-                >
-                  No Image Available
-                </div>
-              )}
+              <DiscogsModalCoverSection
+                coverImageUrl={coverImageUrl}
+                title={title}
+                darkMode={darkMode}
+                imageLoaded={imageLoaded}
+                setImageLoaded={setImageLoaded}
+                insetSurface={insetSurface}
+              />
             </div>
 
             {/* Details */}
@@ -402,75 +507,14 @@ const DiscogsModal = ({ isOpen, onClose, release, orderedReleases, onSelectRelea
             </div>
           </div>
 
-          {/* Tracklist */}
-          {tracklist && tracklist.length > 0 && (
-            <div sx={{ mt: 4 }}>
-              <Themed.h3 sx={{ margin: 0, fontSize: 3, mb: 3 }}>Tracklist</Themed.h3>
-              <div
-                sx={{
-                  backgroundColor: insetSurface,
-                  borderRadius: 2,
-                  overflow: 'hidden',
-                  border: '1px solid',
-                  borderColor: listPanelBorder
-                }}
-              >
-                <div
-                  sx={{
-                    display: 'grid',
-                    gridTemplateColumns: 'auto minmax(0, 1fr) auto',
-                    gap: 2,
-                    padding: 3,
-                    backgroundColor: insetHeaderBg,
-                    borderBottom: '1px solid',
-                    borderBottomColor: insetRule,
-                    fontSize: 1,
-                    fontWeight: 'bold',
-                    color: darkMode ? '#a0aec0' : '#718096'
-                  }}
-                >
-                  <div>Position</div>
-                  <div sx={{ minWidth: 0 }}>Title</div>
-                  <div>Duration</div>
-                </div>
-                {tracklist.map((track, index) => (
-                  <div
-                    key={`${String(track.position ?? '—')}-${String(track.title ?? '')}-${index}`}
-                    sx={{
-                      display: 'grid',
-                      gridTemplateColumns: 'auto minmax(0, 1fr) auto',
-                      gap: 2,
-                      padding: 3,
-                      borderBottom: index < tracklist.length - 1 ? '1px solid' : 'none',
-                      borderBottomColor: insetRule,
-                      fontSize: 1,
-                      minWidth: 0,
-                      '&:hover': {
-                        backgroundColor: darkMode ? 'rgba(255,255,255,0.05)' : 'rgba(0,0,0,0.035)'
-                      }
-                    }}
-                  >
-                    <div sx={{ fontWeight: 'bold', color: darkMode ? '#e2e8f0' : '#2d3748' }}>
-                      {track.position || '—'}
-                    </div>
-                    <div
-                      sx={{
-                        color: darkMode ? '#e2e8f0' : '#2d3748',
-                        minWidth: 0,
-                        overflowWrap: 'break-word',
-                        wordBreak: 'break-word'
-                      }}
-                    >
-                      {track.title || 'Unknown Title'}
-                    </div>
-                    <div sx={{ color: darkMode ? '#a0aec0' : '#718096', textAlign: 'right' }}>
-                      {track.duration || '—'}
-                    </div>
-                  </div>
-                ))}
-              </div>
-            </div>
-          )}
+          <DiscogsModalTracklistSection
+            tracklist={tracklist}
+            darkMode={darkMode}
+            listPanelBorder={listPanelBorder}
+            insetSurface={insetSurface}
+            insetHeaderBg={insetHeaderBg}
+            insetRule={insetRule}
+          />
 
           {/* Action buttons */}
           <div

--- a/packages/theme/src/components/widgets/discogs/discogs-modal.js
+++ b/packages/theme/src/components/widgets/discogs/discogs-modal.js
@@ -45,7 +45,7 @@ function useDiscogsModalFocus(isOpen, modalRef, previousActiveElementRef) {
     } else {
       previousActiveElementRef.current?.focus?.()
     }
-  }, [isOpen])
+  }, [isOpen, modalRef, previousActiveElementRef])
 }
 
 function useDiscogsModalKeyboard(isOpen, onClose, release, orderedReleases, onSelectRelease) {

--- a/packages/theme/src/components/widgets/discogs/vinyl-collection.js
+++ b/packages/theme/src/components/widgets/discogs/vinyl-collection.js
@@ -29,6 +29,55 @@ const DISCOGS_VIEW_GRID = 'grid'
 const DISCOGS_VIEW_LIST = 'list'
 const DEFAULT_DISCOGS_VIEW_MODE = DISCOGS_VIEW_GRID
 
+function vinylBreakpointIndexForWidth(width) {
+  if (width < 640) return 0
+  if (width < 768) return 1
+  if (width < 1024) return 2
+  if (width < 1280) return 3
+  return 4
+}
+
+function buildVinylCollectionPages({
+  isLoading,
+  vinylItems,
+  LOADING_PAGE_COUNT,
+  skeletonItemsPerPage,
+  totalPages,
+  logicalItemsPerPage
+}) {
+  const pages = []
+  if (isLoading && !vinylItems.length) {
+    for (let p = 0; p < LOADING_PAGE_COUNT; p++) {
+      pages.push(Array.from({ length: skeletonItemsPerPage }, (_, i) => ({ _placeholder: true, id: `ph-p${p}-${i}` })))
+    }
+  } else {
+    for (let i = 0; i < totalPages; i++) {
+      const start = i * logicalItemsPerPage
+      const end = Math.min(start + logicalItemsPerPage, vinylItems.length)
+      pages.push(vinylItems.slice(start, end))
+    }
+  }
+  return pages
+}
+
+function scheduleVinylGridHoverClear({ leaveTimeoutRef, vinylId, setCurrentVinylId, setExitingVinylId }) {
+  if (leaveTimeoutRef.current) {
+    clearTimeout(leaveTimeoutRef.current)
+  }
+  const delay = process.env.NODE_ENV === 'test' ? 0 : 220
+  if (delay === 0) {
+    setCurrentVinylId(false)
+    setExitingVinylId(null)
+    return
+  }
+  setExitingVinylId(vinylId)
+  leaveTimeoutRef.current = setTimeout(() => {
+    setCurrentVinylId(false)
+    setExitingVinylId(null)
+    leaveTimeoutRef.current = null
+  }, delay)
+}
+
 /** List layout: fewer records per carousel slide than the old dense list (chunk = columns × this). Matches grid rows (2) for similar page counts. */
 const LIST_ROWS_PER_PAGE = 2
 
@@ -164,22 +213,7 @@ const VinylCollection = ({ isLoading, releases = [] }) => {
   // Detect current breakpoint based on window width
   useEffect(() => {
     const updateBreakpoint = () => {
-      const width = window.innerWidth
-      let breakpointIndex
-
-      if (width < 640) {
-        breakpointIndex = 0 // Mobile: 3 columns
-      } else if (width < 768) {
-        breakpointIndex = 1 // Small: 4 columns
-      } else if (width < 1024) {
-        breakpointIndex = 2 // Medium: 4 columns
-      } else if (width < 1280) {
-        breakpointIndex = 3 // Large: 5 columns
-      } else {
-        breakpointIndex = 4 // XL (≥1280): 5 columns
-      }
-
-      setCurrentBreakpointIndex(breakpointIndex)
+      setCurrentBreakpointIndex(vinylBreakpointIndexForWidth(window.innerWidth))
     }
 
     updateBreakpoint()
@@ -252,19 +286,14 @@ const VinylCollection = ({ isLoading, releases = [] }) => {
     }
   })
 
-  // Split items into pages; when loading assume LOADING_PAGE_COUNT full pages so carousel/pagination space is reserved
-  const pages = []
-  if (isLoading && !vinylItems.length) {
-    for (let p = 0; p < LOADING_PAGE_COUNT; p++) {
-      pages.push(Array.from({ length: skeletonItemsPerPage }, (_, i) => ({ _placeholder: true, id: `ph-p${p}-${i}` })))
-    }
-  } else {
-    for (let i = 0; i < totalPages; i++) {
-      const start = i * logicalItemsPerPage
-      const end = Math.min(start + logicalItemsPerPage, vinylItems.length)
-      pages.push(vinylItems.slice(start, end))
-    }
-  }
+  const pages = buildVinylCollectionPages({
+    isLoading,
+    vinylItems,
+    LOADING_PAGE_COUNT,
+    skeletonItemsPerPage,
+    totalPages,
+    logicalItemsPerPage
+  })
 
   return (
     <div sx={{ mb: 4, maxWidth: '100%', overflow: 'hidden' }}>
@@ -674,25 +703,14 @@ const VinylCollection = ({ isLoading, releases = [] }) => {
                                 setExitingVinylId(null)
                                 if (!isDragging) setCurrentVinylId(id)
                               }}
-                              onMouseLeave={() => {
-                                if (leaveTimeoutRef.current) {
-                                  clearTimeout(leaveTimeoutRef.current)
-                                }
-                                // Delay clearing focus to allow overlay fade-out without flashing center text
-                                const delay = process.env.NODE_ENV === 'test' ? 0 : 220
-                                if (delay === 0) {
-                                  // Synchronous for tests to avoid timing assertions
-                                  setCurrentVinylId(false)
-                                  setExitingVinylId(null)
-                                  return
-                                }
-                                setExitingVinylId(id)
-                                leaveTimeoutRef.current = setTimeout(() => {
-                                  setCurrentVinylId(false)
-                                  setExitingVinylId(null)
-                                  leaveTimeoutRef.current = null
-                                }, delay)
-                              }}
+                              onMouseLeave={() =>
+                                scheduleVinylGridHoverClear({
+                                  leaveTimeoutRef,
+                                  vinylId: id,
+                                  setCurrentVinylId,
+                                  setExitingVinylId
+                                })
+                              }
                               onClick={() => handleVinylClick(release)}
                               onKeyDown={e => {
                                 if (e.key === 'Enter' || e.key === ' ') {

--- a/packages/theme/src/components/widgets/discogs/vinyl-collection.js
+++ b/packages/theme/src/components/widgets/discogs/vinyl-collection.js
@@ -60,22 +60,19 @@ function buildVinylCollectionPages({
   return pages
 }
 
+/** Delay before clearing hover "focused" state after pointer leave (orbit/caption fade). */
+export const VINYL_GRID_HOVER_LEAVE_DELAY_MS = 220
+
 function scheduleVinylGridHoverClear({ leaveTimeoutRef, vinylId, setCurrentVinylId, setExitingVinylId }) {
   if (leaveTimeoutRef.current) {
     clearTimeout(leaveTimeoutRef.current)
-  }
-  const delay = process.env.NODE_ENV === 'test' ? 0 : 220
-  if (delay === 0) {
-    setCurrentVinylId(false)
-    setExitingVinylId(null)
-    return
   }
   setExitingVinylId(vinylId)
   leaveTimeoutRef.current = setTimeout(() => {
     setCurrentVinylId(false)
     setExitingVinylId(null)
     leaveTimeoutRef.current = null
-  }, delay)
+  }, VINYL_GRID_HOVER_LEAVE_DELAY_MS)
 }
 
 /** List layout: fewer records per carousel slide than the old dense list (chunk = columns × this). Matches grid rows (2) for similar page counts. */

--- a/packages/theme/src/components/widgets/discogs/vinyl-collection.spec.js
+++ b/packages/theme/src/components/widgets/discogs/vinyl-collection.spec.js
@@ -3,7 +3,7 @@ import { render, fireEvent, screen, within } from '@testing-library/react'
 import '@testing-library/jest-dom'
 import { act } from 'react'
 
-import VinylCollection from './vinyl-collection'
+import VinylCollection, { VINYL_GRID_HOVER_LEAVE_DELAY_MS } from './vinyl-collection'
 import {
   DISCOGS_SORT_ADDED,
   DISCOGS_SORT_ALPHABETICAL,
@@ -208,20 +208,31 @@ describe('VinylCollection', () => {
     })
 
     it('handles mouse leave on vinyl item', () => {
-      const { container } = render(<VinylCollection isLoading={false} releases={mockReleases} />)
+      jest.useFakeTimers()
+      try {
+        const { container } = render(<VinylCollection isLoading={false} releases={mockReleases} />)
 
-      const vinylItem = container.querySelector('.vinyl-record')
-      expect(vinylItem).toBeTruthy()
+        const vinylItem = container.querySelector('.vinyl-record')
+        expect(vinylItem).toBeTruthy()
 
-      // First enter to set focus
-      fireEvent.mouseEnter(vinylItem)
-      expect(vinylItem.classList.contains('vinyl-record--focused')).toBe(true)
+        fireEvent.mouseEnter(vinylItem)
+        expect(vinylItem.classList.contains('vinyl-record--focused')).toBe(true)
 
-      // Then leave
-      fireEvent.mouseLeave(vinylItem)
+        fireEvent.mouseLeave(vinylItem)
+        expect(vinylItem.classList.contains('vinyl-record--exiting')).toBe(true)
 
-      // Should remove focused class
-      expect(vinylItem.classList.contains('vinyl-record--focused')).toBe(false)
+        act(() => {
+          jest.advanceTimersByTime(VINYL_GRID_HOVER_LEAVE_DELAY_MS)
+        })
+
+        expect(vinylItem.classList.contains('vinyl-record--focused')).toBe(false)
+        expect(vinylItem.classList.contains('vinyl-record--exiting')).toBe(false)
+      } finally {
+        act(() => {
+          jest.runOnlyPendingTimers()
+        })
+        jest.useRealTimers()
+      }
     })
 
     it('opens and closes the Discogs modal when a vinyl is clicked', () => {
@@ -1175,13 +1186,7 @@ describe('VinylCollection', () => {
   })
 
   describe('Hover exit timing and accessibility', () => {
-    const originalNodeEnv = process.env.NODE_ENV
-
-    afterEach(() => {
-      process.env.NODE_ENV = originalNodeEnv
-    })
-
-    describe('mouse leave delay in production (fake timers)', () => {
+    describe('mouse leave delay (fake timers)', () => {
       beforeEach(() => {
         jest.useFakeTimers()
       })
@@ -1193,50 +1198,61 @@ describe('VinylCollection', () => {
         jest.useRealTimers()
       })
 
-      it('adds exiting class on mouse leave and clears after delay (production env)', () => {
-        process.env.NODE_ENV = 'production'
+      it('adds exiting class on mouse leave and clears after delay', () => {
         const manyReleases = createManyReleases(25)
         const { container } = render(<VinylCollection isLoading={false} releases={manyReleases} />)
 
         const vinylItem = container.querySelector('.vinyl-record')
         expect(vinylItem).toBeTruthy()
 
-        // Focus via mouse enter
         fireEvent.mouseEnter(vinylItem)
         expect(vinylItem.classList.contains('vinyl-record--focused')).toBe(true)
 
-        // Trigger exit
         fireEvent.mouseLeave(vinylItem)
         expect(vinylItem.classList.contains('vinyl-record--exiting')).toBe(true)
 
-        // Advance timers to clear exit state
         act(() => {
-          jest.advanceTimersByTime(220)
+          jest.advanceTimersByTime(VINYL_GRID_HOVER_LEAVE_DELAY_MS)
         })
 
         expect(vinylItem.classList.contains('vinyl-record--exiting')).toBe(false)
         expect(vinylItem.classList.contains('vinyl-record--focused')).toBe(false)
       })
-    })
 
-    it('clears pending exit when re-entering quickly (production env)', () => {
-      process.env.NODE_ENV = 'production'
-      const manyReleases = createManyReleases(25)
-      const { container } = render(<VinylCollection isLoading={false} releases={manyReleases} />)
+      it('clears pending exit when re-entering quickly', () => {
+        const manyReleases = createManyReleases(25)
+        const { container } = render(<VinylCollection isLoading={false} releases={manyReleases} />)
 
-      const vinylItem = container.querySelector('.vinyl-record')
-      expect(vinylItem).toBeTruthy()
+        const vinylItem = container.querySelector('.vinyl-record')
+        expect(vinylItem).toBeTruthy()
 
-      // Enter, then leave to schedule exit, then quickly re-enter
-      fireEvent.mouseEnter(vinylItem)
-      expect(vinylItem.classList.contains('vinyl-record--focused')).toBe(true)
-      fireEvent.mouseLeave(vinylItem)
-      expect(vinylItem.classList.contains('vinyl-record--exiting')).toBe(true)
-      fireEvent.mouseEnter(vinylItem)
+        fireEvent.mouseEnter(vinylItem)
+        expect(vinylItem.classList.contains('vinyl-record--focused')).toBe(true)
+        fireEvent.mouseLeave(vinylItem)
+        expect(vinylItem.classList.contains('vinyl-record--exiting')).toBe(true)
+        fireEvent.mouseEnter(vinylItem)
 
-      // Exiting should be cleared and focused retained
-      expect(vinylItem.classList.contains('vinyl-record--exiting')).toBe(false)
-      expect(vinylItem.classList.contains('vinyl-record--focused')).toBe(true)
+        expect(vinylItem.classList.contains('vinyl-record--exiting')).toBe(false)
+        expect(vinylItem.classList.contains('vinyl-record--focused')).toBe(true)
+      })
+
+      it('clears a pending leave timeout when mouse leave fires again before the delay elapses', () => {
+        const clearTimeoutSpy = jest.spyOn(global, 'clearTimeout')
+        const { container } = render(<VinylCollection isLoading={false} releases={mockReleases} />)
+        const vinylItem = container.querySelector('.vinyl-record')
+
+        fireEvent.mouseEnter(vinylItem)
+        fireEvent.mouseLeave(vinylItem)
+        fireEvent.mouseLeave(vinylItem)
+
+        expect(clearTimeoutSpy).toHaveBeenCalled()
+
+        act(() => {
+          jest.runOnlyPendingTimers()
+        })
+
+        clearTimeoutSpy.mockRestore()
+      })
     })
 
     it('exposes aria-label details and album art class', () => {
@@ -1421,40 +1437,6 @@ describe('VinylCollection', () => {
       const listWrap = container.querySelector('.vinyl-collection_list')
       expect(listWrap).toBeTruthy()
       expect(listWrap.children.length).toBeGreaterThan(0)
-    })
-  })
-
-  describe('development leave timeout', () => {
-    beforeEach(() => {
-      jest.useFakeTimers()
-    })
-
-    afterEach(() => {
-      act(() => {
-        jest.runOnlyPendingTimers()
-      })
-      jest.useRealTimers()
-    })
-
-    it('clears a pending leave timeout before scheduling another one outside test mode', () => {
-      const previousNodeEnv = process.env.NODE_ENV
-      process.env.NODE_ENV = 'development'
-
-      const clearTimeoutSpy = jest.spyOn(global, 'clearTimeout')
-      const { container } = render(<VinylCollection isLoading={false} releases={mockReleases} />)
-      const vinylItem = container.querySelector('.vinyl-record')
-
-      fireEvent.mouseEnter(vinylItem)
-      fireEvent.mouseLeave(vinylItem)
-      fireEvent.mouseLeave(vinylItem)
-
-      expect(clearTimeoutSpy).toHaveBeenCalled()
-
-      act(() => {
-        jest.runOnlyPendingTimers()
-      })
-
-      process.env.NODE_ENV = previousNodeEnv
     })
   })
 })

--- a/packages/theme/src/helpers/ai-summary-synced-at.js
+++ b/packages/theme/src/helpers/ai-summary-synced-at.js
@@ -24,6 +24,29 @@ export function pickAiSummarySyncedAtRaw(payload) {
   )
 }
 
+function formatWithMediumDate(d) {
+  try {
+    return new Intl.DateTimeFormat(undefined, { dateStyle: 'medium' }).format(d)
+  } catch {
+    return null
+  }
+}
+
+/**
+ * @param {unknown} raw
+ * @returns {string|null|undefined} formatted label, null if invalid seconds object, undefined if not a Firestore seconds shape
+ */
+function tryFormatAiSummaryFirestoreSeconds(raw) {
+  if (typeof raw !== 'object' || raw === null || !('seconds' in raw)) {
+    return undefined
+  }
+  const sec = /** @type {{ seconds?: number }} */ (raw).seconds
+  if (typeof sec === 'number' && Number.isFinite(sec)) {
+    return formatWithMediumDate(new Date(sec * 1000))
+  }
+  return null
+}
+
 /**
  * @param {unknown} raw ISO string, unix ms/seconds, Date, or Firestore-style `{ seconds }`
  * @returns {string|null} medium date in the visitor's locale, or null if unparseable
@@ -38,12 +61,9 @@ export function formatAiSummarySyncedLabel(raw) {
     return Number.isNaN(t) ? null : formatWithMediumDate(new Date(t))
   }
 
-  if (typeof raw === 'object' && raw !== null && 'seconds' in raw) {
-    const sec = /** @type {{ seconds?: number }} */ (raw).seconds
-    if (typeof sec === 'number' && Number.isFinite(sec)) {
-      return formatWithMediumDate(new Date(sec * 1000))
-    }
-    return null
+  const firestoreLabel = tryFormatAiSummaryFirestoreSeconds(raw)
+  if (firestoreLabel !== undefined) {
+    return firestoreLabel
   }
 
   if (typeof raw === 'number' && Number.isFinite(raw)) {
@@ -57,12 +77,4 @@ export function formatAiSummarySyncedLabel(raw) {
   }
 
   return null
-}
-
-function formatWithMediumDate(d) {
-  try {
-    return new Intl.DateTimeFormat(undefined, { dateStyle: 'medium' }).format(d)
-  } catch {
-    return null
-  }
 }

--- a/packages/ui/src/color-mode/browser-sync.spec.js
+++ b/packages/ui/src/color-mode/browser-sync.spec.js
@@ -7,7 +7,7 @@ import { resolveThemeUiColorMode, scheduleThemeUiColorModeSync, syncThemeUiColor
 describe('resolveThemeUiColorMode', () => {
   beforeEach(() => {
     document.documentElement.className = ''
-    document.documentElement.removeAttribute('data-theme-ui-color-mode')
+    delete document.documentElement.dataset.themeUiColorMode
     window.localStorage.clear()
     window.matchMedia = jest.fn(() => ({
       matches: false,
@@ -72,7 +72,7 @@ describe('resolveThemeUiColorMode', () => {
 describe('syncThemeUiColorMode', () => {
   beforeEach(() => {
     document.documentElement.className = ''
-    document.documentElement.removeAttribute('data-theme-ui-color-mode')
+    delete document.documentElement.dataset.themeUiColorMode
     window.localStorage.clear()
     window.matchMedia = jest.fn(() => ({
       matches: false,

--- a/packages/ui/src/color-mode/spa-navigation.spec.js
+++ b/packages/ui/src/color-mode/spa-navigation.spec.js
@@ -8,7 +8,7 @@ import { RECONCILE_COLOR_MODE_EVENT } from './constants.js'
 describe('reconcileThemeUiColorModeOnNavigation', () => {
   beforeEach(() => {
     window.localStorage.removeItem('theme-ui-color-mode')
-    document.documentElement.removeAttribute('data-theme-ui-color-mode')
+    delete document.documentElement.dataset.themeUiColorMode
     document.documentElement.className = ''
   })
 

--- a/packages/ui/src/color-mode/use-document-color-mode-surface.spec.js
+++ b/packages/ui/src/color-mode/use-document-color-mode-surface.spec.js
@@ -31,7 +31,7 @@ function expectHtmlDatasetThemeUiColorMode(mode) {
 describe('useDocumentColorModeSurface', () => {
   beforeEach(() => {
     document.documentElement.className = 'theme-ui-stale'
-    document.documentElement.removeAttribute('data-theme-ui-color-mode')
+    delete document.documentElement.dataset.themeUiColorMode
     document.documentElement.style.backgroundColor = ''
     window.localStorage.removeItem('theme-ui-color-mode')
   })
@@ -114,7 +114,7 @@ describe('useDocumentColorModeSurface', () => {
     })
     expectHtmlDatasetThemeUiColorMode('default')
 
-    document.documentElement.removeAttribute('data-theme-ui-color-mode')
+    delete document.documentElement.dataset.themeUiColorMode
     act(() => {
       applyDocumentColorModeSurface(undefined, baseTheme, resolveChronogroveSurfaceColors(baseTheme))
     })

--- a/packages/ui/src/gatsby/index.spec.js
+++ b/packages/ui/src/gatsby/index.spec.js
@@ -157,7 +157,7 @@ describe('@chronogrove/ui/gatsby', () => {
   describe('onRouteUpdateThemeUiColorMode', () => {
     beforeEach(() => {
       window.localStorage.removeItem('theme-ui-color-mode')
-      document.documentElement.removeAttribute('data-theme-ui-color-mode')
+      delete document.documentElement.dataset.themeUiColorMode
       document.documentElement.className = ''
     })
 

--- a/websites/www.chrisvogt.me/components/CareerPathVisualization.js
+++ b/websites/www.chrisvogt.me/components/CareerPathVisualization.js
@@ -4,34 +4,121 @@ import * as d3 from 'd3'
 import careerData from '../src/data/career-path.json'
 import isDarkMode from 'gatsby-theme-chronogrove/src/helpers/isDarkMode'
 
+function getTruncatedCareerLabelText(text, maxLength) {
+  if (!text) return ''
+  if (text.length <= maxLength) return text
+  return `${text.substring(0, maxLength - 3)}...`
+}
+
+function getAbbreviatedCareerCompanyName(name, isSmallScreen = false) {
+  const abbreviations = {
+    'OfficeMax Print & Document Services': isSmallScreen ? 'OfficeMax' : 'OfficeMax Print & Doc',
+    "FedEx Kinko's": "FedEx Kinko's",
+    'Robert Half & TEKsystems': isSmallScreen ? 'Robert Half/TEK' : 'Robert Half & TEK',
+    'Apogee Physicians': 'Apogee',
+    'Encore Discovery Solutions': isSmallScreen ? 'Encore' : 'Encore Discovery',
+    'Pan Am Education': 'Pan Am',
+    'Salucro Healthcare Solutions': isSmallScreen ? 'Salucro' : 'Salucro Healthcare',
+    'Art In Reality, LLC': 'Art In Reality'
+  }
+  return abbreviations[name] || name
+}
+
+function resolveCareerNodeDisplayText(d, isSmallScreen) {
+  if (d.data.type === 'path') return d.data.name
+  if (d.data.name === 'GoDaddy') return d.data.name
+  const companyName = getAbbreviatedCareerCompanyName(d.data.name, isSmallScreen)
+  const title = d.data.title || d.data.name
+  const maxTitleLength = isSmallScreen ? 15 : 25
+  const truncatedTitle = getTruncatedCareerLabelText(title, maxTitleLength)
+  return companyName === title ? companyName : truncatedTitle
+}
+
+function resolveCareerNodeTextLayout(d, width, isSmallScreen) {
+  if (d.data.type === 'path') {
+    return { textX: 0, textY: isSmallScreen ? -12 : -15, textAnchor: 'middle' }
+  }
+  if (isSmallScreen) {
+    return { textX: 0, textY: d.children ? -20 : 20, textAnchor: 'middle' }
+  }
+  if (d.x < width * 0.25) {
+    return { textX: 15, textY: 0, textAnchor: 'start' }
+  }
+  if (d.x > width * 0.75) {
+    return { textX: -15, textY: 0, textAnchor: 'end' }
+  }
+  return {
+    textX: d.children ? -15 : 15,
+    textY: 0,
+    textAnchor: d.children ? 'end' : 'start'
+  }
+}
+
+function careerNodeLabelFontSizePx(d, isSmallScreen) {
+  const baseSize = isSmallScreen ? 9 : 11
+  if (d.data.type === 'path') return `${baseSize + 2}px`
+  if (d.data.name === 'GoDaddy') return `${baseSize + 1}px`
+  return `${baseSize}px`
+}
+
+function careerNodeLabelFontWeight(d) {
+  return d.data.type === 'path' || d.data.name === 'GoDaddy' ? 'bold' : 'normal'
+}
+
+function appendCareerTimelineNodeLabel(node, d, { width, isSmallScreen, darkModeActive }) {
+  if (d.data.name === 'Career Journey') return null
+
+  const displayText = resolveCareerNodeDisplayText(d, isSmallScreen)
+  const { textX, textY, textAnchor } = resolveCareerNodeTextLayout(d, width, isSmallScreen)
+
+  const textElement = node
+    .append('text')
+    .attr('x', textX)
+    .attr('y', textY)
+    .attr('dy', '0.35em')
+    .style('text-anchor', textAnchor)
+    .style('font-size', careerNodeLabelFontSizePx(d, isSmallScreen))
+    .style('font-weight', careerNodeLabelFontWeight(d))
+    .style('fill', darkModeActive ? '#e2e8f0' : '#2d3748')
+    .style('pointer-events', 'none')
+    .text(displayText)
+
+  return {
+    element: textElement,
+    node: d,
+    x: d.x + textX,
+    y: d.y + textY,
+    width: displayText.length * (isSmallScreen ? 5 : 6),
+    height: isSmallScreen ? 12 : 14
+  }
+}
+
+function adjustCareerTimelineLabelCollisions(textElements) {
+  textElements.forEach((text, i) => {
+    for (let j = i + 1; j < textElements.length; j++) {
+      const other = textElements[j]
+      const xOverlap = Math.abs(text.x - other.x) < (text.width + other.width) / 2 + 4
+      const yOverlap = Math.abs(text.y - other.y) < Math.max(text.height, other.height) + 2
+      if (!xOverlap || !yOverlap) continue
+
+      const adjustment = Math.max(text.height, other.height) + 4
+      if (other.y > text.y) {
+        other.y += adjustment
+      } else {
+        other.y -= adjustment
+      }
+      const relativeY = other.y - other.node.y
+      other.element.attr('y', relativeY)
+    }
+  })
+}
+
 const CareerPathVisualization = () => {
   const svgRef = useRef(null)
   const containerRef = useRef(null)
   const [selectedNode, setSelectedNode] = useState(null)
   const { colorMode } = useThemeUI()
   const darkModeActive = isDarkMode(colorMode)
-
-  // Helper function to truncate text based on screen size
-  const getTruncatedText = (text, maxLength) => {
-    if (!text) return ''
-    if (text.length <= maxLength) return text
-    return text.substring(0, maxLength - 3) + '...'
-  }
-
-  // Helper function to get abbreviated company names
-  const getAbbreviatedName = (name, isSmallScreen = false) => {
-    const abbreviations = {
-      'OfficeMax Print & Document Services': isSmallScreen ? 'OfficeMax' : 'OfficeMax Print & Doc',
-      "FedEx Kinko's": "FedEx Kinko's",
-      'Robert Half & TEKsystems': isSmallScreen ? 'Robert Half/TEK' : 'Robert Half & TEK',
-      'Apogee Physicians': 'Apogee',
-      'Encore Discovery Solutions': isSmallScreen ? 'Encore' : 'Encore Discovery',
-      'Pan Am Education': 'Pan Am',
-      'Salucro Healthcare Solutions': isSmallScreen ? 'Salucro' : 'Salucro Healthcare',
-      'Art In Reality, LLC': 'Art In Reality'
-    }
-    return abbreviations[name] || name
-  }
 
   const createVisualization = useCallback(() => {
     if (!svgRef.current || !containerRef.current) return
@@ -255,117 +342,14 @@ const CareerPathVisualization = () => {
     // Collect text elements for collision detection
     const textElements = []
 
-    // Add labels with improved positioning and collision detection
+    const labelContext = { width, isSmallScreen, darkModeActive }
+
     nodes.each(function (d) {
-      if (d.data.name === 'Career Journey') return
-
-      const node = d3.select(this)
-      let displayText
-
-      if (d.data.type === 'path') {
-        displayText = d.data.name
-      } else if (d.data.name === 'GoDaddy') {
-        displayText = d.data.name
-      } else {
-        // Use abbreviated names for companies and truncate titles
-        const companyName = getAbbreviatedName(d.data.name, isSmallScreen)
-        const title = d.data.title || d.data.name
-        const maxTitleLength = isSmallScreen ? 15 : 25
-        const truncatedTitle = getTruncatedText(title, maxTitleLength)
-        displayText = companyName === title ? companyName : truncatedTitle
-      }
-
-      // Smart text positioning with collision avoidance
-      let textX
-      let textY
-      let textAnchor
-
-      // Determine initial position based on node location and type
-      if (d.data.type === 'path') {
-        // Path nodes: center the text
-        textX = 0
-        textY = isSmallScreen ? -12 : -15
-        textAnchor = 'middle'
-      } else {
-        // Job nodes: position based on screen size and location
-        if (isSmallScreen) {
-          // On small screens, stack text vertically
-          textX = 0
-          textY = d.children ? -20 : 20
-          textAnchor = 'middle'
-        } else {
-          // On larger screens, use horizontal positioning
-          if (d.x < width * 0.25) {
-            textX = 15
-            textAnchor = 'start'
-          } else if (d.x > width * 0.75) {
-            textX = -15
-            textAnchor = 'end'
-          } else {
-            textX = d.children ? -15 : 15
-            textAnchor = d.children ? 'end' : 'start'
-          }
-          textY = 0
-        }
-      }
-
-      const textElement = node
-        .append('text')
-        .attr('x', textX)
-        .attr('y', textY)
-        .attr('dy', '0.35em')
-        .style('text-anchor', textAnchor)
-        .style('font-size', d => {
-          const baseSize = isSmallScreen ? 9 : 11
-          if (d.data.type === 'path') return `${baseSize + 2}px`
-          if (d.data.name === 'GoDaddy') return `${baseSize + 1}px`
-          return `${baseSize}px`
-        })
-        .style('font-weight', d => {
-          if (d.data.type === 'path' || d.data.name === 'GoDaddy') return 'bold'
-          return 'normal'
-        })
-        .style('fill', darkModeActive ? '#e2e8f0' : '#2d3748')
-        .style('pointer-events', 'none')
-        .text(displayText)
-
-      // Store text element info for collision detection
-      textElements.push({
-        element: textElement,
-        node: d,
-        x: d.x + textX,
-        y: d.y + textY,
-        width: displayText.length * (isSmallScreen ? 5 : 6), // Approximate text width
-        height: isSmallScreen ? 12 : 14
-      })
+      const meta = appendCareerTimelineNodeLabel(d3.select(this), d, labelContext)
+      if (meta) textElements.push(meta)
     })
 
-    // Improved collision detection and adjustment
-    textElements.forEach((text, i) => {
-      for (let j = i + 1; j < textElements.length; j++) {
-        const other = textElements[j]
-
-        // Check for overlap with some padding
-        const xOverlap = Math.abs(text.x - other.x) < (text.width + other.width) / 2 + 4
-        const yOverlap = Math.abs(text.y - other.y) < Math.max(text.height, other.height) + 2
-
-        if (xOverlap && yOverlap) {
-          // More intelligent adjustment based on node positions
-          const adjustment = Math.max(text.height, other.height) + 4
-
-          // Prefer vertical adjustment to maintain readability
-          if (other.y > text.y) {
-            other.y += adjustment
-          } else {
-            other.y -= adjustment
-          }
-
-          // Update the actual text element position
-          const relativeY = other.y - other.node.y
-          other.element.attr('y', relativeY)
-        }
-      }
-    })
+    adjustCareerTimelineLabelCollisions(textElements)
 
     // Add year labels with better visibility and coverage (positioned inside container)
     const years = [2003, 2007, 2011, 2015, 2019, 2023] // Key career milestone years

--- a/websites/www.chrisvogt.me/components/CareerPathVisualization.spec.js
+++ b/websites/www.chrisvogt.me/components/CareerPathVisualization.spec.js
@@ -4,31 +4,22 @@ import '@testing-library/jest-dom'
 import { ThemeUIProvider } from 'theme-ui'
 import CareerPathVisualization from './CareerPathVisualization'
 
-// Mock D3.js with more comprehensive mock
-jest.mock('d3', () => ({
-  select: jest.fn(() => ({
-    selectAll: jest.fn(() => ({
-      remove: jest.fn(),
-      data: jest.fn(() => ({
-        enter: jest.fn(() => ({
-          append: jest.fn(() => ({
-            attr: jest.fn(() => ({
-              attr: jest.fn(() => ({
-                attr: jest.fn(() => ({
-                  style: jest.fn(() => ({
-                    style: jest.fn(() => ({
-                      style: jest.fn(() => ({
-                        text: jest.fn()
-                      }))
-                    }))
-                  }))
-                }))
-              }))
-            }))
-          }))
-        }))
-      }))
-    })),
+function buildD3SelectAllDataEnterChain() {
+  let inner = { text: jest.fn() }
+  for (const key of ['style', 'style', 'style', 'attr', 'attr', 'attr']) {
+    inner = { [key]: jest.fn(() => inner) }
+  }
+  const appendChain = { append: jest.fn(() => inner) }
+  const enterChain = { enter: jest.fn(() => appendChain) }
+  return {
+    remove: jest.fn(),
+    data: jest.fn(() => enterChain)
+  }
+}
+
+function createChainableD3SelectMock() {
+  return {
+    selectAll: jest.fn(() => buildD3SelectAllDataEnterChain()),
     attr: jest.fn(function () {
       return this
     }),
@@ -38,7 +29,19 @@ jest.mock('d3', () => ({
     append: jest.fn(function () {
       return this
     })
-  })),
+  }
+}
+
+function mockD3ScaleLinear() {
+  const range = jest.fn(() => jest.fn(d => d * 100))
+  return {
+    domain: jest.fn(() => ({ range }))
+  }
+}
+
+// Mock D3.js with more comprehensive mock
+jest.mock('d3', () => ({
+  select: jest.fn(() => createChainableD3SelectMock()),
   hierarchy: jest.fn(() => ({
     descendants: jest.fn(() => [
       {
@@ -90,11 +93,7 @@ jest.mock('d3', () => ({
       return this
     })
   })),
-  scaleLinear: jest.fn(() => ({
-    domain: jest.fn(() => ({
-      range: jest.fn(() => d => d * 100) // Simple mock scale function
-    }))
-  })),
+  scaleLinear: jest.fn(() => mockD3ScaleLinear()),
   linkVertical: jest.fn(() => ({
     x: jest.fn(() => ({
       y: jest.fn()

--- a/websites/www.chrisvogt.me/package.json
+++ b/websites/www.chrisvogt.me/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "www.chrisvogt.me",
-  "version": "1.22.5",
+  "version": "1.22.6",
   "license": "GPL",
   "scripts": {
     "build": "gatsby build",


### PR DESCRIPTION
## Summary

Addresses Sonar issues around cognitive complexity, nested callbacks, and preferring `dataset` over `removeAttribute` for `data-theme-ui-color-mode` in tests.

### Theme (`gatsby-theme-chronogrove` 0.91.7)
- **Home navigation**: extracted hash-link handler and icon resolution from `HomeNavRailLink`.
- **Discogs modal**: `useDiscogsModal*` hooks; `DiscogsModalCoverSection` and `DiscogsModalTracklistSection`.
- **Vinyl collection**: `vinylBreakpointIndexForWidth`, `buildVinylCollectionPages`, `scheduleVinylGridHoverClear`.
- **AI summary**: `tryFormatAiSummaryFirestoreSeconds` in `ai-summary-synced-at.js`.
- **Tests**: `gatsby-browser.spec.js`, `root-wrapper.spec.js` use `delete document.documentElement.dataset.themeUiColorMode`.

### UI (spec only; package version unchanged)
- Color-mode and Gatsby specs use `dataset` cleanup instead of `removeAttribute`.

### `www.chrisvogt.me` (1.22.6)
- **CareerPathVisualization**: label/collision helpers at module scope; flatter D3 mocks in the spec.

### Changelog
- `CHANGELOG.md` updated for **0.91.7**.

Made with [Cursor](https://cursor.com)