### PR TITLE
feat(dx): PropTypes across theme, @chronogrove/ui, and Next example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,40 @@
 # Changelog
 
+## 0.91.8
+
+### `gatsby-theme-chronogrove` — PropTypes (Phase 1), shared nullable validators
+
+- **ESLint**: Root `eslint.config.js` enables **`react/prop-types`** (`warn`) for `packages/theme/src` (ignores `*.spec.js`, `testUtils.js`), with a **fixed React version** for ESLint (`settings.react.version`) so `react/version` detection does not warn.
+- **Components**: Broad **`propTypes`** on layout, navigation, SEO, audio player, widgets (GitHub, Spotify, Steam, Goodreads, Discogs, Flickr, Instagram, recent posts, …), shortcodes (YouTube, SoundCloud, Note, …), templates/pages, and MDX-related props—aligned with **runtime `null`** (GraphQL, Zustand, MDX/YAML) where plain `PropTypes.string` would lie.
+- **Deduping**: Theme imports **`nullableString`**, **`nullableObject`**, **`mdxMediaScalar`**, etc. from **`@chronogrove/ui/prop-types-helpers`** instead of repeating `oneOfType`/`oneOf([null])` per file.
+- **Tracking**: Contributes to [#630](https://github.com/chrisvogt/gatsby-theme-chronogrove/issues/630) (incremental TypeScript migration — Phase 1 PropTypes).
+
+### `@chronogrove/ui`
+
+- **ESLint**: **`react/prop-types`** (`warn`) for `packages/ui/src` (ignores `*.spec.js`).
+- **`prop-types`**: Declared dependency; portable components declare **`propTypes`**.
+- **`prop-types-helpers`**: New **`./prop-types-helpers`** export (`nullableString`, `nullableObject`, **`nullableCrossDomainColorMode`**, **`nullableObjectArray`**, …) used by theme and internal Next shell / **`ProfileMetricsBadge`**.
+
+### Repository (root + example)
+
+- **README**: “TypeScript roadmap” / contributor note for PropTypes on touched theme code and pointer to **`eslint.config.js`**.
+- **`examples/chronogrove-next`**: **`prop-types`** dependency and **`propTypes`** on local App Router components (`layout`, `providers`, `home-showcase`).
+
+### Versions
+
+- **`gatsby-theme-chronogrove` 0.91.8**; **`@chronogrove/ui` 0.85.5**; **`www.chrisvogt.me` 1.22.7**; **`www.chronogrove.com` 1.9.6**.
+
+### Files changed (high level)
+
+- `CHANGELOG.md`
+- `eslint.config.js`, `README.md`, `package.json`, `pnpm-lock.yaml`
+- `examples/chronogrove-next/package.json`, `examples/chronogrove-next/app/*.jsx`
+- `packages/theme/package.json` (version **0.91.8**) and broad `packages/theme/src/**/*.js` PropTypes + `@chronogrove/ui/prop-types-helpers` imports
+- `packages/ui/package.json` (version **0.85.5**), `packages/ui/src/prop-types-helpers.js`, `packages/ui/src/**/*.js`
+- `websites/www.chrisvogt.me/package.json` (version **1.22.7**), `websites/www.chronogrove.com/package.json` (version **1.9.6**)
+
+---
+
 ## 0.91.7
 
 ### `gatsby-theme-chronogrove` — Sonar maintainability (complexity, tests)

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@
 
 A modern Gatsby theme for personal websites and blogs with social media integration. It powers [www.chrisvogt.me](https://www.chrisvogt.me) and includes a demo site, reusable theme package, and content examples.
 
+> **TypeScript roadmap:** The monorepo is heading toward **incremental TypeScript adoption** (a full package rewrite in one step has been painful here, so we are not doing that again in one leap). Until files are ported, please **add or update [`prop-types`](https://github.com/facebook/prop-types)** on React components you **create** or **meaningfully change**—especially under **`packages/theme/src`**, where `react/prop-types` is enabled (see root **`eslint.config.js`**). Documenting props now makes it much easier to replace `propTypes` with TypeScript types **file by file** later.
+
 ## 🚀 Features
 
 - **Social Dashboard Homepage**: Display recent activity from multiple social platforms

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -108,10 +108,24 @@ module.exports = [
       }
     }
   },
-  /** PropTypes in theme `src/` only (avoids mocks, Gatsby root, tests; `react/prop-types` breaks on ESLint 10 + current plugin). */
+  /** PropTypes in theme `src/` (avoids mocks, tests). */
   {
     files: ['packages/theme/src/**/*.js'],
     ignores: ['packages/theme/src/**/*.spec.js', 'packages/theme/src/testUtils.js'],
+    plugins: { react },
+    rules: {
+      'react/prop-types': 'warn'
+    },
+    settings: {
+      react: {
+        version: REACT_VERSION_FOR_ESLINT
+      }
+    }
+  },
+  /** PropTypes in @chronogrove/ui `src/` (portable components; same incremental typing story as the theme). */
+  {
+    files: ['packages/ui/src/**/*.js'],
+    ignores: ['packages/ui/src/**/*.spec.js'],
     plugins: { react },
     rules: {
       'react/prop-types': 'warn'

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -6,6 +6,9 @@ const globals = require('globals')
 
 const browserGlobals = Object.fromEntries(Object.entries(globals.browser).filter(([key]) => key.trim() === key))
 
+/** Monorepo root has no `react` dependency, so `detect` prints a warning; align with `pnpm-workspace.yaml` catalog. */
+const REACT_VERSION_FOR_ESLINT = '19.2'
+
 module.exports = [
   {
     ignores: [
@@ -92,7 +95,7 @@ module.exports = [
     },
     settings: {
       react: {
-        version: 'detect'
+        version: REACT_VERSION_FOR_ESLINT
       }
     },
     languageOptions: {
@@ -102,6 +105,20 @@ module.exports = [
         ecmaFeatures: {
           jsx: true
         }
+      }
+    }
+  },
+  /** PropTypes in theme `src/` only (avoids mocks, Gatsby root, tests; `react/prop-types` breaks on ESLint 10 + current plugin). */
+  {
+    files: ['packages/theme/src/**/*.js'],
+    ignores: ['packages/theme/src/**/*.spec.js', 'packages/theme/src/testUtils.js'],
+    plugins: { react },
+    rules: {
+      'react/prop-types': 'warn'
+    },
+    settings: {
+      react: {
+        version: REACT_VERSION_FOR_ESLINT
       }
     }
   },

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -136,6 +136,19 @@ module.exports = [
       }
     }
   },
+  /** PropTypes in Chronogrove Next.js reference app (`examples/chronogrove-next/app`, `.jsx`). */
+  {
+    files: ['examples/chronogrove-next/app/**/*.jsx'],
+    plugins: { react },
+    rules: {
+      'react/prop-types': 'warn'
+    },
+    settings: {
+      react: {
+        version: REACT_VERSION_FOR_ESLINT
+      }
+    }
+  },
   {
     plugins: {
       json: require('eslint-plugin-json')

--- a/examples/chronogrove-next/app/home-showcase.jsx
+++ b/examples/chronogrove-next/app/home-showcase.jsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState } from 'react'
+import PropTypes from 'prop-types'
 import { Box, Card, Container, Flex, Grid, Heading, Text, Badge, Link } from '@theme-ui/components'
 import { useColorMode } from 'theme-ui'
 import { TextBlock, RectShape } from 'react-placeholder/lib/placeholders'
@@ -156,6 +157,13 @@ function Section({ id, title, description, children }) {
   )
 }
 
+Section.propTypes = {
+  id: PropTypes.string.isRequired,
+  title: PropTypes.string.isRequired,
+  description: PropTypes.string,
+  children: PropTypes.node.isRequired
+}
+
 function DemoPreview({ title: previewTitle = 'Preview', children }) {
   return (
     <Box sx={previewShellSx}>
@@ -167,6 +175,11 @@ function DemoPreview({ title: previewTitle = 'Preview', children }) {
   )
 }
 
+DemoPreview.propTypes = {
+  title: PropTypes.string,
+  children: PropTypes.node.isRequired
+}
+
 function DemoBlock({ label, children }) {
   return (
     <Box sx={{ p: [2, 3] }}>
@@ -174,6 +187,11 @@ function DemoBlock({ label, children }) {
       {children}
     </Box>
   )
+}
+
+DemoBlock.propTypes = {
+  label: PropTypes.node,
+  children: PropTypes.node.isRequired
 }
 
 function LazyPlaceholder() {

--- a/examples/chronogrove-next/app/layout.jsx
+++ b/examples/chronogrove-next/app/layout.jsx
@@ -1,5 +1,6 @@
 import './globals.css'
 
+import PropTypes from 'prop-types'
 import { ChronogroveNextEmotionRegistry, ChronogroveNextRootLayoutHead } from '@chronogrove/ui/next'
 
 import Providers from './providers'
@@ -22,4 +23,8 @@ export default function RootLayout({ children }) {
       </body>
     </html>
   )
+}
+
+RootLayout.propTypes = {
+  children: PropTypes.node.isRequired
 }

--- a/examples/chronogrove-next/app/providers.jsx
+++ b/examples/chronogrove-next/app/providers.jsx
@@ -1,7 +1,12 @@
 'use client'
 
+import PropTypes from 'prop-types'
 import { ChronogroveNextAppShell } from '@chronogrove/ui/next'
 
 export default function Providers({ children }) {
   return <ChronogroveNextAppShell>{children}</ChronogroveNextAppShell>
+}
+
+Providers.propTypes = {
+  children: PropTypes.node.isRequired
 }

--- a/examples/chronogrove-next/package.json
+++ b/examples/chronogrove-next/package.json
@@ -17,6 +17,7 @@
     "react": "catalog:",
     "react-dom": "catalog:",
     "react-placeholder": "^4.1.0",
+    "prop-types": "catalog:",
     "theme-ui": "catalog:"
   }
 }

--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
     "build": "turbo run build"
   },
   "devDependencies": {
-    "@eslint/js": "^10.0.1",
-    "eslint": "^10.3.0",
+    "@eslint/js": "^9.39.4",
+    "eslint": "^9.39.4",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-jest": "^29.15.2",
     "eslint-plugin-json": "^4.0.1",

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-theme-chronogrove",
   "description": "A personal website and digital garden theme for GatsbyJS.",
-  "version": "0.91.7",
+  "version": "0.91.8",
   "author": "Chris Vogt <mail@chrisvogt.me> (https://www.chrisvogt.me)",
   "main": "index.js",
   "license": "MIT",

--- a/packages/theme/src/components/artwork/book-3d.js
+++ b/packages/theme/src/components/artwork/book-3d.js
@@ -2,6 +2,7 @@
 import { jsx, Box } from 'theme-ui'
 import { useEffect, useRef } from 'react'
 import PropTypes from 'prop-types'
+import { nullableString } from '@chronogrove/ui/prop-types-helpers'
 import * as THREE from 'three'
 
 const BOOK_W = 0.65
@@ -528,8 +529,6 @@ const Book3D = ({ thumbnailURL, title, introDelay = 0 }) => {
     </Box>
   )
 }
-
-const nullableString = PropTypes.oneOfType([PropTypes.string, PropTypes.oneOf([null])])
 
 Book3D.propTypes = {
   thumbnailURL: nullableString,

--- a/packages/theme/src/components/artwork/book-3d.js
+++ b/packages/theme/src/components/artwork/book-3d.js
@@ -1,6 +1,7 @@
 /** @jsx jsx */
 import { jsx, Box } from 'theme-ui'
 import { useEffect, useRef } from 'react'
+import PropTypes from 'prop-types'
 import * as THREE from 'three'
 
 const BOOK_W = 0.65
@@ -526,6 +527,14 @@ const Book3D = ({ thumbnailURL, title, introDelay = 0 }) => {
       />
     </Box>
   )
+}
+
+const nullableString = PropTypes.oneOfType([PropTypes.string, PropTypes.oneOf([null])])
+
+Book3D.propTypes = {
+  thumbnailURL: nullableString,
+  title: PropTypes.string.isRequired,
+  introDelay: PropTypes.number
 }
 
 export default Book3D

--- a/packages/theme/src/components/artwork/book.js
+++ b/packages/theme/src/components/artwork/book.js
@@ -1,6 +1,7 @@
 /** @jsx jsx */
 import { jsx } from 'theme-ui'
 import { useId } from 'react'
+import PropTypes from 'prop-types'
 
 const Book = ({ thumbnailURL, title }) => {
   const uniqueId = useId()
@@ -47,6 +48,11 @@ const Book = ({ thumbnailURL, title }) => {
       </g>
     </svg>
   )
+}
+
+Book.propTypes = {
+  thumbnailURL: PropTypes.string,
+  title: PropTypes.string.isRequired
 }
 
 export default Book

--- a/packages/theme/src/components/audio-player.js
+++ b/packages/theme/src/components/audio-player.js
@@ -154,12 +154,18 @@ const AudioPlayer = ({ soundcloudId, spotifyURL, isVisible, provider, colorMode:
   )
 }
 
+/** Optional string props that may be `null` at runtime (e.g. zustand initial state). */
+const nullishString = PropTypes.oneOfType([PropTypes.string, PropTypes.oneOf([null])])
+
+/** `useAudioPlayerStore` uses `null` when idle (see `initialAudioPlayerState`). */
+const audioProvider = PropTypes.oneOfType([PropTypes.oneOf(['soundcloud', 'spotify']), PropTypes.oneOf([null])])
+
 AudioPlayer.propTypes = {
-  soundcloudId: PropTypes.string,
-  spotifyURL: PropTypes.string,
+  soundcloudId: nullishString,
+  spotifyURL: nullishString,
   isVisible: PropTypes.bool,
-  provider: PropTypes.string,
-  colorMode: PropTypes.string
+  provider: audioProvider,
+  colorMode: nullishString
 }
 
 export default AudioPlayer

--- a/packages/theme/src/components/audio-player.js
+++ b/packages/theme/src/components/audio-player.js
@@ -2,6 +2,7 @@
 import { jsx, useColorMode, useThemeUI } from 'theme-ui'
 import { useEffect, useRef } from 'react'
 import PropTypes from 'prop-types'
+import { nullableString } from '@chronogrove/ui/prop-types-helpers'
 import { createPortal } from 'react-dom'
 import { useAudioPlayerStore } from '../stores/audio-player-store'
 import SoundCloud from '../shortcodes/soundcloud'
@@ -154,18 +155,15 @@ const AudioPlayer = ({ soundcloudId, spotifyURL, isVisible, provider, colorMode:
   )
 }
 
-/** Optional string props that may be `null` at runtime (e.g. zustand initial state). */
-const nullishString = PropTypes.oneOfType([PropTypes.string, PropTypes.oneOf([null])])
-
 /** `useAudioPlayerStore` uses `null` when idle (see `initialAudioPlayerState`). */
 const audioProvider = PropTypes.oneOfType([PropTypes.oneOf(['soundcloud', 'spotify']), PropTypes.oneOf([null])])
 
 AudioPlayer.propTypes = {
-  soundcloudId: nullishString,
-  spotifyURL: nullishString,
+  soundcloudId: nullableString,
+  spotifyURL: nullableString,
   isVisible: PropTypes.bool,
   provider: audioProvider,
-  colorMode: nullishString
+  colorMode: nullableString
 }
 
 export default AudioPlayer

--- a/packages/theme/src/components/audio-player.js
+++ b/packages/theme/src/components/audio-player.js
@@ -1,6 +1,7 @@
 /** @jsx jsx */
 import { jsx, useColorMode, useThemeUI } from 'theme-ui'
 import { useEffect, useRef } from 'react'
+import PropTypes from 'prop-types'
 import { createPortal } from 'react-dom'
 import { useAudioPlayerStore } from '../stores/audio-player-store'
 import SoundCloud from '../shortcodes/soundcloud'
@@ -151,6 +152,14 @@ const AudioPlayer = ({ soundcloudId, spotifyURL, isVisible, provider, colorMode:
     </div>,
     containerRef.current
   )
+}
+
+AudioPlayer.propTypes = {
+  soundcloudId: PropTypes.string,
+  spotifyURL: PropTypes.string,
+  isVisible: PropTypes.bool,
+  provider: PropTypes.string,
+  colorMode: PropTypes.string
 }
 
 export default AudioPlayer

--- a/packages/theme/src/components/blog/post-timeline-index.js
+++ b/packages/theme/src/components/blog/post-timeline-index.js
@@ -1,6 +1,7 @@
 /** @jsx jsx */
 /* global Image, IntersectionObserver */
 import React, { Fragment, useEffect, useMemo, useRef, useState } from 'react'
+import PropTypes from 'prop-types'
 import { jsx, Box } from 'theme-ui'
 import { Link } from 'gatsby'
 
@@ -893,4 +894,98 @@ export default function PostTimelineIndex({
       ) : null}
     </Fragment>
   )
+}
+
+TimelineEmbedAside.propTypes = {
+  soundcloudId: PropTypes.string,
+  sx: PropTypes.object,
+  title: PropTypes.string,
+  youtubeSrc: PropTypes.string
+}
+
+Thumb.propTypes = {
+  sizePx: PropTypes.number.isRequired,
+  sx: PropTypes.object,
+  url: PropTypes.string
+}
+
+FeaturedHeroCarousel.propTypes = {
+  slideKeys: PropTypes.arrayOf(PropTypes.string).isRequired,
+  title: PropTypes.string.isRequired,
+  tid: PropTypes.func.isRequired,
+  featuredImageAltFallback: PropTypes.string.isRequired
+}
+
+MetaFeatured.propTypes = {
+  category: PropTypes.string,
+  date: PropTypes.string
+}
+
+Featured.propTypes = {
+  featuredImageAltFallback: PropTypes.string.isRequired,
+  post: PropTypes.object.isRequired,
+  readMoreAriaFallback: PropTypes.string.isRequired,
+  showBottomSeparator: PropTypes.bool,
+  tid: PropTypes.func.isRequired,
+  timelineAsideMedia: PropTypes.bool
+}
+
+TimelineReadMoreLink.propTypes = {
+  emphasis: PropTypes.bool,
+  href: PropTypes.string.isRequired,
+  readMoreAriaFallback: PropTypes.string.isRequired,
+  tid: PropTypes.func.isRequired,
+  title: PropTypes.string,
+  variant: PropTypes.oneOf(['timeline', 'featured'])
+}
+
+StampDenseMeta.propTypes = {
+  category: PropTypes.string,
+  date: PropTypes.string
+}
+
+TimelineStampLeadMedia.propTypes = {
+  timelineAsideMedia: PropTypes.bool.isRequired,
+  tid: PropTypes.func.isRequired,
+  soundcloudId: PropTypes.string,
+  title: PropTypes.string,
+  youtubeSrc: PropTypes.string,
+  href: PropTypes.string.isRequired,
+  thumbUrl: PropTypes.string
+}
+
+TimelineStampArticleColumn.propTypes = {
+  category: PropTypes.string,
+  date: PropTypes.string,
+  emphasis: PropTypes.bool.isRequired,
+  excerpt: PropTypes.string,
+  href: PropTypes.string.isRequired,
+  readMoreAriaFallback: PropTypes.string.isRequired,
+  tid: PropTypes.func.isRequired,
+  title: PropTypes.string.isRequired,
+  titleFont: PropTypes.array
+}
+
+TimelineStamp.propTypes = {
+  category: PropTypes.string,
+  date: PropTypes.string,
+  emphasis: PropTypes.bool.isRequired,
+  excerpt: PropTypes.string,
+  href: PropTypes.string.isRequired,
+  readMoreAriaFallback: PropTypes.string.isRequired,
+  soundcloudId: PropTypes.string,
+  thumbUrl: PropTypes.string,
+  tid: PropTypes.func.isRequired,
+  timelineAsideMedia: PropTypes.bool,
+  title: PropTypes.string.isRequired,
+  youtubeSrc: PropTypes.string
+}
+
+PostTimelineIndex.propTypes = {
+  posts: PropTypes.arrayOf(PropTypes.object).isRequired,
+  dataTestIdPrefix: PropTypes.string,
+  featuredImageAltFallback: PropTypes.string,
+  readMoreAriaFallback: PropTypes.string,
+  timelineAsideMedia: PropTypes.bool,
+  afterFeatured: PropTypes.node
 }

--- a/packages/theme/src/components/blog/post-timeline-index.js
+++ b/packages/theme/src/components/blog/post-timeline-index.js
@@ -2,6 +2,7 @@
 /* global Image, IntersectionObserver */
 import React, { Fragment, useEffect, useMemo, useRef, useState } from 'react'
 import PropTypes from 'prop-types'
+import { mdxMediaScalar, nullableString } from '@chronogrove/ui/prop-types-helpers'
 import { jsx, Box } from 'theme-ui'
 import { Link } from 'gatsby'
 
@@ -895,11 +896,6 @@ export default function PostTimelineIndex({
     </Fragment>
   )
 }
-
-/** Optional `PropTypes.string` rejects `null`; timeline passes explicit `null` from GraphQL coercions. */
-const nullableString = PropTypes.oneOfType([PropTypes.string, PropTypes.oneOf([null])])
-/** MDX / frontmatter media fields may be string, number, or null (YAML looseness). */
-const mdxMediaScalar = PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.oneOf([null])])
 
 TimelineEmbedAside.propTypes = {
   soundcloudId: mdxMediaScalar,

--- a/packages/theme/src/components/blog/post-timeline-index.js
+++ b/packages/theme/src/components/blog/post-timeline-index.js
@@ -896,11 +896,16 @@ export default function PostTimelineIndex({
   )
 }
 
+/** Optional `PropTypes.string` rejects `null`; timeline passes explicit `null` from GraphQL coercions. */
+const nullableString = PropTypes.oneOfType([PropTypes.string, PropTypes.oneOf([null])])
+/** MDX / frontmatter media fields may be string, number, or null (YAML looseness). */
+const mdxMediaScalar = PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.oneOf([null])])
+
 TimelineEmbedAside.propTypes = {
-  soundcloudId: PropTypes.string,
+  soundcloudId: mdxMediaScalar,
   sx: PropTypes.object,
-  title: PropTypes.string,
-  youtubeSrc: PropTypes.string
+  title: mdxMediaScalar,
+  youtubeSrc: mdxMediaScalar
 }
 
 Thumb.propTypes = {
@@ -917,8 +922,8 @@ FeaturedHeroCarousel.propTypes = {
 }
 
 MetaFeatured.propTypes = {
-  category: PropTypes.string,
-  date: PropTypes.string
+  category: nullableString,
+  date: nullableString
 }
 
 Featured.propTypes = {
@@ -935,30 +940,30 @@ TimelineReadMoreLink.propTypes = {
   href: PropTypes.string.isRequired,
   readMoreAriaFallback: PropTypes.string.isRequired,
   tid: PropTypes.func.isRequired,
-  title: PropTypes.string,
+  title: nullableString,
   variant: PropTypes.oneOf(['timeline', 'featured'])
 }
 
 StampDenseMeta.propTypes = {
-  category: PropTypes.string,
-  date: PropTypes.string
+  category: nullableString,
+  date: nullableString
 }
 
 TimelineStampLeadMedia.propTypes = {
   timelineAsideMedia: PropTypes.bool.isRequired,
   tid: PropTypes.func.isRequired,
-  soundcloudId: PropTypes.string,
-  title: PropTypes.string,
-  youtubeSrc: PropTypes.string,
+  soundcloudId: mdxMediaScalar,
+  title: mdxMediaScalar,
+  youtubeSrc: mdxMediaScalar,
   href: PropTypes.string.isRequired,
   thumbUrl: PropTypes.string
 }
 
 TimelineStampArticleColumn.propTypes = {
-  category: PropTypes.string,
-  date: PropTypes.string,
+  category: nullableString,
+  date: nullableString,
   emphasis: PropTypes.bool.isRequired,
-  excerpt: PropTypes.string,
+  excerpt: nullableString,
   href: PropTypes.string.isRequired,
   readMoreAriaFallback: PropTypes.string.isRequired,
   tid: PropTypes.func.isRequired,
@@ -967,18 +972,18 @@ TimelineStampArticleColumn.propTypes = {
 }
 
 TimelineStamp.propTypes = {
-  category: PropTypes.string,
-  date: PropTypes.string,
+  category: nullableString,
+  date: nullableString,
   emphasis: PropTypes.bool.isRequired,
-  excerpt: PropTypes.string,
+  excerpt: nullableString,
   href: PropTypes.string.isRequired,
   readMoreAriaFallback: PropTypes.string.isRequired,
-  soundcloudId: PropTypes.string,
+  soundcloudId: mdxMediaScalar,
   thumbUrl: PropTypes.string,
   tid: PropTypes.func.isRequired,
   timelineAsideMedia: PropTypes.bool,
   title: PropTypes.string.isRequired,
-  youtubeSrc: PropTypes.string
+  youtubeSrc: mdxMediaScalar
 }
 
 PostTimelineIndex.propTypes = {

--- a/packages/theme/src/components/category.js
+++ b/packages/theme/src/components/category.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 
 import CategoryLabel from '@chronogrove/ui/category-label'
 import { getCategoryDisplayName } from '../helpers/categoryHelpers'
@@ -11,6 +12,11 @@ const Category = ({ sx = {}, type, ...props }) => {
       {category}
     </CategoryLabel>
   )
+}
+
+Category.propTypes = {
+  sx: PropTypes.object,
+  type: PropTypes.string
 }
 
 export default Category

--- a/packages/theme/src/components/home-navigation.js
+++ b/packages/theme/src/components/home-navigation.js
@@ -1,6 +1,7 @@
 /** @jsx jsx */
 import { jsx, useColorMode, useThemeUI } from 'theme-ui'
 import { useMemo, useState, useEffect } from 'react'
+import PropTypes from 'prop-types'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { scrollToElementWhenReady } from '../helpers/scroll-to-element-when-ready'
 import useNavigationData from '../hooks/use-navigation-data'
@@ -370,6 +371,31 @@ const HomeNavigation = props => {
       </nav>
     </div>
   )
+}
+
+const homeNavRailIconPropType = PropTypes.shape({
+  reactIcon: PropTypes.string
+})
+
+HomeNavRailLink.propTypes = {
+  activeIconColor: PropTypes.string.isRequired,
+  activeSection: PropTypes.string.isRequired,
+  badgeIdleBg: PropTypes.string.isRequired,
+  badgeIdleBorder: PropTypes.string.isRequired,
+  badgeIdleIcon: PropTypes.string.isRequired,
+  href: PropTypes.string.isRequired,
+  icon: homeNavRailIconPropType,
+  id: PropTypes.string.isRequired,
+  index: PropTypes.number.isRequired,
+  labelActiveColor: PropTypes.string.isRequired,
+  labelColor: PropTypes.string.isRequired,
+  primaryColor: PropTypes.string.isRequired,
+  primaryRgb: PropTypes.string.isRequired,
+  text: PropTypes.string.isRequired
+}
+
+HomeNavigation.propTypes = {
+  scrollSyncDisabled: PropTypes.bool
 }
 
 export { HomeNavigation }

--- a/packages/theme/src/components/layout.js
+++ b/packages/theme/src/components/layout.js
@@ -3,6 +3,7 @@ import { jsx } from 'theme-ui'
 import { ChronogrovePageShell } from '@chronogrove/ui/page-shell-layout'
 import { useAudioPlayerStore } from '../stores/audio-player-store'
 import React from 'react'
+import PropTypes from 'prop-types'
 
 import Footer from './footer'
 import TopNavigation from './top-navigation'
@@ -30,6 +31,14 @@ const Layout = ({ children, disableMainWrapper, hideHeader, hideFooter, transpar
       {children}
     </ChronogrovePageShell>
   )
+}
+
+Layout.propTypes = {
+  children: PropTypes.node,
+  disableMainWrapper: PropTypes.bool,
+  hideFooter: PropTypes.bool,
+  hideHeader: PropTypes.bool,
+  transparentBackground: PropTypes.bool
 }
 
 export default Layout

--- a/packages/theme/src/components/root-wrapper.js
+++ b/packages/theme/src/components/root-wrapper.js
@@ -1,5 +1,6 @@
 /** @jsx jsx */
 import React, { useEffect } from 'react'
+import PropTypes from 'prop-types'
 import { jsx, useColorMode, useThemeUI } from 'theme-ui'
 import { useShallow } from 'zustand/react/shallow'
 
@@ -71,6 +72,10 @@ const RootWrapper = ({ children }) => {
       />
     </>
   )
+}
+
+RootWrapper.propTypes = {
+  children: PropTypes.node
 }
 
 export default RootWrapper

--- a/packages/theme/src/components/scroll-to-hash-when-ready.js
+++ b/packages/theme/src/components/scroll-to-hash-when-ready.js
@@ -8,6 +8,7 @@
  * to it when it appears.
  */
 import { useEffect } from 'react'
+import PropTypes from 'prop-types'
 import { useLocation } from '@gatsbyjs/reach-router'
 import { scrollToElementWhenReady } from '../helpers/scroll-to-element-when-ready'
 
@@ -24,4 +25,8 @@ export default function ScrollToHashWhenReady({ getHash } = {}) {
   }, [location.pathname, location.hash, getHash])
 
   return null
+}
+
+ScrollToHashWhenReady.propTypes = {
+  getHash: PropTypes.func
 }

--- a/packages/theme/src/components/seo.js
+++ b/packages/theme/src/components/seo.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import { useThemeUI } from 'theme-ui'
 
 import useSiteMetadata from '../hooks/use-site-metadata'
@@ -45,6 +46,16 @@ const Seo = ({ article, canonicalPath, children, description, image: imageURL, k
       {children}
     </>
   )
+}
+
+Seo.propTypes = {
+  article: PropTypes.bool,
+  canonicalPath: PropTypes.string,
+  children: PropTypes.node,
+  description: PropTypes.string,
+  image: PropTypes.string,
+  keywords: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.string), PropTypes.string]),
+  title: PropTypes.string
 }
 
 export default Seo

--- a/packages/theme/src/components/widgets/call-to-action.js
+++ b/packages/theme/src/components/widgets/call-to-action.js
@@ -1,8 +1,20 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import { Link } from 'gatsby'
 
 import { WidgetCallToAction } from '@chronogrove/ui/widget-call-to-action'
 
 const CallToAction = props => <WidgetCallToAction linkComponent={Link} {...props} />
+
+CallToAction.propTypes = {
+  children: PropTypes.node,
+  isLoading: PropTypes.bool,
+  loadingSlot: PropTypes.node,
+  title: PropTypes.string,
+  to: PropTypes.string,
+  url: PropTypes.string,
+  href: PropTypes.string,
+  sx: PropTypes.object
+}
 
 export default CallToAction

--- a/packages/theme/src/components/widgets/discogs/discogs-modal.js
+++ b/packages/theme/src/components/widgets/discogs/discogs-modal.js
@@ -2,6 +2,7 @@
 import { jsx, useThemeUI } from 'theme-ui'
 import { createPortal } from 'react-dom'
 import { Fragment, useEffect, useRef, useState } from 'react'
+import PropTypes from 'prop-types'
 import { Themed } from '@theme-ui/mdx'
 import { faTimes, faExternalLinkAlt } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
@@ -236,6 +237,26 @@ function DiscogsModalTracklistSection({
       </div>
     </div>
   )
+}
+
+const nullableString = PropTypes.oneOfType([PropTypes.string, PropTypes.oneOf([null])])
+
+DiscogsModalCoverSection.propTypes = {
+  coverImageUrl: nullableString,
+  title: nullableString,
+  darkMode: PropTypes.bool.isRequired,
+  imageLoaded: PropTypes.bool.isRequired,
+  setImageLoaded: PropTypes.func.isRequired,
+  insetSurface: PropTypes.string.isRequired
+}
+
+DiscogsModalTracklistSection.propTypes = {
+  tracklist: PropTypes.arrayOf(PropTypes.object),
+  darkMode: PropTypes.bool.isRequired,
+  listPanelBorder: PropTypes.string.isRequired,
+  insetSurface: PropTypes.string.isRequired,
+  insetHeaderBg: PropTypes.string.isRequired,
+  insetRule: PropTypes.string.isRequired
 }
 
 const DiscogsModal = ({ isOpen, onClose, release, orderedReleases, onSelectRelease }) => {
@@ -590,6 +611,14 @@ const DiscogsModal = ({ isOpen, onClose, release, orderedReleases, onSelectRelea
     </div>,
     document.body
   )
+}
+
+DiscogsModal.propTypes = {
+  isOpen: PropTypes.bool.isRequired,
+  onClose: PropTypes.func.isRequired,
+  release: PropTypes.object,
+  orderedReleases: PropTypes.arrayOf(PropTypes.object).isRequired,
+  onSelectRelease: PropTypes.func.isRequired
 }
 
 export default DiscogsModal

--- a/packages/theme/src/components/widgets/discogs/discogs-modal.js
+++ b/packages/theme/src/components/widgets/discogs/discogs-modal.js
@@ -240,6 +240,7 @@ function DiscogsModalTracklistSection({
 }
 
 const nullableString = PropTypes.oneOfType([PropTypes.string, PropTypes.oneOf([null])])
+const nullableObject = PropTypes.oneOfType([PropTypes.object, PropTypes.oneOf([null])])
 
 DiscogsModalCoverSection.propTypes = {
   coverImageUrl: nullableString,
@@ -616,7 +617,7 @@ const DiscogsModal = ({ isOpen, onClose, release, orderedReleases, onSelectRelea
 DiscogsModal.propTypes = {
   isOpen: PropTypes.bool.isRequired,
   onClose: PropTypes.func.isRequired,
-  release: PropTypes.object,
+  release: nullableObject,
   orderedReleases: PropTypes.arrayOf(PropTypes.object).isRequired,
   onSelectRelease: PropTypes.func.isRequired
 }

--- a/packages/theme/src/components/widgets/discogs/discogs-modal.js
+++ b/packages/theme/src/components/widgets/discogs/discogs-modal.js
@@ -3,6 +3,7 @@ import { jsx, useThemeUI } from 'theme-ui'
 import { createPortal } from 'react-dom'
 import { Fragment, useEffect, useRef, useState } from 'react'
 import PropTypes from 'prop-types'
+import { nullableObject, nullableString } from '@chronogrove/ui/prop-types-helpers'
 import { Themed } from '@theme-ui/mdx'
 import { faTimes, faExternalLinkAlt } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
@@ -238,9 +239,6 @@ function DiscogsModalTracklistSection({
     </div>
   )
 }
-
-const nullableString = PropTypes.oneOfType([PropTypes.string, PropTypes.oneOf([null])])
-const nullableObject = PropTypes.oneOfType([PropTypes.object, PropTypes.oneOf([null])])
 
 DiscogsModalCoverSection.propTypes = {
   coverImageUrl: nullableString,

--- a/packages/theme/src/components/widgets/discogs/vinyl-collection.js
+++ b/packages/theme/src/components/widgets/discogs/vinyl-collection.js
@@ -3,6 +3,7 @@ import { jsx, useThemeUI } from 'theme-ui'
 import { Box, Card, Heading, Select } from '@theme-ui/components'
 import { Themed } from '@theme-ui/mdx'
 import { useState, useRef, useEffect, useMemo } from 'react'
+import PropTypes from 'prop-types'
 import isDarkMode from '../../../helpers/isDarkMode'
 import Pagination from '../../pagination'
 import useSwipePagination from '../../../hooks/use-swipe-pagination'
@@ -1052,6 +1053,11 @@ const VinylCollection = ({ isLoading, releases = [] }) => {
       />
     </div>
   )
+}
+
+VinylCollection.propTypes = {
+  isLoading: PropTypes.bool.isRequired,
+  releases: PropTypes.arrayOf(PropTypes.object)
 }
 
 export default VinylCollection

--- a/packages/theme/src/components/widgets/discogs/vinyl-pagination.js
+++ b/packages/theme/src/components/widgets/discogs/vinyl-pagination.js
@@ -1,5 +1,6 @@
 /** @jsx jsx */
 import { jsx } from 'theme-ui'
+import PropTypes from 'prop-types'
 import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 
@@ -202,6 +203,12 @@ const VinylPagination = ({ currentPage, totalPages, onPageChange }) => {
       )}
     </div>
   )
+}
+
+VinylPagination.propTypes = {
+  currentPage: PropTypes.number.isRequired,
+  totalPages: PropTypes.number.isRequired,
+  onPageChange: PropTypes.func.isRequired
 }
 
 export default VinylPagination

--- a/packages/theme/src/components/widgets/discogs/vinyl-record-skeleton.js
+++ b/packages/theme/src/components/widgets/discogs/vinyl-record-skeleton.js
@@ -1,5 +1,6 @@
 /** @jsx jsx */
 import { jsx } from 'theme-ui'
+import PropTypes from 'prop-types'
 import { Card } from '@theme-ui/components'
 
 import 'react-placeholder/lib/reactPlaceholder.css'
@@ -185,6 +186,11 @@ const VinylRecordSkeleton = ({ darkModeActive, variant = 'grid' }) => {
       </div>
     </Card>
   )
+}
+
+VinylRecordSkeleton.propTypes = {
+  darkModeActive: PropTypes.bool.isRequired,
+  variant: PropTypes.oneOf(['grid', 'list'])
 }
 
 export default VinylRecordSkeleton

--- a/packages/theme/src/components/widgets/flickr/flickr-widget-item.js
+++ b/packages/theme/src/components/widgets/flickr/flickr-widget-item.js
@@ -1,5 +1,6 @@
 /** @jsx jsx */
 import { jsx } from 'theme-ui'
+import PropTypes from 'prop-types'
 import { Box } from '@theme-ui/components'
 
 const FlickrWidgetItem = ({ photo = {}, handleClick = () => {}, index }) => {
@@ -33,6 +34,12 @@ const FlickrWidgetItem = ({ photo = {}, handleClick = () => {}, index }) => {
       />
     </Box>
   )
+}
+
+FlickrWidgetItem.propTypes = {
+  photo: PropTypes.object,
+  handleClick: PropTypes.func,
+  index: PropTypes.number.isRequired
 }
 
 export default FlickrWidgetItem

--- a/packages/theme/src/components/widgets/github/contribution-graph.js
+++ b/packages/theme/src/components/widgets/github/contribution-graph.js
@@ -557,9 +557,11 @@ const ContributionGraph = ({ isLoading, contributionCalendar }) => {
   )
 }
 
+const nullableObject = PropTypes.oneOfType([PropTypes.object, PropTypes.oneOf([null])])
+
 ContributionGraph.propTypes = {
   isLoading: PropTypes.bool.isRequired,
-  contributionCalendar: PropTypes.object
+  contributionCalendar: nullableObject
 }
 
 // Wrap with React.memo to prevent unnecessary re-renders

--- a/packages/theme/src/components/widgets/github/contribution-graph.js
+++ b/packages/theme/src/components/widgets/github/contribution-graph.js
@@ -3,6 +3,7 @@ import { jsx, useThemeUI } from 'theme-ui'
 import { Themed } from '@theme-ui/mdx'
 import { Box, Card, Heading } from '@theme-ui/components'
 import React, { useMemo, useRef, useEffect, useState } from 'react'
+import PropTypes from 'prop-types'
 import { createPortal } from 'react-dom'
 import isDarkMode from '../../../helpers/isDarkMode'
 
@@ -556,10 +557,19 @@ const ContributionGraph = ({ isLoading, contributionCalendar }) => {
   )
 }
 
+ContributionGraph.propTypes = {
+  isLoading: PropTypes.bool.isRequired,
+  contributionCalendar: PropTypes.object
+}
+
 // Wrap with React.memo to prevent unnecessary re-renders
 // Only re-render if isLoading or contributionCalendar changes
-export default React.memo(ContributionGraph, (prevProps, nextProps) => {
+const MemoizedContributionGraph = React.memo(ContributionGraph, (prevProps, nextProps) => {
   return (
     prevProps.isLoading === nextProps.isLoading && prevProps.contributionCalendar === nextProps.contributionCalendar
   )
 })
+
+MemoizedContributionGraph.propTypes = ContributionGraph.propTypes
+
+export default MemoizedContributionGraph

--- a/packages/theme/src/components/widgets/github/contribution-graph.js
+++ b/packages/theme/src/components/widgets/github/contribution-graph.js
@@ -4,6 +4,7 @@ import { Themed } from '@theme-ui/mdx'
 import { Box, Card, Heading } from '@theme-ui/components'
 import React, { useMemo, useRef, useEffect, useState } from 'react'
 import PropTypes from 'prop-types'
+import { nullableObject } from '@chronogrove/ui/prop-types-helpers'
 import { createPortal } from 'react-dom'
 import isDarkMode from '../../../helpers/isDarkMode'
 
@@ -556,8 +557,6 @@ const ContributionGraph = ({ isLoading, contributionCalendar }) => {
     </Box>
   )
 }
-
-const nullableObject = PropTypes.oneOfType([PropTypes.object, PropTypes.oneOf([null])])
 
 ContributionGraph.propTypes = {
   isLoading: PropTypes.bool.isRequired,

--- a/packages/theme/src/components/widgets/github/last-pull-request.js
+++ b/packages/theme/src/components/widgets/github/last-pull-request.js
@@ -5,6 +5,7 @@ import { Box, Card, Heading } from '@theme-ui/components'
 import Placeholder from 'react-placeholder'
 import { TextRow } from 'react-placeholder/lib/placeholders'
 import ago from 's-ago'
+import PropTypes from 'prop-types'
 
 import CardFooter from '../card-footer'
 import ViewExternal from '../view-external'
@@ -61,6 +62,11 @@ const LastPullRequest = ({ isLoading, pullRequest = {} }) => {
       </Themed.a>
     </Box>
   )
+}
+
+LastPullRequest.propTypes = {
+  isLoading: PropTypes.bool.isRequired,
+  pullRequest: PropTypes.object
 }
 
 export default LastPullRequest

--- a/packages/theme/src/components/widgets/github/pinned-item-card.js
+++ b/packages/theme/src/components/widgets/github/pinned-item-card.js
@@ -1,5 +1,6 @@
 /** @jsx jsx */
 import { jsx } from 'theme-ui'
+import PropTypes from 'prop-types'
 import { Card } from '@theme-ui/components'
 import { actionCardPinnedLayoutSx } from '@chronogrove/ui/action-card-layout'
 
@@ -19,5 +20,10 @@ const PinnedItemCard = ({ item, type = PLACEHOLDER }) => (
     {rendererRegistry[type]?.(item)}
   </Card>
 )
+
+PinnedItemCard.propTypes = {
+  item: PropTypes.object.isRequired,
+  type: PropTypes.string
+}
 
 export default PinnedItemCard

--- a/packages/theme/src/components/widgets/github/pinned-items.js
+++ b/packages/theme/src/components/widgets/github/pinned-items.js
@@ -1,5 +1,6 @@
 /** @jsx jsx */
 import { jsx } from 'theme-ui'
+import PropTypes from 'prop-types'
 import { Themed } from '@theme-ui/mdx'
 import { Box, Heading } from '@theme-ui/components'
 
@@ -51,6 +52,12 @@ const PinnedItems = ({ isLoading, items = [], placeholderCount = 4 }) => {
       </Box>
     </Box>
   )
+}
+
+PinnedItems.propTypes = {
+  isLoading: PropTypes.bool.isRequired,
+  items: PropTypes.arrayOf(PropTypes.object),
+  placeholderCount: PropTypes.number
 }
 
 export default PinnedItems

--- a/packages/theme/src/components/widgets/github/renderers/repository.js
+++ b/packages/theme/src/components/widgets/github/renderers/repository.js
@@ -1,5 +1,6 @@
 /** @jsx jsx */
 import { jsx } from 'theme-ui'
+import PropTypes from 'prop-types'
 import { Box, Flex, Heading } from '@theme-ui/components'
 import ago from 's-ago'
 
@@ -32,6 +33,15 @@ const Repository = ({ description, nameWithOwner, pushedAt, updatedAt }) => {
       </CardFooter>
     </Flex>
   )
+}
+
+const nullableString = PropTypes.oneOfType([PropTypes.string, PropTypes.oneOf([null])])
+
+Repository.propTypes = {
+  description: nullableString,
+  nameWithOwner: PropTypes.string.isRequired,
+  pushedAt: nullableString,
+  updatedAt: nullableString
 }
 
 export default Repository

--- a/packages/theme/src/components/widgets/github/renderers/repository.js
+++ b/packages/theme/src/components/widgets/github/renderers/repository.js
@@ -1,6 +1,7 @@
 /** @jsx jsx */
 import { jsx } from 'theme-ui'
 import PropTypes from 'prop-types'
+import { nullableString } from '@chronogrove/ui/prop-types-helpers'
 import { Box, Flex, Heading } from '@theme-ui/components'
 import ago from 's-ago'
 
@@ -34,8 +35,6 @@ const Repository = ({ description, nameWithOwner, pushedAt, updatedAt }) => {
     </Flex>
   )
 }
-
-const nullableString = PropTypes.oneOfType([PropTypes.string, PropTypes.oneOf([null])])
 
 Repository.propTypes = {
   description: nullableString,

--- a/packages/theme/src/components/widgets/goodreads/book-explorer.js
+++ b/packages/theme/src/components/widgets/goodreads/book-explorer.js
@@ -8,6 +8,7 @@ import { useLocation } from '@gatsbyjs/reach-router'
 import Book3D from '../../artwork/book-3d'
 import ViewExternal from '../view-external'
 import { parseSafeHtml } from '../../../helpers/safeHtmlParser'
+import PropTypes from 'prop-types'
 
 const renderStarsForRating = count => {
   const repeat = (char, n) => Array(n).fill(char).join('')
@@ -138,6 +139,11 @@ const BookExplorer = ({ book, onClose }) => {
       </Box>
     </Card>
   )
+}
+
+BookExplorer.propTypes = {
+  book: PropTypes.object.isRequired,
+  onClose: PropTypes.func.isRequired
 }
 
 export default BookExplorer

--- a/packages/theme/src/components/widgets/goodreads/book-link.js
+++ b/packages/theme/src/components/widgets/goodreads/book-link.js
@@ -3,6 +3,7 @@ import { jsx } from 'theme-ui'
 import { Box, Card } from '@theme-ui/components'
 import { navigate as gatsbyNavigate } from 'gatsby'
 import { useEffect, useState } from 'react'
+import PropTypes from 'prop-types'
 import Book3D from '../../artwork/book-3d'
 
 const BookLink = ({
@@ -178,6 +179,17 @@ const BookLink = ({
       </Box>
     </Card>
   )
+}
+
+const nullableString = PropTypes.oneOfType([PropTypes.string, PropTypes.oneOf([null])])
+
+BookLink.propTypes = {
+  id: PropTypes.string.isRequired,
+  thumbnailURL: nullableString,
+  title: PropTypes.string.isRequired,
+  suppressNavigation: PropTypes.bool,
+  introDelay: PropTypes.number,
+  flatCover: PropTypes.bool
 }
 
 export default BookLink

--- a/packages/theme/src/components/widgets/goodreads/book-link.js
+++ b/packages/theme/src/components/widgets/goodreads/book-link.js
@@ -4,6 +4,7 @@ import { Box, Card } from '@theme-ui/components'
 import { navigate as gatsbyNavigate } from 'gatsby'
 import { useEffect, useState } from 'react'
 import PropTypes from 'prop-types'
+import { nullableString } from '@chronogrove/ui/prop-types-helpers'
 import Book3D from '../../artwork/book-3d'
 
 const BookLink = ({
@@ -180,8 +181,6 @@ const BookLink = ({
     </Card>
   )
 }
-
-const nullableString = PropTypes.oneOfType([PropTypes.string, PropTypes.oneOf([null])])
 
 BookLink.propTypes = {
   id: PropTypes.string.isRequired,

--- a/packages/theme/src/components/widgets/goodreads/recently-read-books.js
+++ b/packages/theme/src/components/widgets/goodreads/recently-read-books.js
@@ -5,6 +5,7 @@ import { RectShape } from 'react-placeholder/lib/placeholders'
 import { Themed } from '@theme-ui/mdx'
 import { useLocation, navigate } from '@gatsbyjs/reach-router'
 import { useEffect, useMemo, useRef, useState, useCallback } from 'react'
+import PropTypes from 'prop-types'
 import isDarkMode from '../../../helpers/isDarkMode'
 import Pagination from '../../pagination'
 import useSwipePagination from '../../../hooks/use-swipe-pagination'
@@ -300,6 +301,11 @@ const RecentlyReadBooks = ({ books = [], isLoading }) => {
       </Box>
     </div>
   )
+}
+
+RecentlyReadBooks.propTypes = {
+  books: PropTypes.arrayOf(PropTypes.object),
+  isLoading: PropTypes.bool.isRequired
 }
 
 export default RecentlyReadBooks

--- a/packages/theme/src/components/widgets/goodreads/user-profile.js
+++ b/packages/theme/src/components/widgets/goodreads/user-profile.js
@@ -1,5 +1,6 @@
 /** @jsx jsx */
 import { jsx, useThemeUI } from 'theme-ui'
+import PropTypes from 'prop-types'
 import { Box, Card, Heading } from '@theme-ui/components'
 import Placeholder from 'react-placeholder'
 
@@ -67,6 +68,11 @@ const UserProfile = ({ isLoading, profile }) => {
       </Box>
     </Card>
   )
+}
+
+UserProfile.propTypes = {
+  isLoading: PropTypes.bool.isRequired,
+  profile: PropTypes.object.isRequired
 }
 
 export default UserProfile

--- a/packages/theme/src/components/widgets/goodreads/user-status.js
+++ b/packages/theme/src/components/widgets/goodreads/user-status.js
@@ -4,6 +4,7 @@ import { Themed } from '@theme-ui/mdx'
 import { Box, Card, Heading } from '@theme-ui/components'
 import { useRef, useState, useCallback } from 'react'
 import PropTypes from 'prop-types'
+import { nullableString } from '@chronogrove/ui/prop-types-helpers'
 import ago from 's-ago'
 import Placeholder from 'react-placeholder'
 import { TextRow } from 'react-placeholder/lib/placeholders'
@@ -157,8 +158,6 @@ const UserStatus = ({ isLoading, status, actorName }) => {
     </Box>
   )
 }
-
-const nullableString = PropTypes.oneOfType([PropTypes.string, PropTypes.oneOf([null])])
 
 UserStatus.propTypes = {
   isLoading: PropTypes.bool.isRequired,

--- a/packages/theme/src/components/widgets/goodreads/user-status.js
+++ b/packages/theme/src/components/widgets/goodreads/user-status.js
@@ -3,6 +3,7 @@ import { jsx } from 'theme-ui'
 import { Themed } from '@theme-ui/mdx'
 import { Box, Card, Heading } from '@theme-ui/components'
 import { useRef, useState, useCallback } from 'react'
+import PropTypes from 'prop-types'
 import ago from 's-ago'
 import Placeholder from 'react-placeholder'
 import { TextRow } from 'react-placeholder/lib/placeholders'
@@ -155,6 +156,14 @@ const UserStatus = ({ isLoading, status, actorName }) => {
       </Themed.a>
     </Box>
   )
+}
+
+const nullableString = PropTypes.oneOfType([PropTypes.string, PropTypes.oneOf([null])])
+
+UserStatus.propTypes = {
+  isLoading: PropTypes.bool.isRequired,
+  status: PropTypes.object,
+  actorName: nullableString
 }
 
 export default UserStatus

--- a/packages/theme/src/components/widgets/instagram/instagram-widget-item.js
+++ b/packages/theme/src/components/widgets/instagram/instagram-widget-item.js
@@ -3,6 +3,7 @@ import { jsx } from 'theme-ui'
 import { Box } from '@theme-ui/components'
 import { keyframes } from '@emotion/react'
 import { useState, useEffect, useRef, useCallback } from 'react'
+import PropTypes from 'prop-types'
 import { faImages, faVideo } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 
@@ -296,6 +297,14 @@ const InstagramWidgetItem = ({
       />
     </Box>
   )
+}
+
+InstagramWidgetItem.propTypes = {
+  handleClick: PropTypes.func.isRequired,
+  index: PropTypes.number.isRequired,
+  post: PropTypes.object,
+  isAmbientActive: PropTypes.bool,
+  ambientTrigger: PropTypes.number
 }
 
 export default InstagramWidgetItem

--- a/packages/theme/src/components/widgets/recent-posts/image-thumbnails.js
+++ b/packages/theme/src/components/widgets/recent-posts/image-thumbnails.js
@@ -1,10 +1,10 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import ImageThumbnailsUI from '@chronogrove/ui/image-thumbnails'
+import { thumbnailSrcItem } from '@chronogrove/ui/prop-types-helpers'
 import { optimizeCloudinaryThumbnailSrc } from '../../../helpers/cloudinaryThumbnailUrl'
 
 /** Post-card thumbnails row with Cloudinary-optimized retina sizes. */
-const thumbnailSrcItem = PropTypes.oneOfType([PropTypes.string, PropTypes.oneOf([null, undefined])])
 
 const ImageThumbnails = props => <ImageThumbnailsUI {...props} optimizeSrc={optimizeCloudinaryThumbnailSrc} />
 

--- a/packages/theme/src/components/widgets/recent-posts/image-thumbnails.js
+++ b/packages/theme/src/components/widgets/recent-posts/image-thumbnails.js
@@ -1,8 +1,16 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import ImageThumbnailsUI from '@chronogrove/ui/image-thumbnails'
 import { optimizeCloudinaryThumbnailSrc } from '../../../helpers/cloudinaryThumbnailUrl'
 
 /** Post-card thumbnails row with Cloudinary-optimized retina sizes. */
+const thumbnailSrcItem = PropTypes.oneOfType([PropTypes.string, PropTypes.oneOf([null])])
+
 const ImageThumbnails = props => <ImageThumbnailsUI {...props} optimizeSrc={optimizeCloudinaryThumbnailSrc} />
+
+ImageThumbnails.propTypes = {
+  images: PropTypes.arrayOf(thumbnailSrcItem),
+  maxImages: PropTypes.number
+}
 
 export default ImageThumbnails

--- a/packages/theme/src/components/widgets/recent-posts/image-thumbnails.js
+++ b/packages/theme/src/components/widgets/recent-posts/image-thumbnails.js
@@ -4,7 +4,7 @@ import ImageThumbnailsUI from '@chronogrove/ui/image-thumbnails'
 import { optimizeCloudinaryThumbnailSrc } from '../../../helpers/cloudinaryThumbnailUrl'
 
 /** Post-card thumbnails row with Cloudinary-optimized retina sizes. */
-const thumbnailSrcItem = PropTypes.oneOfType([PropTypes.string, PropTypes.oneOf([null])])
+const thumbnailSrcItem = PropTypes.oneOfType([PropTypes.string, PropTypes.oneOf([null, undefined])])
 
 const ImageThumbnails = props => <ImageThumbnailsUI {...props} optimizeSrc={optimizeCloudinaryThumbnailSrc} />
 

--- a/packages/theme/src/components/widgets/recent-posts/post-card.js
+++ b/packages/theme/src/components/widgets/recent-posts/post-card.js
@@ -1,6 +1,7 @@
 /** @jsx jsx */
 import React, { Fragment } from 'react'
 import PropTypes from 'prop-types'
+import { nullableString, nullableStringArray } from '@chronogrove/ui/prop-types-helpers'
 import { jsx, Box as ThemeBox } from 'theme-ui'
 import { Heading, Card } from '@theme-ui/components'
 import { Link } from 'gatsby'
@@ -28,13 +29,6 @@ export const buildYouTubeEmbedUrl = url => {
   return `${url}${separator}rel=0&modestbranding=1`
 }
 
-const nullableString = PropTypes.oneOfType([PropTypes.string, PropTypes.oneOf([null])])
-
-const thumbnailsPropType = PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.string), PropTypes.oneOf([null])])
-
-const previewUrlPropType = PropTypes.oneOfType([PropTypes.string, PropTypes.oneOf([null])])
-
-/** Small float beside headline — wide crop matches OG / banner art */
 const HORIZONTAL_PREVIEW_ASPECT = '1.9 / 1'
 /** Fixed width for the headline-row thumb (height follows aspect ratio); 5.625rem = 4.5rem × 1.25 */
 const HEADLINE_THUMB_WIDTH = '5.625rem'
@@ -217,10 +211,10 @@ PostCardInner.propTypes = {
   hasMediaEmbed: PropTypes.bool.isRequired,
   hasSoundCloud: PropTypes.bool.isRequired,
   hasYouTube: PropTypes.bool.isRequired,
-  horizontalPreviewUrl: previewUrlPropType,
+  horizontalPreviewUrl: nullableString,
   link: PropTypes.string.isRequired,
   soundcloudId: nullableString,
-  thumbnails: thumbnailsPropType,
+  thumbnails: nullableStringArray,
   title: PropTypes.string.isRequired,
   youtubeSrc: nullableString
 }
@@ -378,7 +372,7 @@ HorizontalTextBlock.propTypes = {
   date: PropTypes.string,
   excerpt: nullableString,
   hasMediaEmbed: PropTypes.bool.isRequired,
-  headlinePreviewUrl: previewUrlPropType,
+  headlinePreviewUrl: nullableString,
   horizontal: PropTypes.bool.isRequired,
   link: PropTypes.string.isRequired,
   title: PropTypes.string.isRequired
@@ -448,7 +442,7 @@ PostCard.propTypes = {
   isRecap: PropTypes.bool,
   link: PropTypes.string.isRequired,
   soundcloudId: nullableString,
-  thumbnails: thumbnailsPropType,
+  thumbnails: nullableStringArray,
   title: PropTypes.string.isRequired,
   youtubeSrc: nullableString
 }

--- a/packages/theme/src/components/widgets/recent-posts/recent-posts-widget.js
+++ b/packages/theme/src/components/widgets/recent-posts/recent-posts-widget.js
@@ -1,5 +1,6 @@
 /** @jsx jsx */
 import { jsx } from 'theme-ui'
+import PropTypes from 'prop-types'
 import { Grid, Box, Text } from '@theme-ui/components'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 
@@ -35,6 +36,11 @@ const SectionHeader = ({ icon, title }) => (
     </Text>
   </Box>
 )
+
+SectionHeader.propTypes = {
+  icon: PropTypes.object.isRequired,
+  title: PropTypes.string.isRequired
+}
 
 const musicGridSx = {
   display: 'grid',

--- a/packages/theme/src/components/widgets/spotify/media-item-grid.js
+++ b/packages/theme/src/components/widgets/spotify/media-item-grid.js
@@ -1,6 +1,7 @@
 /** @jsx jsx */
 import { jsx, Box, useThemeUI } from 'theme-ui'
 import { useState } from 'react'
+import PropTypes from 'prop-types'
 import { Themed } from '@theme-ui/mdx'
 import Placeholder from 'react-placeholder'
 import { RectShape } from 'react-placeholder/lib/placeholders'
@@ -134,6 +135,13 @@ const MediaItemGrid = ({ interactionDisabled = false, isLoading, items = [], onT
       </Placeholder>
     </Box>
   )
+}
+
+MediaItemGrid.propTypes = {
+  interactionDisabled: PropTypes.bool,
+  isLoading: PropTypes.bool.isRequired,
+  items: PropTypes.arrayOf(PropTypes.object),
+  onTrackClick: PropTypes.func
 }
 
 export default MediaItemGrid

--- a/packages/theme/src/components/widgets/spotify/playlists-error-boundary.js
+++ b/packages/theme/src/components/widgets/spotify/playlists-error-boundary.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import { ErrorBoundary } from 'react-error-boundary'
 
 // This component is a temporary solution for an issue I've been observing the last month or two
@@ -20,6 +21,10 @@ const PlaylistsErrorBoundary = ({ children }) => {
       {children}
     </ErrorBoundary>
   )
+}
+
+PlaylistsErrorBoundary.propTypes = {
+  children: PropTypes.node
 }
 
 export default PlaylistsErrorBoundary

--- a/packages/theme/src/components/widgets/spotify/playlists.js
+++ b/packages/theme/src/components/widgets/spotify/playlists.js
@@ -4,6 +4,7 @@ import { Heading } from '@theme-ui/components'
 import MediaItemGrid from './media-item-grid'
 import { Themed } from '@theme-ui/mdx'
 import { useAudioPlayerStore } from '../../../stores/audio-player-store'
+import PropTypes from 'prop-types'
 
 const transformPlaylist = playlist => {
   if (!playlist) {
@@ -62,6 +63,11 @@ const Playlists = ({ isLoading, playlists = [] }) => {
       <MediaItemGrid isLoading={isLoading} items={items} onTrackClick={handlePlaylistClick} />
     </Box>
   )
+}
+
+Playlists.propTypes = {
+  isLoading: PropTypes.bool.isRequired,
+  playlists: PropTypes.arrayOf(PropTypes.object)
 }
 
 export default Playlists

--- a/packages/theme/src/components/widgets/spotify/top-tracks.js
+++ b/packages/theme/src/components/widgets/spotify/top-tracks.js
@@ -3,6 +3,7 @@ import { jsx, Box } from 'theme-ui'
 import { Heading } from '@theme-ui/components'
 import { Themed } from '@theme-ui/mdx'
 import { useEffect, useMemo, useState } from 'react'
+import PropTypes from 'prop-types'
 
 import { useAudioPlayerStore } from '../../../stores/audio-player-store'
 import useSwipePagination from '../../../hooks/use-swipe-pagination'
@@ -154,6 +155,11 @@ const TopTracks = ({ isLoading, tracks = [] }) => {
       ) : null}
     </Box>
   )
+}
+
+TopTracks.propTypes = {
+  isLoading: PropTypes.bool.isRequired,
+  tracks: PropTypes.arrayOf(PropTypes.object)
 }
 
 export default TopTracks

--- a/packages/theme/src/components/widgets/spotify/track-preview.js
+++ b/packages/theme/src/components/widgets/spotify/track-preview.js
@@ -1,6 +1,7 @@
 /** @jsx jsx */
 import { jsx, Box } from 'theme-ui'
 import PropTypes from 'prop-types'
+import { nullableString } from '@chronogrove/ui/prop-types-helpers'
 import { Themed } from '@theme-ui/mdx'
 
 const TrackPreview = ({ link, name, thumbnailURL }) => (
@@ -24,8 +25,6 @@ const TrackPreview = ({ link, name, thumbnailURL }) => (
     />
   </Themed.a>
 )
-
-const nullableString = PropTypes.oneOfType([PropTypes.string, PropTypes.oneOf([null])])
 
 TrackPreview.propTypes = {
   link: PropTypes.string.isRequired,

--- a/packages/theme/src/components/widgets/spotify/track-preview.js
+++ b/packages/theme/src/components/widgets/spotify/track-preview.js
@@ -1,5 +1,6 @@
 /** @jsx jsx */
 import { jsx, Box } from 'theme-ui'
+import PropTypes from 'prop-types'
 import { Themed } from '@theme-ui/mdx'
 
 const TrackPreview = ({ link, name, thumbnailURL }) => (
@@ -23,5 +24,13 @@ const TrackPreview = ({ link, name, thumbnailURL }) => (
     />
   </Themed.a>
 )
+
+const nullableString = PropTypes.oneOfType([PropTypes.string, PropTypes.oneOf([null])])
+
+TrackPreview.propTypes = {
+  link: PropTypes.string.isRequired,
+  name: PropTypes.string.isRequired,
+  thumbnailURL: nullableString
+}
 
 export default TrackPreview

--- a/packages/theme/src/components/widgets/steam/ai-summary-skeleton.js
+++ b/packages/theme/src/components/widgets/steam/ai-summary-skeleton.js
@@ -4,6 +4,7 @@ import { TextBlock } from 'react-placeholder/lib/placeholders'
 import isDarkMode from '../../../helpers/isDarkMode'
 
 import 'react-placeholder/lib/reactPlaceholder.css'
+import PropTypes from 'prop-types'
 
 /**
  * Skeleton placeholder for AI summary block. Matches the layout of AiSummary
@@ -41,6 +42,11 @@ const AiSummarySkeleton = ({ skeletonRows = 4, sx: sxProp }) => {
       </div>
     </div>
   )
+}
+
+AiSummarySkeleton.propTypes = {
+  skeletonRows: PropTypes.number,
+  sx: PropTypes.object
 }
 
 export default AiSummarySkeleton

--- a/packages/theme/src/components/widgets/steam/ai-summary.js
+++ b/packages/theme/src/components/widgets/steam/ai-summary.js
@@ -2,6 +2,7 @@
 import { jsx } from 'theme-ui'
 import { Box, Text } from '@theme-ui/components'
 import React, { useEffect, useState, useRef } from 'react'
+import PropTypes from 'prop-types'
 
 import { formatAiSummarySyncedLabel } from '../../../helpers/ai-summary-synced-at'
 import { parseSafeHtml } from '../../../helpers/safeHtmlParser'
@@ -49,7 +50,7 @@ const proseSx = {
   }
 }
 
-const AiSummary = React.memo(({ aiSummary, aiSummarySyncedAt, sx: sxProp }) => {
+function AiSummaryComponent({ aiSummary, aiSummarySyncedAt, sx: sxProp }) {
   const [isVisible, setIsVisible] = useState(false)
   const [showContent, setShowContent] = useState(false)
   const [isExpanded, setIsExpanded] = useState(false)
@@ -161,6 +162,18 @@ const AiSummary = React.memo(({ aiSummary, aiSummarySyncedAt, sx: sxProp }) => {
       )}
     </div>
   )
-})
+}
+
+const nullableString = PropTypes.oneOfType([PropTypes.string, PropTypes.oneOf([null])])
+
+AiSummaryComponent.propTypes = {
+  aiSummary: PropTypes.string.isRequired,
+  aiSummarySyncedAt: nullableString,
+  sx: PropTypes.object
+}
+
+const AiSummary = React.memo(AiSummaryComponent)
+
+AiSummary.propTypes = AiSummaryComponent.propTypes
 
 export default AiSummary

--- a/packages/theme/src/components/widgets/steam/ai-summary.js
+++ b/packages/theme/src/components/widgets/steam/ai-summary.js
@@ -3,6 +3,7 @@ import { jsx } from 'theme-ui'
 import { Box, Text } from '@theme-ui/components'
 import React, { useEffect, useState, useRef } from 'react'
 import PropTypes from 'prop-types'
+import { nullableString } from '@chronogrove/ui/prop-types-helpers'
 
 import { formatAiSummarySyncedLabel } from '../../../helpers/ai-summary-synced-at'
 import { parseSafeHtml } from '../../../helpers/safeHtmlParser'
@@ -163,8 +164,6 @@ function AiSummaryComponent({ aiSummary, aiSummarySyncedAt, sx: sxProp }) {
     </div>
   )
 }
-
-const nullableString = PropTypes.oneOfType([PropTypes.string, PropTypes.oneOf([null])])
 
 AiSummaryComponent.propTypes = {
   /** Tests and callers may mount with `null` / omitted while the effect no-ops on falsy values. */

--- a/packages/theme/src/components/widgets/steam/ai-summary.js
+++ b/packages/theme/src/components/widgets/steam/ai-summary.js
@@ -167,7 +167,8 @@ function AiSummaryComponent({ aiSummary, aiSummarySyncedAt, sx: sxProp }) {
 const nullableString = PropTypes.oneOfType([PropTypes.string, PropTypes.oneOf([null])])
 
 AiSummaryComponent.propTypes = {
-  aiSummary: PropTypes.string.isRequired,
+  /** Tests and callers may mount with `null` / omitted while the effect no-ops on falsy values. */
+  aiSummary: nullableString,
   aiSummarySyncedAt: nullableString,
   sx: PropTypes.object
 }

--- a/packages/theme/src/components/widgets/steam/play-time-chart.js
+++ b/packages/theme/src/components/widgets/steam/play-time-chart.js
@@ -6,6 +6,7 @@ import getTimeSpent from './get-time-spent'
 import isDarkMode from '../../../helpers/isDarkMode'
 import ViewExternal from '../view-external'
 import SteamGameCard from './steam-game-card'
+import PropTypes from 'prop-types'
 
 /** Subtitle shown under leaderboard cards (recent playtime appended when present). */
 const leaderboardSubtitle = game => {
@@ -171,6 +172,12 @@ const PlayTimeChart = ({ games = [], isLoading = false, profileURL = '' }) => {
       ) : null}
     </Box>
   )
+}
+
+PlayTimeChart.propTypes = {
+  games: PropTypes.arrayOf(PropTypes.object),
+  isLoading: PropTypes.bool,
+  profileURL: PropTypes.string
 }
 
 export default PlayTimeChart

--- a/packages/theme/src/components/widgets/steam/steam-game-card.js
+++ b/packages/theme/src/components/widgets/steam/steam-game-card.js
@@ -1,6 +1,7 @@
 /** @jsx jsx */
 import { jsx, Box, useThemeUI } from 'theme-ui'
 import PropTypes from 'prop-types'
+import { nullableNumber, nullableString } from '@chronogrove/ui/prop-types-helpers'
 import { useState } from 'react'
 import { RectShape } from 'react-placeholder/lib/placeholders'
 import isDarkMode from '../../../helpers/isDarkMode'
@@ -241,9 +242,9 @@ const SteamGameCard = ({ game, showRank = false, rank = null, subtitle = null, o
 SteamGameCard.propTypes = {
   game: steamGamePropType,
   onClick: PropTypes.func,
-  rank: PropTypes.oneOfType([PropTypes.number, PropTypes.oneOf([null])]),
+  rank: nullableNumber,
   showRank: PropTypes.bool,
-  subtitle: PropTypes.oneOfType([PropTypes.string, PropTypes.oneOf([null])])
+  subtitle: nullableString
 }
 
 export default SteamGameCard

--- a/packages/theme/src/components/widgets/steam/steam-game-card.js
+++ b/packages/theme/src/components/widgets/steam/steam-game-card.js
@@ -50,6 +50,10 @@ const SteamCardImagePlaceholder = ({ darkModeActive }) => {
   )
 }
 
+SteamCardImagePlaceholder.propTypes = {
+  darkModeActive: PropTypes.bool.isRequired
+}
+
 const SteamCardGameLazyImage = ({ darkModeActive, displayName, gameImage, isImageZoomed }) => (
   <LazyLoad placeholder={<SteamCardImagePlaceholder darkModeActive={darkModeActive} />}>
     <Box
@@ -68,9 +72,22 @@ const SteamCardGameLazyImage = ({ darkModeActive, displayName, gameImage, isImag
   </LazyLoad>
 )
 
+SteamCardGameLazyImage.propTypes = {
+  darkModeActive: PropTypes.bool.isRequired,
+  displayName: PropTypes.string.isRequired,
+  gameImage: PropTypes.string.isRequired,
+  isImageZoomed: PropTypes.bool.isRequired
+}
+
 const SteamRankBadge = ({ darkModeActive, rank, showRank }) => {
   if (!showRank || !rank) return null
   return <Box sx={steamRankBadgeSx(darkModeActive)}>{rank}</Box>
+}
+
+SteamRankBadge.propTypes = {
+  darkModeActive: PropTypes.bool.isRequired,
+  rank: PropTypes.number,
+  showRank: PropTypes.bool.isRequired
 }
 
 const SteamGameCaptionOverlay = ({ displayName, subtitle }) => (
@@ -114,6 +131,11 @@ const SteamGameCaptionOverlay = ({ displayName, subtitle }) => (
     {subtitle ? <Box sx={{ fontSize: '12px', color: 'rgba(255,255,255,0.85)' }}>{subtitle}</Box> : null}
   </Box>
 )
+
+SteamGameCaptionOverlay.propTypes = {
+  displayName: PropTypes.string.isRequired,
+  subtitle: PropTypes.string
+}
 
 const SteamCardGameMedia = ({ darkModeActive, game, gameImage, isImageZoomed, rank, showRank, subtitle }) => (
   <Box

--- a/packages/theme/src/mdx-provider-components.js
+++ b/packages/theme/src/mdx-provider-components.js
@@ -1,5 +1,6 @@
 /** @jsx jsx */
 import React from 'react'
+import PropTypes from 'prop-types'
 import { jsx, useColorMode } from 'theme-ui'
 import { Themed } from '@theme-ui/mdx'
 
@@ -10,6 +11,14 @@ export function MdxTable(props) {
   return <Themed.table {...props} sx={{ variant: tableVariant }} />
 }
 
+MdxTable.propTypes = {
+  children: PropTypes.node
+}
+
 export function MdxPrePassthrough({ children }) {
   return <>{children}</>
+}
+
+MdxPrePassthrough.propTypes = {
+  children: PropTypes.node
 }

--- a/packages/theme/src/pages/blog.js
+++ b/packages/theme/src/pages/blog.js
@@ -3,6 +3,7 @@ import { Container, jsx, Box } from 'theme-ui'
 import { Themed } from '@theme-ui/mdx'
 import { Flex } from '@theme-ui/components'
 import { graphql } from 'gatsby'
+import PropTypes from 'prop-types'
 
 import {
   CategoryIndexHeroChrome,
@@ -56,6 +57,14 @@ const BlogIndexPage = ({ data }) => {
       </Layout>
     </CategoryIndexHeroChrome>
   )
+}
+
+BlogIndexPage.propTypes = {
+  data: PropTypes.shape({
+    allMdx: PropTypes.shape({
+      edges: PropTypes.array
+    })
+  }).isRequired
 }
 
 export { default as Head } from './blog-head'

--- a/packages/theme/src/shortcodes/Note.js
+++ b/packages/theme/src/shortcodes/Note.js
@@ -1,5 +1,6 @@
 /** @jsx jsx */
 import { Box, jsx, useColorMode } from 'theme-ui'
+import PropTypes from 'prop-types'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faCircleCheck, faCircleInfo, faClock } from '@fortawesome/free-solid-svg-icons'
 
@@ -94,6 +95,12 @@ const Note = ({ children, variant = 'info', icon: showIcon = true }) => {
       </Box>
     </Box>
   )
+}
+
+Note.propTypes = {
+  children: PropTypes.node.isRequired,
+  variant: PropTypes.oneOf(['update', 'info', 'outdated']),
+  icon: PropTypes.bool
 }
 
 export default Note

--- a/packages/theme/src/shortcodes/color-mode-image.js
+++ b/packages/theme/src/shortcodes/color-mode-image.js
@@ -1,5 +1,6 @@
 /** @jsx jsx */
 import { jsx, useColorMode } from 'theme-ui'
+import PropTypes from 'prop-types'
 import { Themed } from '@theme-ui/mdx'
 
 import isDarkMode from '../helpers/isDarkMode'
@@ -61,6 +62,14 @@ const ColorModeImage = ({ light, dark, alt, optimizeDelivery = true, loading, ..
   const src = pickDark ? darkSrc : lightSrc
 
   return <Themed.img {...rest} alt={alt} src={src} loading={loading ?? 'lazy'} />
+}
+
+ColorModeImage.propTypes = {
+  light: PropTypes.string.isRequired,
+  dark: PropTypes.string.isRequired,
+  alt: PropTypes.string.isRequired,
+  optimizeDelivery: PropTypes.bool,
+  loading: PropTypes.string
 }
 
 export default ColorModeImage

--- a/packages/theme/src/shortcodes/emoji.js
+++ b/packages/theme/src/shortcodes/emoji.js
@@ -1,9 +1,15 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 
 const Emoji = ({ children, label }) => (
   <span aria-hidden={label ? 'false' : 'true'} aria-label={label ? label : ''} className='emoji' role='img'>
     {children}
   </span>
 )
+
+Emoji.propTypes = {
+  children: PropTypes.node.isRequired,
+  label: PropTypes.string
+}
 
 export default Emoji

--- a/packages/theme/src/shortcodes/soundcloud.js
+++ b/packages/theme/src/shortcodes/soundcloud.js
@@ -1,6 +1,7 @@
 /** @jsx jsx */
 import { jsx, useColorMode } from 'theme-ui'
 import PropTypes from 'prop-types'
+import { nullableString } from '@chronogrove/ui/prop-types-helpers'
 
 // Use a theme-aware accent color for the SoundCloud player
 const buildSoundCloudEmbedURL = (trackId, isDarkMode) => {
@@ -25,8 +26,6 @@ const SoundCloud = ({ title, soundcloudId }) => {
     ></iframe>
   )
 }
-
-const nullableString = PropTypes.oneOfType([PropTypes.string, PropTypes.oneOf([null])])
 
 SoundCloud.propTypes = {
   title: nullableString,

--- a/packages/theme/src/shortcodes/soundcloud.js
+++ b/packages/theme/src/shortcodes/soundcloud.js
@@ -1,5 +1,6 @@
 /** @jsx jsx */
 import { jsx, useColorMode } from 'theme-ui'
+import PropTypes from 'prop-types'
 
 // Use a theme-aware accent color for the SoundCloud player
 const buildSoundCloudEmbedURL = (trackId, isDarkMode) => {
@@ -23,6 +24,13 @@ const SoundCloud = ({ title, soundcloudId }) => {
       width='100%'
     ></iframe>
   )
+}
+
+const nullableString = PropTypes.oneOfType([PropTypes.string, PropTypes.oneOf([null])])
+
+SoundCloud.propTypes = {
+  title: nullableString,
+  soundcloudId: PropTypes.string.isRequired
 }
 
 export default SoundCloud

--- a/packages/theme/src/shortcodes/spotify.js
+++ b/packages/theme/src/shortcodes/spotify.js
@@ -1,5 +1,6 @@
 /** @jsx jsx */
 import { jsx, Box } from 'theme-ui'
+import PropTypes from 'prop-types'
 
 // Build embed URL from share URL so we can render a simple iframe (like SoundCloud).
 // This avoids oEmbed fetch + state, so the iframe is preserved across re-renders and
@@ -34,6 +35,10 @@ const Spotify = ({ spotifyURL }) => {
       />
     </Box>
   )
+}
+
+Spotify.propTypes = {
+  spotifyURL: PropTypes.string.isRequired
 }
 
 export default Spotify

--- a/packages/theme/src/shortcodes/youtube.js
+++ b/packages/theme/src/shortcodes/youtube.js
@@ -1,6 +1,7 @@
 /** @jsx jsx */
 import { jsx } from 'theme-ui'
 import PropTypes from 'prop-types'
+import { nullableString } from '@chronogrove/ui/prop-types-helpers'
 import { Themed } from '@theme-ui/mdx'
 import { Embed } from '@theme-ui/components'
 
@@ -32,8 +33,6 @@ const YouTube = ({ title, url, sx = {}, compact = false }) => (
     />
   </Themed.div>
 )
-
-const nullableString = PropTypes.oneOfType([PropTypes.string, PropTypes.oneOf([null])])
 
 YouTube.propTypes = {
   title: nullableString,

--- a/packages/theme/src/shortcodes/youtube.js
+++ b/packages/theme/src/shortcodes/youtube.js
@@ -1,5 +1,6 @@
 /** @jsx jsx */
 import { jsx } from 'theme-ui'
+import PropTypes from 'prop-types'
 import { Themed } from '@theme-ui/mdx'
 import { Embed } from '@theme-ui/components'
 
@@ -31,5 +32,14 @@ const YouTube = ({ title, url, sx = {}, compact = false }) => (
     />
   </Themed.div>
 )
+
+const nullableString = PropTypes.oneOfType([PropTypes.string, PropTypes.oneOf([null])])
+
+YouTube.propTypes = {
+  title: nullableString,
+  url: PropTypes.string.isRequired,
+  sx: PropTypes.object,
+  compact: PropTypes.bool
+}
 
 export default YouTube

--- a/packages/theme/src/templates/media.js
+++ b/packages/theme/src/templates/media.js
@@ -13,6 +13,23 @@ import { useAudioPlayerStore } from '../stores/audio-player-store'
 import YouTube from '../shortcodes/youtube'
 import useSiteMetadata from '../hooks/use-site-metadata'
 
+const mediaMdxPropType = PropTypes.shape({
+  id: PropTypes.string.isRequired,
+  fields: PropTypes.shape({
+    category: PropTypes.string,
+    path: PropTypes.string.isRequired
+  }).isRequired,
+  frontmatter: PropTypes.shape({
+    banner: PropTypes.string,
+    date: PropTypes.string,
+    description: PropTypes.string,
+    keywords: PropTypes.arrayOf(PropTypes.string),
+    soundcloudId: PropTypes.string,
+    title: PropTypes.string.isRequired,
+    youtubeSrc: PropTypes.string
+  }).isRequired
+}).isRequired
+
 const getBanner = mdx => mdx.frontmatter.banner
 const getDescription = mdx => mdx.frontmatter.description
 const getTitle = mdx => mdx.frontmatter.title
@@ -113,22 +130,7 @@ const MediaTemplate = ({ data: { mdx }, children }) => {
 MediaTemplate.propTypes = {
   children: PropTypes.node,
   data: PropTypes.shape({
-    mdx: PropTypes.shape({
-      id: PropTypes.string.isRequired,
-      fields: PropTypes.shape({
-        category: PropTypes.string,
-        path: PropTypes.string.isRequired
-      }).isRequired,
-      frontmatter: PropTypes.shape({
-        banner: PropTypes.string,
-        date: PropTypes.string,
-        description: PropTypes.string,
-        keywords: PropTypes.arrayOf(PropTypes.string),
-        soundcloudId: PropTypes.string,
-        title: PropTypes.string.isRequired,
-        youtubeSrc: PropTypes.string
-      }).isRequired
-    }).isRequired
+    mdx: mediaMdxPropType
   }).isRequired
 }
 
@@ -171,6 +173,12 @@ export const Head = ({ data: { mdx } }) => {
       <script type='application/ld+json'>{JSON.stringify(breadcrumbData)}</script>
     </Seo>
   )
+}
+
+Head.propTypes = {
+  data: PropTypes.shape({
+    mdx: mediaMdxPropType
+  }).isRequired
 }
 
 export const pageQuery = graphql`

--- a/packages/theme/src/templates/post.js
+++ b/packages/theme/src/templates/post.js
@@ -76,6 +76,7 @@ const mdxHeadPropType = PropTypes.shape({
   }),
   frontmatter: PropTypes.shape({
     banner: PropTypes.string,
+    date: PropTypes.string,
     description: PropTypes.string,
     title: PropTypes.string,
     keywords: PropTypes.arrayOf(PropTypes.string)

--- a/packages/theme/src/templates/post.js
+++ b/packages/theme/src/templates/post.js
@@ -1,5 +1,6 @@
 /** @jsx jsx */
 import { Container, jsx } from 'theme-ui'
+import PropTypes from 'prop-types'
 import { Themed } from '@theme-ui/mdx'
 import { graphql } from 'gatsby'
 
@@ -67,6 +68,27 @@ const PostTemplate = ({ children, data }) => {
   )
 }
 
+const mdxHeadPropType = PropTypes.shape({
+  id: PropTypes.string,
+  fields: PropTypes.shape({
+    category: PropTypes.string,
+    path: PropTypes.string
+  }),
+  frontmatter: PropTypes.shape({
+    banner: PropTypes.string,
+    description: PropTypes.string,
+    title: PropTypes.string,
+    keywords: PropTypes.arrayOf(PropTypes.string)
+  })
+}).isRequired
+
+PostTemplate.propTypes = {
+  children: PropTypes.node.isRequired,
+  data: PropTypes.shape({
+    mdx: mdxHeadPropType
+  }).isRequired
+}
+
 export const Head = ({ data: { mdx } }) => {
   const banner = mdx.frontmatter.banner
   const description = mdx.frontmatter.description
@@ -106,6 +128,12 @@ export const Head = ({ data: { mdx } }) => {
       <script type='application/ld+json'>{JSON.stringify(breadcrumbData)}</script>
     </Seo>
   )
+}
+
+Head.propTypes = {
+  data: PropTypes.shape({
+    mdx: mdxHeadPropType
+  }).isRequired
 }
 
 export const pageQuery = graphql`

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chronogrove/ui",
-  "version": "0.85.4",
+  "version": "0.85.5",
   "description": "Chronogrove Theme UI theme, color mode helpers, and shared UI primitives",
   "license": "MIT",
   "type": "module",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -189,6 +189,7 @@
     "@theme-toggles/react": "catalog:",
     "@theme-ui/components": "catalog:",
     "@theme-ui/presets": "catalog:",
+    "prop-types": "catalog:",
     "react-intersection-observer": "catalog:",
     "theme-ui": "catalog:",
     "three": "catalog:"

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -154,6 +154,10 @@
       "import": "./src/page-shell-layout.js",
       "default": "./src/page-shell-layout.js"
     },
+    "./prop-types-helpers": {
+      "import": "./src/prop-types-helpers.js",
+      "default": "./src/prop-types-helpers.js"
+    },
     "./thumbnail-strip": {
       "import": "./src/thumbnail-strip.js",
       "default": "./src/thumbnail-strip.js"

--- a/packages/ui/src/action-button.js
+++ b/packages/ui/src/action-button.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import { Box } from '@theme-ui/components'
 import { useThemeUI } from 'theme-ui'
 import isDarkMode from './helpers/isDarkMode.js'
@@ -80,6 +81,15 @@ const ActionButton = ({ children, href, onClick, variant = 'primary', size = 'me
       {content}
     </Box>
   )
+}
+
+ActionButton.propTypes = {
+  children: PropTypes.node,
+  href: PropTypes.string,
+  onClick: PropTypes.func,
+  variant: PropTypes.oneOf(['primary', 'secondary', 'success', 'warning', 'danger']),
+  size: PropTypes.oneOf(['small', 'medium', 'large', 'xlarge']),
+  icon: PropTypes.node
 }
 
 export default ActionButton

--- a/packages/ui/src/animated-page-background/ChronogroveAnimatedPageBackground.js
+++ b/packages/ui/src/animated-page-background/ChronogroveAnimatedPageBackground.js
@@ -1,6 +1,7 @@
 'use client'
 
 import React, { useMemo, useEffect, useState } from 'react'
+import PropTypes from 'prop-types'
 import { Box } from '@theme-ui/components'
 import { useColorMode, useThemeUI } from 'theme-ui'
 
@@ -150,4 +151,11 @@ export default function ChronogroveAnimatedPageBackground({
       />
     </>
   )
+}
+
+ChronogroveAnimatedPageBackground.propTypes = {
+  overlayHeight: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  darkOpacity: PropTypes.number,
+  fadeDistance: PropTypes.number,
+  maxParallaxOffset: PropTypes.number
 }

--- a/packages/ui/src/animated-page-background/ColorBends.js
+++ b/packages/ui/src/animated-page-background/ColorBends.js
@@ -1,4 +1,5 @@
 import React, { useEffect, useRef } from 'react'
+import PropTypes from 'prop-types'
 
 import * as THREE from 'three'
 import './color-bends.css'
@@ -309,4 +310,20 @@ export default function ColorBends({
   }, [])
 
   return <div ref={containerRef} className={`color-bends-container ${className || ''}`} style={style} />
+}
+
+ColorBends.propTypes = {
+  className: PropTypes.string,
+  style: PropTypes.object,
+  rotation: PropTypes.number,
+  speed: PropTypes.number,
+  colors: PropTypes.arrayOf(PropTypes.string),
+  transparent: PropTypes.bool,
+  autoRotate: PropTypes.number,
+  scale: PropTypes.number,
+  frequency: PropTypes.number,
+  warpStrength: PropTypes.number,
+  mouseInfluence: PropTypes.number,
+  parallax: PropTypes.number,
+  noise: PropTypes.number
 }

--- a/packages/ui/src/article-column-container.js
+++ b/packages/ui/src/article-column-container.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import { Container } from '@theme-ui/components'
 
 /**
@@ -20,4 +21,9 @@ export function ArticleColumnContainer({ children, sx = {}, ...rest }) {
       {children}
     </Container>
   )
+}
+
+ArticleColumnContainer.propTypes = {
+  children: PropTypes.node.isRequired,
+  sx: PropTypes.object
 }

--- a/packages/ui/src/button.js
+++ b/packages/ui/src/button.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import { Box } from '@theme-ui/components'
 
 const Button = ({ variant = 'primary', ...props }) => (
@@ -22,5 +23,9 @@ const Button = ({ variant = 'primary', ...props }) => (
     }}
   />
 )
+
+Button.propTypes = {
+  variant: PropTypes.string
+}
 
 export default Button

--- a/packages/ui/src/category-index-layout.js
+++ b/packages/ui/src/category-index-layout.js
@@ -4,6 +4,7 @@
  */
 
 import React, { Fragment } from 'react'
+import PropTypes from 'prop-types'
 import { Box } from '@theme-ui/components'
 
 import AnimatedPageBackground from './animated-page-background/index.js'
@@ -52,4 +53,9 @@ export function CategoryIndexHeroChrome({ children, overlayHeight = 'min(75vh, 1
       </Box>
     </Fragment>
   )
+}
+
+CategoryIndexHeroChrome.propTypes = {
+  children: PropTypes.node.isRequired,
+  overlayHeight: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
 }

--- a/packages/ui/src/category-label.js
+++ b/packages/ui/src/category-label.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import { Box } from '@theme-ui/components'
 
 /**
@@ -19,5 +20,10 @@ const CategoryLabel = ({ children, sx: sxProp = {}, ...props }) => (
     {children}
   </Box>
 )
+
+CategoryLabel.propTypes = {
+  children: PropTypes.node.isRequired,
+  sx: PropTypes.object
+}
 
 export default CategoryLabel

--- a/packages/ui/src/header.js
+++ b/packages/ui/src/header.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types'
 import { Box } from '@theme-ui/components'
 
 /**
@@ -11,6 +12,11 @@ const Header = ({ children, styles }) => {
       <Box sx={{ ...(styles ?? {}) }}>{children}</Box>
     </Box>
   )
+}
+
+Header.propTypes = {
+  children: PropTypes.node,
+  styles: PropTypes.object
 }
 
 export default Header

--- a/packages/ui/src/home-dashboard-layout.js
+++ b/packages/ui/src/home-dashboard-layout.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import { Box, Grid } from '@theme-ui/components'
 
 /** Theme UI `Grid` `columns` for the home dashboard: single column until `md`, then sidebar + main. */
@@ -55,4 +56,11 @@ export function HomeDashboardGrid({ aside, main, asideSx = {}, gridProps = {}, .
       {main}
     </Grid>
   )
+}
+
+HomeDashboardGrid.propTypes = {
+  aside: PropTypes.node.isRequired,
+  main: PropTypes.node.isRequired,
+  asideSx: PropTypes.object,
+  gridProps: PropTypes.object
 }

--- a/packages/ui/src/image-thumbnails.js
+++ b/packages/ui/src/image-thumbnails.js
@@ -2,6 +2,8 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { Box } from '@theme-ui/components'
 
+import { thumbnailSrcItem } from './prop-types-helpers.js'
+
 /** Default cap on thumbnails shown when `images` exceeds this count. */
 export const IMAGE_THUMBNAILS_DEFAULT_MAX = 4
 
@@ -87,8 +89,6 @@ const ImageThumbnails = ({
     </Box>
   )
 }
-
-const thumbnailSrcItem = PropTypes.oneOfType([PropTypes.string, PropTypes.oneOf([null, undefined])])
 
 ImageThumbnails.propTypes = {
   images: PropTypes.arrayOf(thumbnailSrcItem),

--- a/packages/ui/src/image-thumbnails.js
+++ b/packages/ui/src/image-thumbnails.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import { Box } from '@theme-ui/components'
 
 /** Default cap on thumbnails shown when `images` exceeds this count. */
@@ -85,6 +86,14 @@ const ImageThumbnails = ({
       })}
     </Box>
   )
+}
+
+const thumbnailSrcItem = PropTypes.oneOfType([PropTypes.string, PropTypes.oneOf([null, undefined])])
+
+ImageThumbnails.propTypes = {
+  images: PropTypes.arrayOf(thumbnailSrcItem),
+  maxImages: PropTypes.number,
+  optimizeSrc: PropTypes.func
 }
 
 export default ImageThumbnails

--- a/packages/ui/src/lazy-load.js
+++ b/packages/ui/src/lazy-load.js
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react'
+import PropTypes from 'prop-types'
 import { Box } from '@theme-ui/components'
 import { useInView } from 'react-intersection-observer'
 
@@ -15,6 +16,11 @@ const DefaultPlaceholder = ({ height = '100%', width = '100%' }) => (
     {' '}
   </Box>
 )
+
+DefaultPlaceholder.propTypes = {
+  height: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  width: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+}
 
 /**
  * Lazy Loader
@@ -55,6 +61,12 @@ const LazyLoad = ({ children, placeholder = <DefaultPlaceholder />, useInViewOpt
   }, [mounted, inView])
 
   return <Box ref={ref}>{revealed ? children : placeholder}</Box>
+}
+
+LazyLoad.propTypes = {
+  children: PropTypes.node.isRequired,
+  placeholder: PropTypes.node,
+  useInViewOptions: PropTypes.object
 }
 
 export default LazyLoad

--- a/packages/ui/src/metric-badge.js
+++ b/packages/ui/src/metric-badge.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import { Badge } from '@theme-ui/components'
 
 const MetricBadge = ({ children, ...props }) => (
@@ -6,5 +7,9 @@ const MetricBadge = ({ children, ...props }) => (
     {children}
   </Badge>
 )
+
+MetricBadge.propTypes = {
+  children: PropTypes.node.isRequired
+}
 
 export default MetricBadge

--- a/packages/ui/src/metric-card.js
+++ b/packages/ui/src/metric-card.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import { Box, Card, Text } from '@theme-ui/components'
 import { useThemeUI } from 'theme-ui'
 
@@ -91,6 +92,15 @@ const MetricCard = ({ title, value, loading = false, showPlaceholder, loadingSlo
       {body}
     </Card>
   )
+}
+
+MetricCard.propTypes = {
+  title: PropTypes.string,
+  value: PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.node]),
+  loading: PropTypes.bool,
+  showPlaceholder: PropTypes.bool,
+  loadingSlot: PropTypes.node,
+  sx: PropTypes.object
 }
 
 export default MetricCard

--- a/packages/ui/src/muted-card-footer.js
+++ b/packages/ui/src/muted-card-footer.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import { Box } from '@theme-ui/components'
 
 /**
@@ -18,5 +19,10 @@ const MutedCardFooter = ({ children, customStyles, ...props }) => (
     {children}
   </Box>
 )
+
+MutedCardFooter.propTypes = {
+  children: PropTypes.node.isRequired,
+  customStyles: PropTypes.object
+}
 
 export default MutedCardFooter

--- a/packages/ui/src/next/app-shell.js
+++ b/packages/ui/src/next/app-shell.js
@@ -1,6 +1,7 @@
 'use client'
 
 import { useEffect } from 'react'
+import PropTypes from 'prop-types'
 
 import { Box } from '@theme-ui/components'
 
@@ -41,4 +42,18 @@ export function ChronogroveNextAppShell({ children, theme = chronogroveTheme, cr
       </Box>
     </ChronogroveThemeProvider>
   )
+}
+
+const crossDomainColorModePropType = PropTypes.oneOfType([
+  PropTypes.shape({
+    registrableDomain: PropTypes.string,
+    cookieName: PropTypes.string
+  }),
+  PropTypes.oneOf([null])
+])
+
+ChronogroveNextAppShell.propTypes = {
+  children: PropTypes.node.isRequired,
+  theme: PropTypes.object,
+  crossDomainColorMode: crossDomainColorModePropType
 }

--- a/packages/ui/src/next/app-shell.js
+++ b/packages/ui/src/next/app-shell.js
@@ -2,6 +2,7 @@
 
 import { useEffect } from 'react'
 import PropTypes from 'prop-types'
+import { nullableCrossDomainColorMode } from '../prop-types-helpers.js'
 
 import { Box } from '@theme-ui/components'
 
@@ -44,16 +45,8 @@ export function ChronogroveNextAppShell({ children, theme = chronogroveTheme, cr
   )
 }
 
-const crossDomainColorModePropType = PropTypes.oneOfType([
-  PropTypes.shape({
-    registrableDomain: PropTypes.string,
-    cookieName: PropTypes.string
-  }),
-  PropTypes.oneOf([null])
-])
-
 ChronogroveNextAppShell.propTypes = {
   children: PropTypes.node.isRequired,
   theme: PropTypes.object,
-  crossDomainColorMode: crossDomainColorModePropType
+  crossDomainColorMode: nullableCrossDomainColorMode
 }

--- a/packages/ui/src/next/emotion-registry.js
+++ b/packages/ui/src/next/emotion-registry.js
@@ -1,6 +1,7 @@
 'use client'
 
 import * as React from 'react'
+import PropTypes from 'prop-types'
 import { CacheProvider } from '@emotion/react'
 import createCache from '@emotion/cache'
 import { useServerInsertedHTML } from 'next/navigation'
@@ -65,4 +66,8 @@ export function ChronogroveNextEmotionRegistry({ children }) {
   })
 
   return <CacheProvider value={cache}>{children}</CacheProvider>
+}
+
+ChronogroveNextEmotionRegistry.propTypes = {
+  children: PropTypes.node.isRequired
 }

--- a/packages/ui/src/next/root-layout-head.js
+++ b/packages/ui/src/next/root-layout-head.js
@@ -1,4 +1,4 @@
-import PropTypes from 'prop-types'
+import { nullableCrossDomainColorMode } from '../prop-types-helpers.js'
 
 import {
   chronogroveHeadTheme,
@@ -47,11 +47,5 @@ export function ChronogroveNextRootLayoutHead({ crossDomainColorMode = null } = 
 }
 
 ChronogroveNextRootLayoutHead.propTypes = {
-  crossDomainColorMode: PropTypes.oneOfType([
-    PropTypes.shape({
-      registrableDomain: PropTypes.string,
-      cookieName: PropTypes.string
-    }),
-    PropTypes.oneOf([null])
-  ])
+  crossDomainColorMode: nullableCrossDomainColorMode
 }

--- a/packages/ui/src/next/root-layout-head.js
+++ b/packages/ui/src/next/root-layout-head.js
@@ -1,3 +1,5 @@
+import PropTypes from 'prop-types'
+
 import {
   chronogroveHeadTheme,
   resolveChronogroveSurfaceColors,
@@ -42,4 +44,14 @@ export function ChronogroveNextRootLayoutHead({ crossDomainColorMode = null } = 
       <style dangerouslySetInnerHTML={{ __html: colorModeFallbackCSS }} />
     </>
   )
+}
+
+ChronogroveNextRootLayoutHead.propTypes = {
+  crossDomainColorMode: PropTypes.oneOfType([
+    PropTypes.shape({
+      registrableDomain: PropTypes.string,
+      cookieName: PropTypes.string
+    }),
+    PropTypes.oneOf([null])
+  ])
 }

--- a/packages/ui/src/page-header.js
+++ b/packages/ui/src/page-header.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import { Heading } from '@theme-ui/components'
 
 const PageHeader = ({ children }) => (
@@ -6,5 +7,9 @@ const PageHeader = ({ children }) => (
     {children}
   </Heading>
 )
+
+PageHeader.propTypes = {
+  children: PropTypes.node.isRequired
+}
 
 export default PageHeader

--- a/packages/ui/src/page-shell-layout.js
+++ b/packages/ui/src/page-shell-layout.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import { Box } from '@theme-ui/components'
 
 import { SkipNavContent, SkipNavLink } from './skip-nav/index.js'
@@ -54,4 +55,15 @@ export function ChronogrovePageShell({
       {!hideFooter && footer ? footer : null}
     </Box>
   )
+}
+
+ChronogrovePageShell.propTypes = {
+  children: PropTypes.node.isRequired,
+  disableMainWrapper: PropTypes.bool,
+  hideHeader: PropTypes.bool,
+  hideFooter: PropTypes.bool,
+  transparentBackground: PropTypes.bool,
+  paddingBottom: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+  header: PropTypes.node,
+  footer: PropTypes.node
 }

--- a/packages/ui/src/pagination-button.js
+++ b/packages/ui/src/pagination-button.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import { Box } from '@theme-ui/components'
 import { useThemeUI } from 'theme-ui'
 import isDarkMode from './helpers/isDarkMode.js'
@@ -101,6 +102,16 @@ const PaginationButton = ({
       {content}
     </Box>
   )
+}
+
+PaginationButton.propTypes = {
+  children: PropTypes.node,
+  onClick: PropTypes.func,
+  disabled: PropTypes.bool,
+  active: PropTypes.bool,
+  variant: PropTypes.oneOf(['primary', 'secondary', 'success', 'warning', 'danger']),
+  size: PropTypes.oneOf(['small', 'medium', 'large']),
+  icon: PropTypes.node
 }
 
 export default PaginationButton

--- a/packages/ui/src/pagination.js
+++ b/packages/ui/src/pagination.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import { Box } from '@theme-ui/components'
 
 import PaginationButton from './pagination-button.js'
@@ -193,6 +194,19 @@ const Pagination = ({
       )}
     </Box>
   )
+}
+
+Pagination.propTypes = {
+  currentPage: PropTypes.number.isRequired,
+  totalPages: PropTypes.number.isRequired,
+  onPageChange: PropTypes.func.isRequired,
+  variant: PropTypes.oneOf(['primary', 'secondary', 'success', 'warning', 'danger']),
+  size: PropTypes.oneOf(['small', 'medium', 'large']),
+  showPageInfo: PropTypes.bool,
+  maxVisiblePages: PropTypes.number,
+  simple: PropTypes.bool,
+  prevIcon: PropTypes.node,
+  nextIcon: PropTypes.node
 }
 
 export default Pagination

--- a/packages/ui/src/profile-metrics-badge.js
+++ b/packages/ui/src/profile-metrics-badge.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import { Badge, Box } from '@theme-ui/components'
 
 const ProfileMetricsBadge = ({ compact = false, isLoading, metrics = [] }) => {
@@ -27,6 +28,12 @@ const ProfileMetricsBadge = ({ compact = false, isLoading, metrics = [] }) => {
       ))}
     </Box>
   )
+}
+
+ProfileMetricsBadge.propTypes = {
+  compact: PropTypes.bool,
+  isLoading: PropTypes.bool,
+  metrics: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.object), PropTypes.oneOf([null])])
 }
 
 export default ProfileMetricsBadge

--- a/packages/ui/src/profile-metrics-badge.js
+++ b/packages/ui/src/profile-metrics-badge.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import { nullableObjectArray } from './prop-types-helpers.js'
 import { Badge, Box } from '@theme-ui/components'
 
 const ProfileMetricsBadge = ({ compact = false, isLoading, metrics = [] }) => {
@@ -33,7 +34,7 @@ const ProfileMetricsBadge = ({ compact = false, isLoading, metrics = [] }) => {
 ProfileMetricsBadge.propTypes = {
   compact: PropTypes.bool,
   isLoading: PropTypes.bool,
-  metrics: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.object), PropTypes.oneOf([null])])
+  metrics: nullableObjectArray
 }
 
 export default ProfileMetricsBadge

--- a/packages/ui/src/prop-types-helpers.js
+++ b/packages/ui/src/prop-types-helpers.js
@@ -1,0 +1,26 @@
+import PropTypes from 'prop-types'
+
+/**
+ * Explicit `null` as a PropTypes value (e.g. Zustand initial state, loading placeholders).
+ * Prefer `nullable*` helpers below; export this for one-off `oneOfType` compositions.
+ */
+export const nullLiteral = PropTypes.oneOf([null])
+
+export const nullableString = PropTypes.oneOfType([PropTypes.string, nullLiteral])
+export const nullableNumber = PropTypes.oneOfType([PropTypes.number, nullLiteral])
+export const nullableObject = PropTypes.oneOfType([PropTypes.object, nullLiteral])
+
+/** MDX / frontmatter fields that may be string, number, or null. */
+export const mdxMediaScalar = PropTypes.oneOfType([PropTypes.string, PropTypes.number, nullLiteral])
+
+export const nullableStringArray = PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.string), nullLiteral])
+
+/** Widget metric rows: array of objects or `null` while idle / loading. */
+export const nullableObjectArray = PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.object), nullLiteral])
+
+const crossDomainColorModeShape = PropTypes.shape({
+  registrableDomain: PropTypes.string,
+  cookieName: PropTypes.string
+})
+
+export const nullableCrossDomainColorMode = PropTypes.oneOfType([crossDomainColorModeShape, nullLiteral])

--- a/packages/ui/src/prop-types-helpers.js
+++ b/packages/ui/src/prop-types-helpers.js
@@ -15,6 +15,11 @@ export const mdxMediaScalar = PropTypes.oneOfType([PropTypes.string, PropTypes.n
 
 export const nullableStringArray = PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.string), nullLiteral])
 
+/**
+ * `@chronogrove/ui/image-thumbnails` entry: URL string or null/undefined (sparse lists, CDN optimizer holes).
+ */
+export const thumbnailSrcItem = PropTypes.oneOfType([PropTypes.string, PropTypes.oneOf([null, undefined])])
+
 /** Widget metric rows: array of objects or `null` while idle / loading. */
 export const nullableObjectArray = PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.object), nullLiteral])
 

--- a/packages/ui/src/provider.js
+++ b/packages/ui/src/provider.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import { Global } from '@emotion/react'
 import { ThemeUIProvider, InitializeColorMode } from 'theme-ui'
 
@@ -10,4 +11,12 @@ export function ChronogroveThemeProvider({ theme, children }) {
       {children}
     </ThemeUIProvider>
   )
+}
+
+ChronogroveThemeProvider.propTypes = {
+  /** Full Theme UI theme object (must include `global` for Emotion `Global`). */
+  theme: PropTypes.shape({
+    global: PropTypes.any
+  }).isRequired,
+  children: PropTypes.node.isRequired
 }

--- a/packages/ui/src/skip-nav/SkipNavContent.js
+++ b/packages/ui/src/skip-nav/SkipNavContent.js
@@ -1,4 +1,5 @@
 import React, { forwardRef } from 'react'
+import PropTypes from 'prop-types'
 
 const SkipNavContent = forwardRef(function SkipNavContent(
   { as: Comp = 'div', id = 'skip-nav-content', children, ...props },
@@ -12,5 +13,11 @@ const SkipNavContent = forwardRef(function SkipNavContent(
 })
 
 SkipNavContent.displayName = 'SkipNavContent'
+
+SkipNavContent.propTypes = {
+  as: PropTypes.oneOfType([PropTypes.string, PropTypes.elementType]),
+  id: PropTypes.string,
+  children: PropTypes.node
+}
 
 export default SkipNavContent

--- a/packages/ui/src/skip-nav/SkipNavLink.js
+++ b/packages/ui/src/skip-nav/SkipNavLink.js
@@ -1,4 +1,5 @@
 import React, { forwardRef } from 'react'
+import PropTypes from 'prop-types'
 import { Box } from '@theme-ui/components'
 import { useThemeUI } from 'theme-ui'
 import isDarkMode from '../helpers/isDarkMode.js'
@@ -69,5 +70,11 @@ const SkipNavLink = forwardRef(function SkipNavLink(
 })
 
 SkipNavLink.displayName = 'SkipNavLink'
+
+SkipNavLink.propTypes = {
+  as: PropTypes.oneOfType([PropTypes.string, PropTypes.elementType]),
+  children: PropTypes.node,
+  contentId: PropTypes.string
+}
 
 export default SkipNavLink

--- a/packages/ui/src/status-card.js
+++ b/packages/ui/src/status-card.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import { Card } from '@theme-ui/components'
 import { useThemeUI } from 'theme-ui'
 
@@ -13,6 +14,10 @@ const StatusCard = ({ message, ...props }) => {
       {message}
     </Card>
   )
+}
+
+StatusCard.propTypes = {
+  message: PropTypes.node.isRequired
 }
 
 export default StatusCard

--- a/packages/ui/src/thumbnail-strip.js
+++ b/packages/ui/src/thumbnail-strip.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import { Box } from '@theme-ui/components'
 
 /**
@@ -70,6 +71,12 @@ const ThumbnailStrip = ({ images = [], maxImages = 4, size = 36 }) => {
       })}
     </Box>
   )
+}
+
+ThumbnailStrip.propTypes = {
+  images: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.string, PropTypes.oneOf([null, undefined])])),
+  maxImages: PropTypes.number,
+  size: PropTypes.number
 }
 
 export default ThumbnailStrip

--- a/packages/ui/src/widget-call-to-action.js
+++ b/packages/ui/src/widget-call-to-action.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import { Box } from '@theme-ui/components'
 
 /**
@@ -102,6 +103,18 @@ export const WidgetCallToAction = ({
       {children}
     </Box>
   )
+}
+
+WidgetCallToAction.propTypes = {
+  children: PropTypes.node,
+  isLoading: PropTypes.bool,
+  loadingSlot: PropTypes.node,
+  title: PropTypes.string,
+  to: PropTypes.string,
+  url: PropTypes.string,
+  href: PropTypes.string,
+  linkComponent: PropTypes.elementType,
+  sx: PropTypes.object
 }
 
 export default WidgetCallToAction

--- a/packages/ui/src/widget-header.js
+++ b/packages/ui/src/widget-header.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { Box, Heading } from '@theme-ui/components'
 
@@ -183,6 +184,17 @@ const WidgetHeader = ({ aside, children, icon, metrics, metricsLoading, sx: sxPr
       )}
     </Box>
   )
+}
+
+WidgetHeader.propTypes = {
+  aside: PropTypes.node,
+  children: PropTypes.node.isRequired,
+  /** Font Awesome icon definition (object or array/tuple). */
+  icon: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
+  /** Chip data; loading state uses `{}` entries; shape varies slightly by widget (e.g. `displayName` / `value`). */
+  metrics: PropTypes.arrayOf(PropTypes.object),
+  metricsLoading: PropTypes.bool,
+  sx: PropTypes.object
 }
 
 export default WidgetHeader

--- a/packages/ui/src/widget-section.js
+++ b/packages/ui/src/widget-section.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import { Box } from '@theme-ui/components'
 import { useThemeUI } from 'theme-ui'
 
@@ -79,6 +80,14 @@ const WidgetSection = ({ children, hasFatalError, id, styleOverrides = {}, tabIn
       {children}
     </Box>
   )
+}
+
+WidgetSection.propTypes = {
+  children: PropTypes.node.isRequired,
+  hasFatalError: PropTypes.bool,
+  id: PropTypes.string,
+  styleOverrides: PropTypes.object,
+  tabIndex: PropTypes.number
 }
 
 export default WidgetSection

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -168,10 +168,13 @@ importers:
         version: 7.2.0
       '@theme-ui/components':
         specifier: 'catalog:'
-        version: 0.17.4(@emotion/react@11.14.0(react@19.2.6))(@theme-ui/theme-provider@0.17.4(@emotion/react@11.14.0(react@19.2.6))(react@19.2.6))(react@19.2.6)
+        version: 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@theme-ui/theme-provider@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react@19.2.6)
       next:
         specifier: 'catalog:'
         version: 16.2.6(@babel/core@7.29.0)(babel-plugin-macros@3.1.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      prop-types:
+        specifier: 'catalog:'
+        version: 15.8.1
       react:
         specifier: 'catalog:'
         version: 19.2.6
@@ -183,7 +186,7 @@ importers:
         version: 4.1.0(react@19.2.6)
       theme-ui:
         specifier: 'catalog:'
-        version: 0.17.4(@emotion/react@11.14.0(react@19.2.6))(react@19.2.6)
+        version: 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
 
   packages/theme:
     dependencies:
@@ -243,10 +246,10 @@ importers:
         version: 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))
       '@theme-ui/components':
         specifier: 'catalog:'
-        version: 0.17.4(@emotion/react@11.14.0(react@19.2.6))(@theme-ui/theme-provider@0.17.4(@emotion/react@11.14.0(react@19.2.6))(react@19.2.6))(react@19.2.6)
+        version: 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@theme-ui/theme-provider@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react@19.2.6)
       '@theme-ui/css':
         specifier: 'catalog:'
-        version: 0.17.4(@emotion/react@11.14.0(react@19.2.6))
+        version: 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))
       '@theme-ui/mdx':
         specifier: 'catalog:'
         version: 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/mdx@2.0.13)(react@19.2.6)
@@ -357,7 +360,7 @@ importers:
         version: 3.1.1
       theme-ui:
         specifier: 'catalog:'
-        version: 0.17.4(@emotion/react@11.14.0(react@19.2.6))(react@19.2.6)
+        version: 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
       three:
         specifier: 'catalog:'
         version: 0.184.0
@@ -421,7 +424,7 @@ importers:
         version: 4.1.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@theme-ui/components':
         specifier: 'catalog:'
-        version: 0.17.4(@emotion/react@11.14.0(react@19.2.6))(@theme-ui/theme-provider@0.17.4(@emotion/react@11.14.0(react@19.2.6))(react@19.2.6))(react@19.2.6)
+        version: 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@theme-ui/theme-provider@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react@19.2.6)
       '@theme-ui/presets':
         specifier: 'catalog:'
         version: 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6)))
@@ -433,7 +436,7 @@ importers:
         version: 10.0.3(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       theme-ui:
         specifier: 'catalog:'
-        version: 0.17.4(@emotion/react@11.14.0(react@19.2.6))(react@19.2.6)
+        version: 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
       three:
         specifier: 'catalog:'
         version: 0.184.0
@@ -482,7 +485,7 @@ importers:
         version: 3.1.1(@types/react@19.2.14)(react@19.2.6)
       '@theme-ui/components':
         specifier: 'catalog:'
-        version: 0.17.4(@emotion/react@11.14.0(react@19.2.6))(@theme-ui/theme-provider@0.17.4(@emotion/react@11.14.0(react@19.2.6))(react@19.2.6))(react@19.2.6)
+        version: 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@theme-ui/theme-provider@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react@19.2.6)
       '@theme-ui/mdx':
         specifier: 'catalog:'
         version: 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/mdx@2.0.13)(react@19.2.6)
@@ -527,7 +530,7 @@ importers:
         version: 8.0.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       theme-ui:
         specifier: 'catalog:'
-        version: 0.17.4(@emotion/react@11.14.0(react@19.2.6))(react@19.2.6)
+        version: 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
 
   websites/www.chronogrove.com:
     dependencies:
@@ -539,7 +542,7 @@ importers:
         version: 3.1.1(@types/react@19.2.14)(react@19.2.6)
       '@theme-ui/components':
         specifier: 'catalog:'
-        version: 0.17.4(@emotion/react@11.14.0(react@19.2.6))(@theme-ui/theme-provider@0.17.4(@emotion/react@11.14.0(react@19.2.6))(react@19.2.6))(react@19.2.6)
+        version: 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@theme-ui/theme-provider@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react@19.2.6)
       '@theme-ui/mdx':
         specifier: 'catalog:'
         version: 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/mdx@2.0.13)(react@19.2.6)
@@ -557,7 +560,7 @@ importers:
         version: 19.2.6(react@19.2.6)
       theme-ui:
         specifier: 'catalog:'
-        version: 0.17.4(@emotion/react@11.14.0(react@19.2.6))(react@19.2.6)
+        version: 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
 
 packages:
 
@@ -12000,122 +12003,122 @@ snapshots:
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
 
-  '@theme-ui/color-modes@0.17.4(@emotion/react@11.14.0(react@19.2.6))(react@19.2.6)':
+  '@theme-ui/color-modes@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.6)
-      '@theme-ui/core': 0.17.4(@emotion/react@11.14.0(react@19.2.6))(react@19.2.6)
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
+      '@theme-ui/core': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))
       deepmerge: 4.3.1
       react: 19.2.6
 
   '@theme-ui/color@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))':
     dependencies:
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))
       polished: 4.3.1
     transitivePeerDependencies:
       - '@emotion/react'
 
-  '@theme-ui/components@0.17.4(@emotion/react@11.14.0(react@19.2.6))(@theme-ui/theme-provider@0.17.4(@emotion/react@11.14.0(react@19.2.6))(react@19.2.6))(react@19.2.6)':
+  '@theme-ui/components@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@theme-ui/theme-provider@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.6)
       '@styled-system/color': 5.1.2
       '@styled-system/should-forward-prop': 5.1.5
       '@styled-system/space': 5.1.2
-      '@theme-ui/core': 0.17.4(@emotion/react@11.14.0(react@19.2.6))(react@19.2.6)
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
-      '@theme-ui/theme-provider': 0.17.4(@emotion/react@11.14.0(react@19.2.6))(react@19.2.6)
+      '@theme-ui/core': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))
+      '@theme-ui/theme-provider': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
       '@types/styled-system': 5.1.25
       react: 19.2.6
 
-  '@theme-ui/core@0.17.4(@emotion/react@11.14.0(react@19.2.6))(react@19.2.6)':
+  '@theme-ui/core@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.6)
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))
       deepmerge: 4.3.1
       react: 19.2.6
 
-  '@theme-ui/css@0.17.4(@emotion/react@11.14.0(react@19.2.6))':
+  '@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))':
     dependencies:
       '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.6)
       csstype: 3.2.3
 
-  '@theme-ui/global@0.17.4(@emotion/react@11.14.0(react@19.2.6))(react@19.2.6)':
+  '@theme-ui/global@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.6)
-      '@theme-ui/core': 0.17.4(@emotion/react@11.14.0(react@19.2.6))(react@19.2.6)
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
+      '@theme-ui/core': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))
       react: 19.2.6
 
   '@theme-ui/mdx@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/mdx@2.0.13)(react@19.2.6)':
     dependencies:
       '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.6)
-      '@theme-ui/core': 0.17.4(@emotion/react@11.14.0(react@19.2.6))(react@19.2.6)
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
+      '@theme-ui/core': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))
       '@types/mdx': 2.0.13
       react: 19.2.6
 
   '@theme-ui/preset-base@0.17.4(@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6)))':
     dependencies:
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))
 
   '@theme-ui/preset-bootstrap@0.17.4(@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6)))':
     dependencies:
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))
 
   '@theme-ui/preset-bulma@0.17.4(@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6)))':
     dependencies:
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))
       '@theme-ui/preset-base': 0.17.4(@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6)))
 
   '@theme-ui/preset-dark@0.17.4(@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6)))':
     dependencies:
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))
 
   '@theme-ui/preset-deep@0.17.4(@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6)))':
     dependencies:
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))
 
   '@theme-ui/preset-funk@0.17.4(@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6)))':
     dependencies:
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))
       '@theme-ui/preset-base': 0.17.4(@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6)))
 
   '@theme-ui/preset-future@0.17.4(@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6)))':
     dependencies:
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))
       '@theme-ui/preset-base': 0.17.4(@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6)))
 
   '@theme-ui/preset-polaris@0.17.4(@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6)))':
     dependencies:
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))
       '@theme-ui/preset-base': 0.17.4(@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6)))
 
   '@theme-ui/preset-roboto@0.17.4(@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6)))':
     dependencies:
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))
       '@theme-ui/preset-base': 0.17.4(@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6)))
 
   '@theme-ui/preset-sketchy@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))':
     dependencies:
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))
     transitivePeerDependencies:
       - '@emotion/react'
 
   '@theme-ui/preset-swiss@0.17.4(@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6)))':
     dependencies:
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))
 
   '@theme-ui/preset-system@0.17.4(@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6)))':
     dependencies:
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))
 
   '@theme-ui/preset-tailwind@0.17.4(@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6)))':
     dependencies:
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))
 
   '@theme-ui/preset-tosh@0.17.4(@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6)))':
     dependencies:
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))
 
   '@theme-ui/presets@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6)))':
     dependencies:
@@ -12139,10 +12142,10 @@ snapshots:
 
   '@theme-ui/prism@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@theme-ui/mdx@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/mdx@2.0.13)(react@19.2.6))(react@19.2.6)(theme-ui@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))':
     dependencies:
-      '@theme-ui/core': 0.17.4(@emotion/react@11.14.0(react@19.2.6))(react@19.2.6)
+      '@theme-ui/core': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
       '@theme-ui/mdx': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/mdx@2.0.13)(react@19.2.6)
       prism-react-renderer: 1.3.5(react@19.2.6)
-      theme-ui: 0.17.4(@emotion/react@11.14.0(react@19.2.6))(react@19.2.6)
+      theme-ui: 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
     transitivePeerDependencies:
       - '@emotion/react'
       - react
@@ -12150,23 +12153,23 @@ snapshots:
   '@theme-ui/style-guide@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6)))(react@19.2.6)(theme-ui@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))':
     dependencies:
       '@theme-ui/color': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))
-      '@theme-ui/core': 0.17.4(@emotion/react@11.14.0(react@19.2.6))(react@19.2.6)
+      '@theme-ui/core': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
       '@theme-ui/presets': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6)))
       '@types/color': 3.0.7
       color: 3.2.1
       lodash.get: 4.4.2
       react: 19.2.6
-      theme-ui: 0.17.4(@emotion/react@11.14.0(react@19.2.6))(react@19.2.6)
+      theme-ui: 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
     transitivePeerDependencies:
       - '@emotion/react'
       - '@theme-ui/css'
 
-  '@theme-ui/theme-provider@0.17.4(@emotion/react@11.14.0(react@19.2.6))(react@19.2.6)':
+  '@theme-ui/theme-provider@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.6)
-      '@theme-ui/color-modes': 0.17.4(@emotion/react@11.14.0(react@19.2.6))(react@19.2.6)
-      '@theme-ui/core': 0.17.4(@emotion/react@11.14.0(react@19.2.6))(react@19.2.6)
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
+      '@theme-ui/color-modes': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
+      '@theme-ui/core': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))
       react: 19.2.6
 
   '@tokenizer/token@0.3.0': {}
@@ -15570,11 +15573,11 @@ snapshots:
     dependencies:
       '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.6)
       '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@19.2.6)
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))
       '@theme-ui/mdx': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/mdx@2.0.13)(react@19.2.6)
       gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)
       react: 19.2.6
-      theme-ui: 0.17.4(@emotion/react@11.14.0(react@19.2.6))(react@19.2.6)
+      theme-ui: 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
 
   gatsby-plugin-typescript@5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)):
     dependencies:
@@ -15734,7 +15737,7 @@ snapshots:
       gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
-      theme-ui: 0.17.4(@emotion/react@11.14.0(react@19.2.6))(react@19.2.6)
+      theme-ui: 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
     transitivePeerDependencies:
       - '@emotion/react'
       - '@theme-ui/css'
@@ -20738,15 +20741,15 @@ snapshots:
 
   text-table@0.2.0: {}
 
-  theme-ui@0.17.4(@emotion/react@11.14.0(react@19.2.6))(react@19.2.6):
+  theme-ui@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6):
     dependencies:
       '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.6)
-      '@theme-ui/color-modes': 0.17.4(@emotion/react@11.14.0(react@19.2.6))(react@19.2.6)
-      '@theme-ui/components': 0.17.4(@emotion/react@11.14.0(react@19.2.6))(@theme-ui/theme-provider@0.17.4(@emotion/react@11.14.0(react@19.2.6))(react@19.2.6))(react@19.2.6)
-      '@theme-ui/core': 0.17.4(@emotion/react@11.14.0(react@19.2.6))(react@19.2.6)
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
-      '@theme-ui/global': 0.17.4(@emotion/react@11.14.0(react@19.2.6))(react@19.2.6)
-      '@theme-ui/theme-provider': 0.17.4(@emotion/react@11.14.0(react@19.2.6))(react@19.2.6)
+      '@theme-ui/color-modes': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
+      '@theme-ui/components': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@theme-ui/theme-provider@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react@19.2.6)
+      '@theme-ui/core': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))
+      '@theme-ui/global': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
+      '@theme-ui/theme-provider': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
       react: 19.2.6
 
   three@0.184.0: {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -168,7 +168,7 @@ importers:
         version: 7.2.0
       '@theme-ui/components':
         specifier: 'catalog:'
-        version: 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@theme-ui/theme-provider@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react@19.2.6)
+        version: 0.17.4(@emotion/react@11.14.0(react@19.2.6))(@theme-ui/theme-provider@0.17.4(@emotion/react@11.14.0(react@19.2.6))(react@19.2.6))(react@19.2.6)
       next:
         specifier: 'catalog:'
         version: 16.2.6(@babel/core@7.29.0)(babel-plugin-macros@3.1.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -183,7 +183,7 @@ importers:
         version: 4.1.0(react@19.2.6)
       theme-ui:
         specifier: 'catalog:'
-        version: 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
+        version: 0.17.4(@emotion/react@11.14.0(react@19.2.6))(react@19.2.6)
 
   packages/theme:
     dependencies:
@@ -243,10 +243,10 @@ importers:
         version: 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))
       '@theme-ui/components':
         specifier: 'catalog:'
-        version: 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@theme-ui/theme-provider@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react@19.2.6)
+        version: 0.17.4(@emotion/react@11.14.0(react@19.2.6))(@theme-ui/theme-provider@0.17.4(@emotion/react@11.14.0(react@19.2.6))(react@19.2.6))(react@19.2.6)
       '@theme-ui/css':
         specifier: 'catalog:'
-        version: 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))
+        version: 0.17.4(@emotion/react@11.14.0(react@19.2.6))
       '@theme-ui/mdx':
         specifier: 'catalog:'
         version: 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/mdx@2.0.13)(react@19.2.6)
@@ -357,7 +357,7 @@ importers:
         version: 3.1.1
       theme-ui:
         specifier: 'catalog:'
-        version: 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
+        version: 0.17.4(@emotion/react@11.14.0(react@19.2.6))(react@19.2.6)
       three:
         specifier: 'catalog:'
         version: 0.184.0
@@ -421,16 +421,19 @@ importers:
         version: 4.1.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@theme-ui/components':
         specifier: 'catalog:'
-        version: 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@theme-ui/theme-provider@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react@19.2.6)
+        version: 0.17.4(@emotion/react@11.14.0(react@19.2.6))(@theme-ui/theme-provider@0.17.4(@emotion/react@11.14.0(react@19.2.6))(react@19.2.6))(react@19.2.6)
       '@theme-ui/presets':
         specifier: 'catalog:'
         version: 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6)))
+      prop-types:
+        specifier: 'catalog:'
+        version: 15.8.1
       react-intersection-observer:
         specifier: 'catalog:'
         version: 10.0.3(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       theme-ui:
         specifier: 'catalog:'
-        version: 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
+        version: 0.17.4(@emotion/react@11.14.0(react@19.2.6))(react@19.2.6)
       three:
         specifier: 'catalog:'
         version: 0.184.0
@@ -479,7 +482,7 @@ importers:
         version: 3.1.1(@types/react@19.2.14)(react@19.2.6)
       '@theme-ui/components':
         specifier: 'catalog:'
-        version: 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@theme-ui/theme-provider@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react@19.2.6)
+        version: 0.17.4(@emotion/react@11.14.0(react@19.2.6))(@theme-ui/theme-provider@0.17.4(@emotion/react@11.14.0(react@19.2.6))(react@19.2.6))(react@19.2.6)
       '@theme-ui/mdx':
         specifier: 'catalog:'
         version: 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/mdx@2.0.13)(react@19.2.6)
@@ -524,7 +527,7 @@ importers:
         version: 8.0.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       theme-ui:
         specifier: 'catalog:'
-        version: 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
+        version: 0.17.4(@emotion/react@11.14.0(react@19.2.6))(react@19.2.6)
 
   websites/www.chronogrove.com:
     dependencies:
@@ -536,7 +539,7 @@ importers:
         version: 3.1.1(@types/react@19.2.14)(react@19.2.6)
       '@theme-ui/components':
         specifier: 'catalog:'
-        version: 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@theme-ui/theme-provider@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react@19.2.6)
+        version: 0.17.4(@emotion/react@11.14.0(react@19.2.6))(@theme-ui/theme-provider@0.17.4(@emotion/react@11.14.0(react@19.2.6))(react@19.2.6))(react@19.2.6)
       '@theme-ui/mdx':
         specifier: 'catalog:'
         version: 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/mdx@2.0.13)(react@19.2.6)
@@ -554,7 +557,7 @@ importers:
         version: 19.2.6(react@19.2.6)
       theme-ui:
         specifier: 'catalog:'
-        version: 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
+        version: 0.17.4(@emotion/react@11.14.0(react@19.2.6))(react@19.2.6)
 
 packages:
 
@@ -11997,122 +12000,122 @@ snapshots:
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
 
-  '@theme-ui/color-modes@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)':
+  '@theme-ui/color-modes@0.17.4(@emotion/react@11.14.0(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.6)
-      '@theme-ui/core': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))
+      '@theme-ui/core': 0.17.4(@emotion/react@11.14.0(react@19.2.6))(react@19.2.6)
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
       deepmerge: 4.3.1
       react: 19.2.6
 
   '@theme-ui/color@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))':
     dependencies:
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
       polished: 4.3.1
     transitivePeerDependencies:
       - '@emotion/react'
 
-  '@theme-ui/components@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@theme-ui/theme-provider@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react@19.2.6)':
+  '@theme-ui/components@0.17.4(@emotion/react@11.14.0(react@19.2.6))(@theme-ui/theme-provider@0.17.4(@emotion/react@11.14.0(react@19.2.6))(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.6)
       '@styled-system/color': 5.1.2
       '@styled-system/should-forward-prop': 5.1.5
       '@styled-system/space': 5.1.2
-      '@theme-ui/core': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))
-      '@theme-ui/theme-provider': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
+      '@theme-ui/core': 0.17.4(@emotion/react@11.14.0(react@19.2.6))(react@19.2.6)
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
+      '@theme-ui/theme-provider': 0.17.4(@emotion/react@11.14.0(react@19.2.6))(react@19.2.6)
       '@types/styled-system': 5.1.25
       react: 19.2.6
 
-  '@theme-ui/core@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)':
+  '@theme-ui/core@0.17.4(@emotion/react@11.14.0(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.6)
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
       deepmerge: 4.3.1
       react: 19.2.6
 
-  '@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))':
+  '@theme-ui/css@0.17.4(@emotion/react@11.14.0(react@19.2.6))':
     dependencies:
       '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.6)
       csstype: 3.2.3
 
-  '@theme-ui/global@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)':
+  '@theme-ui/global@0.17.4(@emotion/react@11.14.0(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.6)
-      '@theme-ui/core': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))
+      '@theme-ui/core': 0.17.4(@emotion/react@11.14.0(react@19.2.6))(react@19.2.6)
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
       react: 19.2.6
 
   '@theme-ui/mdx@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/mdx@2.0.13)(react@19.2.6)':
     dependencies:
       '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.6)
-      '@theme-ui/core': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))
+      '@theme-ui/core': 0.17.4(@emotion/react@11.14.0(react@19.2.6))(react@19.2.6)
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
       '@types/mdx': 2.0.13
       react: 19.2.6
 
   '@theme-ui/preset-base@0.17.4(@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6)))':
     dependencies:
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
 
   '@theme-ui/preset-bootstrap@0.17.4(@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6)))':
     dependencies:
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
 
   '@theme-ui/preset-bulma@0.17.4(@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6)))':
     dependencies:
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
       '@theme-ui/preset-base': 0.17.4(@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6)))
 
   '@theme-ui/preset-dark@0.17.4(@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6)))':
     dependencies:
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
 
   '@theme-ui/preset-deep@0.17.4(@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6)))':
     dependencies:
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
 
   '@theme-ui/preset-funk@0.17.4(@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6)))':
     dependencies:
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
       '@theme-ui/preset-base': 0.17.4(@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6)))
 
   '@theme-ui/preset-future@0.17.4(@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6)))':
     dependencies:
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
       '@theme-ui/preset-base': 0.17.4(@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6)))
 
   '@theme-ui/preset-polaris@0.17.4(@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6)))':
     dependencies:
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
       '@theme-ui/preset-base': 0.17.4(@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6)))
 
   '@theme-ui/preset-roboto@0.17.4(@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6)))':
     dependencies:
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
       '@theme-ui/preset-base': 0.17.4(@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6)))
 
   '@theme-ui/preset-sketchy@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))':
     dependencies:
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
     transitivePeerDependencies:
       - '@emotion/react'
 
   '@theme-ui/preset-swiss@0.17.4(@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6)))':
     dependencies:
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
 
   '@theme-ui/preset-system@0.17.4(@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6)))':
     dependencies:
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
 
   '@theme-ui/preset-tailwind@0.17.4(@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6)))':
     dependencies:
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
 
   '@theme-ui/preset-tosh@0.17.4(@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6)))':
     dependencies:
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
 
   '@theme-ui/presets@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6)))':
     dependencies:
@@ -12136,10 +12139,10 @@ snapshots:
 
   '@theme-ui/prism@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@theme-ui/mdx@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/mdx@2.0.13)(react@19.2.6))(react@19.2.6)(theme-ui@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))':
     dependencies:
-      '@theme-ui/core': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
+      '@theme-ui/core': 0.17.4(@emotion/react@11.14.0(react@19.2.6))(react@19.2.6)
       '@theme-ui/mdx': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/mdx@2.0.13)(react@19.2.6)
       prism-react-renderer: 1.3.5(react@19.2.6)
-      theme-ui: 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
+      theme-ui: 0.17.4(@emotion/react@11.14.0(react@19.2.6))(react@19.2.6)
     transitivePeerDependencies:
       - '@emotion/react'
       - react
@@ -12147,23 +12150,23 @@ snapshots:
   '@theme-ui/style-guide@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6)))(react@19.2.6)(theme-ui@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))':
     dependencies:
       '@theme-ui/color': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))
-      '@theme-ui/core': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
+      '@theme-ui/core': 0.17.4(@emotion/react@11.14.0(react@19.2.6))(react@19.2.6)
       '@theme-ui/presets': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6)))
       '@types/color': 3.0.7
       color: 3.2.1
       lodash.get: 4.4.2
       react: 19.2.6
-      theme-ui: 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
+      theme-ui: 0.17.4(@emotion/react@11.14.0(react@19.2.6))(react@19.2.6)
     transitivePeerDependencies:
       - '@emotion/react'
       - '@theme-ui/css'
 
-  '@theme-ui/theme-provider@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)':
+  '@theme-ui/theme-provider@0.17.4(@emotion/react@11.14.0(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.6)
-      '@theme-ui/color-modes': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
-      '@theme-ui/core': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))
+      '@theme-ui/color-modes': 0.17.4(@emotion/react@11.14.0(react@19.2.6))(react@19.2.6)
+      '@theme-ui/core': 0.17.4(@emotion/react@11.14.0(react@19.2.6))(react@19.2.6)
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
       react: 19.2.6
 
   '@tokenizer/token@0.3.0': {}
@@ -15567,11 +15570,11 @@ snapshots:
     dependencies:
       '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.6)
       '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@19.2.6)
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
       '@theme-ui/mdx': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/mdx@2.0.13)(react@19.2.6)
       gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)
       react: 19.2.6
-      theme-ui: 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
+      theme-ui: 0.17.4(@emotion/react@11.14.0(react@19.2.6))(react@19.2.6)
 
   gatsby-plugin-typescript@5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)):
     dependencies:
@@ -15731,7 +15734,7 @@ snapshots:
       gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
-      theme-ui: 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
+      theme-ui: 0.17.4(@emotion/react@11.14.0(react@19.2.6))(react@19.2.6)
     transitivePeerDependencies:
       - '@emotion/react'
       - '@theme-ui/css'
@@ -20735,15 +20738,15 @@ snapshots:
 
   text-table@0.2.0: {}
 
-  theme-ui@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6):
+  theme-ui@0.17.4(@emotion/react@11.14.0(react@19.2.6))(react@19.2.6):
     dependencies:
       '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.6)
-      '@theme-ui/color-modes': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
-      '@theme-ui/components': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@theme-ui/theme-provider@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react@19.2.6)
-      '@theme-ui/core': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))
-      '@theme-ui/global': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
-      '@theme-ui/theme-provider': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
+      '@theme-ui/color-modes': 0.17.4(@emotion/react@11.14.0(react@19.2.6))(react@19.2.6)
+      '@theme-ui/components': 0.17.4(@emotion/react@11.14.0(react@19.2.6))(@theme-ui/theme-provider@0.17.4(@emotion/react@11.14.0(react@19.2.6))(react@19.2.6))(react@19.2.6)
+      '@theme-ui/core': 0.17.4(@emotion/react@11.14.0(react@19.2.6))(react@19.2.6)
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
+      '@theme-ui/global': 0.17.4(@emotion/react@11.14.0(react@19.2.6))(react@19.2.6)
+      '@theme-ui/theme-provider': 0.17.4(@emotion/react@11.14.0(react@19.2.6))(react@19.2.6)
       react: 19.2.6
 
   three@0.184.0: {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -107,32 +107,32 @@ importers:
         version: 4.18.1
     devDependencies:
       '@eslint/js':
-        specifier: ^10.0.1
-        version: 10.0.1(eslint@10.3.0)
+        specifier: ^9.39.4
+        version: 9.39.4
       eslint:
-        specifier: ^10.3.0
-        version: 10.3.0
+        specifier: ^9.39.4
+        version: 9.39.4
       eslint-config-prettier:
         specifier: ^10.1.8
-        version: 10.1.8(eslint@10.3.0)
+        version: 10.1.8(eslint@9.39.4)
       eslint-plugin-jest:
         specifier: ^29.15.2
-        version: 29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3)
+        version: 29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3)
       eslint-plugin-json:
         specifier: ^4.0.1
         version: 4.0.1
       eslint-plugin-jsx-a11y:
         specifier: ^6.10.2
-        version: 6.10.2(eslint@10.3.0)
+        version: 6.10.2(eslint@9.39.4)
       eslint-plugin-prettier:
         specifier: ^5.5.5
-        version: 5.5.5(@types/eslint@9.6.1)(eslint-config-prettier@10.1.8(eslint@10.3.0))(eslint@10.3.0)(prettier@3.8.3)
+        version: 5.5.5(@types/eslint@9.6.1)(eslint-config-prettier@10.1.8(eslint@9.39.4))(eslint@9.39.4)(prettier@3.8.3)
       eslint-plugin-react:
         specifier: ^7.37.5
-        version: 7.37.5(eslint@10.3.0)
+        version: 7.37.5(eslint@9.39.4)
       eslint-plugin-react-hooks:
         specifier: ^7.1.1
-        version: 7.1.1(eslint@10.3.0)
+        version: 7.1.1(eslint@9.39.4)
       husky:
         specifier: ^9.1.7
         version: 9.1.7
@@ -264,52 +264,52 @@ importers:
         version: 2.5.1
       gatsby-plugin-emotion:
         specifier: ^8.16.0
-        version: 8.16.0(@babel/core@7.29.0)(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3))
+        version: 8.16.0(@babel/core@7.29.0)(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3))
       gatsby-plugin-feed:
         specifier: ^5.16.0
-        version: 5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3))(graphql@16.14.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3))(graphql@16.14.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       gatsby-plugin-manifest:
         specifier: ^5.16.0
-        version: 5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3))(graphql@16.14.0)
+        version: 5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3))(graphql@16.14.0)
       gatsby-plugin-mdx:
         specifier: ^5.16.0
-        version: 5.16.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6))(gatsby-source-filesystem@5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)))(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3))(graphql@16.14.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 5.16.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6))(gatsby-source-filesystem@5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)))(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3))(graphql@16.14.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       gatsby-plugin-sharp:
         specifier: ^5.16.0
-        version: 5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3))(graphql@16.14.0)
+        version: 5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3))(graphql@16.14.0)
       gatsby-plugin-theme-ui:
         specifier: ^0.17.4
-        version: 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6))(@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6)))(@theme-ui/mdx@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/mdx@2.0.13)(react@19.2.6))(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3))(react@19.2.6)(theme-ui@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))
+        version: 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6))(@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6)))(@theme-ui/mdx@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/mdx@2.0.13)(react@19.2.6))(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3))(react@19.2.6)(theme-ui@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))
       gatsby-remark-autolink-headers:
         specifier: ^6.16.0
-        version: 6.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 6.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       gatsby-remark-copy-linked-files:
         specifier: ^6.16.0
-        version: 6.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3))
+        version: 6.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3))
       gatsby-remark-embed-video:
         specifier: ^3.2.1
         version: 3.2.1
       gatsby-remark-images:
         specifier: ^7.16.0
-        version: 7.16.0(gatsby-plugin-sharp@5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3))(graphql@16.14.0))(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3))
+        version: 7.16.0(gatsby-plugin-sharp@5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3))(graphql@16.14.0))(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3))
       gatsby-remark-prismjs:
         specifier: ^7.16.0
-        version: 7.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3))(prismjs@1.30.0)
+        version: 7.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3))(prismjs@1.30.0)
       gatsby-source-filesystem:
         specifier: ^5.16.0
-        version: 5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3))
+        version: 5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3))
       gatsby-theme-style-guide:
         specifier: ^0.17.4
-        version: 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6)))(@types/mdx@2.0.13)(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6)))(@types/mdx@2.0.13)(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       gatsby-transformer-json:
         specifier: ^5.16.0
-        version: 5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3))
+        version: 5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3))
       gatsby-transformer-remark:
         specifier: ^6.16.0
-        version: 6.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3))
+        version: 6.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3))
       gatsby-transformer-sharp:
         specifier: ^5.16.0
-        version: 5.16.0(gatsby-plugin-sharp@5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3))(graphql@16.14.0))(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3))(graphql@16.14.0)
+        version: 5.16.0(gatsby-plugin-sharp@5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3))(graphql@16.14.0))(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3))(graphql@16.14.0)
       html-react-parser:
         specifier: ^5.2.17
         version: 5.2.17(@types/react@19.2.14)(react@19.2.6)
@@ -382,7 +382,7 @@ importers:
         version: 3.16.0(@babel/core@7.29.0)(core-js@3.49.0)
       gatsby:
         specifier: 'catalog:'
-        version: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)
+        version: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)
       husky:
         specifier: ^9.1.7
         version: 9.1.7
@@ -491,16 +491,16 @@ importers:
         version: 7.9.0
       gatsby:
         specifier: 'catalog:'
-        version: 5.16.1(babel-eslint@10.1.0(eslint@10.3.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)
+        version: 5.16.1(babel-eslint@10.1.0(eslint@9.39.4))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)
       gatsby-plugin-google-gtag:
         specifier: 'catalog:'
-        version: 5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@10.3.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@9.39.4))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       gatsby-plugin-robots-txt:
         specifier: 'catalog:'
-        version: 1.8.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@10.3.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3))
+        version: 1.8.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@9.39.4))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3))
       gatsby-plugin-sitemap:
         specifier: 'catalog:'
-        version: 6.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@10.3.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 6.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@9.39.4))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       gatsby-theme-chronogrove:
         specifier: workspace:*
         version: link:../../packages/theme
@@ -542,7 +542,7 @@ importers:
         version: 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/mdx@2.0.13)(react@19.2.6)
       gatsby:
         specifier: 'catalog:'
-        version: 5.16.1(babel-eslint@10.1.0(eslint@10.3.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)
+        version: 5.16.1(babel-eslint@10.1.0(eslint@9.39.4))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)
       gatsby-theme-chronogrove:
         specifier: workspace:*
         version: link:../../packages/theme
@@ -1406,38 +1406,37 @@ packages:
     resolution: {integrity: sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==}
     engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
 
-  '@eslint/config-array@0.23.5':
-    resolution: {integrity: sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==}
-    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+  '@eslint/config-array@0.21.2':
+    resolution: {integrity: sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@eslint/config-helpers@0.5.5':
-    resolution: {integrity: sha512-eIJYKTCECbP/nsKaaruF6LW967mtbQbsw4JTtSVkUQc9MneSkbrgPJAbKl9nWr0ZeowV8BfsarBmPpBzGelA2w==}
-    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+  '@eslint/config-helpers@0.4.2':
+    resolution: {integrity: sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@eslint/core@1.2.1':
-    resolution: {integrity: sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==}
-    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+  '@eslint/core@0.17.0':
+    resolution: {integrity: sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@eslint/eslintrc@0.4.3':
     resolution: {integrity: sha512-J6KFFz5QCYUJq3pf0mjEcCJVERbzv71PUIDczuh9JkwGEzced6CO5ADLHB1rbf/+oPBtoPfMYNOpGDzCANlbXw==}
     engines: {node: ^10.12.0 || >=12.0.0}
 
-  '@eslint/js@10.0.1':
-    resolution: {integrity: sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==}
-    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
-    peerDependencies:
-      eslint: ^10.0.0
-    peerDependenciesMeta:
-      eslint:
-        optional: true
+  '@eslint/eslintrc@3.3.5':
+    resolution: {integrity: sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@eslint/object-schema@3.0.5':
-    resolution: {integrity: sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==}
-    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+  '@eslint/js@9.39.4':
+    resolution: {integrity: sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@eslint/plugin-kit@0.7.1':
-    resolution: {integrity: sha512-rZAP3aVgB9ds9KOeUSL+zZ21hPmo8dh6fnIFwRQj5EAZl9gzR7wxYbYXYysAM8CTqGmUGyp2S4kUdV17MnGuWQ==}
-    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+  '@eslint/object-schema@2.1.7':
+    resolution: {integrity: sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/plugin-kit@0.4.1':
+    resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@expo/devcert@1.2.1':
     resolution: {integrity: sha512-qC4eaxmKMTmJC2ahwyui6ud8f3W60Ss7pMkpBq40Hu3zyiAaugPXnZ24145U7K36qO9UHdZUVxsCvIpz2RYYCA==}
@@ -2697,9 +2696,6 @@ packages:
   '@types/eslint@9.6.1':
     resolution: {integrity: sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==}
 
-  '@types/esrecurse@4.3.1':
-    resolution: {integrity: sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==}
-
   '@types/estree-jsx@1.0.5':
     resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
 
@@ -3271,6 +3267,9 @@ packages:
 
   argparse@1.0.10:
     resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
+
+  argparse@2.0.1:
+    resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
   aria-query@5.3.0:
     resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
@@ -4749,9 +4748,9 @@ packages:
     resolution: {integrity: sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==}
     engines: {node: '>=8.0.0'}
 
-  eslint-scope@9.1.2:
-    resolution: {integrity: sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==}
-    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+  eslint-scope@8.4.0:
+    resolution: {integrity: sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   eslint-utils@2.1.0:
     resolution: {integrity: sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==}
@@ -4769,6 +4768,10 @@ packages:
     resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
+  eslint-visitor-keys@4.2.1:
+    resolution: {integrity: sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   eslint-visitor-keys@5.0.1:
     resolution: {integrity: sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
@@ -4780,9 +4783,15 @@ packages:
       eslint: ^7.0.0 || ^8.0.0
       webpack: ^4.0.0 || ^5.0.0
 
-  eslint@10.3.0:
-    resolution: {integrity: sha512-XbEXaRva5cF0ZQB8w6MluHA0kZZfV2DuCMJ3ozyEOHLwDpZX2Lmm/7Pp0xdJmI0GL1W05VH5VwIFHEm1Vcw2gw==}
-    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+  eslint@7.32.0:
+    resolution: {integrity: sha512-VHZ8gX+EDfz+97jGcgyGCyRia/dPOd6Xh9yPv8Bl1+SoaIwD+a/vlrOmGRUyOYu7MwUhc7CxqeaDZU13S4+EpA==}
+    engines: {node: ^10.12.0 || >=12.0.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
+    hasBin: true
+
+  eslint@9.39.4:
+    resolution: {integrity: sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     hasBin: true
     peerDependencies:
       jiti: '*'
@@ -4790,19 +4799,13 @@ packages:
       jiti:
         optional: true
 
-  eslint@7.32.0:
-    resolution: {integrity: sha512-VHZ8gX+EDfz+97jGcgyGCyRia/dPOd6Xh9yPv8Bl1+SoaIwD+a/vlrOmGRUyOYu7MwUhc7CxqeaDZU13S4+EpA==}
-    engines: {node: ^10.12.0 || >=12.0.0}
-    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
-    hasBin: true
-
   esniff@2.0.1:
     resolution: {integrity: sha512-kTUIGKQ/mDPFoJ0oVfcmyJn4iBDRptjNVIzwIFR7tqWXdVI9xfA2RMwY/gbSpJG3lkdWNEjLap/NqVHZiJsdfg==}
     engines: {node: '>=0.10'}
 
-  espree@11.2.0:
-    resolution: {integrity: sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==}
-    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+  espree@10.4.0:
+    resolution: {integrity: sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   espree@7.3.1:
     resolution: {integrity: sha512-v3JCNCE64umkFpmkFGqzVKsOT0tN1Zr+ueqLZfpV1Ob8e+CEgPWa+OxCoGH3tnhimMKIaBm4m/vaRpJ/krRz2g==}
@@ -5463,6 +5466,10 @@ packages:
   globals@13.24.0:
     resolution: {integrity: sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==}
     engines: {node: '>=8'}
+
+  globals@14.0.0:
+    resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
+    engines: {node: '>=18'}
 
   globalthis@1.0.4:
     resolution: {integrity: sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==}
@@ -6327,6 +6334,10 @@ packages:
 
   js-yaml@3.14.2:
     resolution: {integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==}
+    hasBin: true
+
+  js-yaml@4.1.1:
+    resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
 
   jsdom@26.1.0:
@@ -10667,31 +10678,31 @@ snapshots:
 
   '@emotion/weak-memoize@0.4.0': {}
 
-  '@eslint-community/eslint-utils@4.9.1(eslint@10.3.0)':
-    dependencies:
-      eslint: 10.3.0
-      eslint-visitor-keys: 3.4.3
-
   '@eslint-community/eslint-utils@4.9.1(eslint@7.32.0)':
     dependencies:
       eslint: 7.32.0
       eslint-visitor-keys: 3.4.3
 
+  '@eslint-community/eslint-utils@4.9.1(eslint@9.39.4)':
+    dependencies:
+      eslint: 9.39.4
+      eslint-visitor-keys: 3.4.3
+
   '@eslint-community/regexpp@4.12.2': {}
 
-  '@eslint/config-array@0.23.5':
+  '@eslint/config-array@0.21.2':
     dependencies:
-      '@eslint/object-schema': 3.0.5
+      '@eslint/object-schema': 2.1.7
       debug: 4.4.3
-      minimatch: 10.2.5
+      minimatch: 3.1.5
     transitivePeerDependencies:
       - supports-color
 
-  '@eslint/config-helpers@0.5.5':
+  '@eslint/config-helpers@0.4.2':
     dependencies:
-      '@eslint/core': 1.2.1
+      '@eslint/core': 0.17.0
 
-  '@eslint/core@1.2.1':
+  '@eslint/core@0.17.0':
     dependencies:
       '@types/json-schema': 7.0.15
 
@@ -10709,15 +10720,27 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@eslint/js@10.0.1(eslint@10.3.0)':
-    optionalDependencies:
-      eslint: 10.3.0
-
-  '@eslint/object-schema@3.0.5': {}
-
-  '@eslint/plugin-kit@0.7.1':
+  '@eslint/eslintrc@3.3.5':
     dependencies:
-      '@eslint/core': 1.2.1
+      ajv: 6.15.0
+      debug: 4.4.3
+      espree: 10.4.0
+      globals: 14.0.0
+      ignore: 5.3.2
+      import-fresh: 3.3.1
+      js-yaml: 4.1.1
+      minimatch: 3.1.5
+      strip-json-comments: 3.1.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@eslint/js@9.39.4': {}
+
+  '@eslint/object-schema@2.1.7': {}
+
+  '@eslint/plugin-kit@0.4.1':
+    dependencies:
+      '@eslint/core': 0.17.0
       levn: 0.4.1
 
   '@expo/devcert@1.2.1':
@@ -12237,8 +12260,6 @@ snapshots:
       '@types/estree': 1.0.9
       '@types/json-schema': 7.0.15
 
-  '@types/esrecurse@4.3.1': {}
-
   '@types/estree-jsx@1.0.5':
     dependencies:
       '@types/estree': 1.0.9
@@ -12372,15 +12393,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(typescript@5.9.3)':
+  '@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.58.1(eslint@10.3.0)(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.58.1(eslint@9.39.4)(typescript@5.9.3)
       '@typescript-eslint/scope-manager': 8.58.1
-      '@typescript-eslint/type-utils': 8.58.1(eslint@10.3.0)(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.58.1(eslint@10.3.0)(typescript@5.9.3)
+      '@typescript-eslint/type-utils': 8.58.1(eslint@9.39.4)(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.58.1(eslint@9.39.4)(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 8.58.1
-      eslint: 10.3.0
+      eslint: 9.39.4
       ignore: 7.0.5
       natural-compare: 1.4.0
       ts-api-utils: 2.5.0(typescript@5.9.3)
@@ -12401,14 +12422,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.58.1(eslint@10.3.0)(typescript@5.9.3)':
+  '@typescript-eslint/parser@8.58.1(eslint@9.39.4)(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.58.1
       '@typescript-eslint/types': 8.58.1
       '@typescript-eslint/typescript-estree': 8.58.1(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 8.58.1
       debug: 4.4.3
-      eslint: 10.3.0
+      eslint: 9.39.4
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -12470,13 +12491,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/type-utils@8.58.1(eslint@10.3.0)(typescript@5.9.3)':
+  '@typescript-eslint/type-utils@8.58.1(eslint@9.39.4)(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/types': 8.58.1
       '@typescript-eslint/typescript-estree': 8.58.1(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.58.1(eslint@10.3.0)(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.58.1(eslint@9.39.4)(typescript@5.9.3)
       debug: 4.4.3
-      eslint: 10.3.0
+      eslint: 9.39.4
       ts-api-utils: 2.5.0(typescript@5.9.3)
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -12550,25 +12571,25 @@ snapshots:
       - supports-color
       - typescript
 
-  '@typescript-eslint/utils@8.58.1(eslint@10.3.0)(typescript@5.9.3)':
+  '@typescript-eslint/utils@8.58.1(eslint@9.39.4)(typescript@5.9.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.3.0)
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4)
       '@typescript-eslint/scope-manager': 8.58.1
       '@typescript-eslint/types': 8.58.1
       '@typescript-eslint/typescript-estree': 8.58.1(typescript@5.9.3)
-      eslint: 10.3.0
+      eslint: 9.39.4
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
     optional: true
 
-  '@typescript-eslint/utils@8.59.2(eslint@10.3.0)(typescript@5.9.3)':
+  '@typescript-eslint/utils@8.59.2(eslint@9.39.4)(typescript@5.9.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.3.0)
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4)
       '@typescript-eslint/scope-manager': 8.59.2
       '@typescript-eslint/types': 8.59.2
       '@typescript-eslint/typescript-estree': 8.59.2(typescript@5.9.3)
-      eslint: 10.3.0
+      eslint: 9.39.4
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -12851,6 +12872,8 @@ snapshots:
     dependencies:
       sprintf-js: 1.0.3
 
+  argparse@2.0.1: {}
+
   aria-query@5.3.0:
     dependencies:
       dequal: 2.0.3
@@ -12981,18 +13004,6 @@ snapshots:
 
   b4a@1.8.1: {}
 
-  babel-eslint@10.1.0(eslint@10.3.0):
-    dependencies:
-      '@babel/code-frame': 7.29.0
-      '@babel/parser': 7.29.3
-      '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.0
-      eslint: 10.3.0
-      eslint-visitor-keys: 1.3.0
-      resolve: 1.22.12
-    transitivePeerDependencies:
-      - supports-color
-
   babel-eslint@10.1.0(eslint@7.32.0):
     dependencies:
       '@babel/code-frame': 7.29.0
@@ -13000,6 +13011,18 @@ snapshots:
       '@babel/traverse': 7.29.0
       '@babel/types': 7.29.0
       eslint: 7.32.0
+      eslint-visitor-keys: 1.3.0
+      resolve: 1.22.12
+    transitivePeerDependencies:
+      - supports-color
+
+  babel-eslint@10.1.0(eslint@9.39.4):
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/parser': 7.29.3
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+      eslint: 9.39.4
       eslint-visitor-keys: 1.3.0
       resolve: 1.22.12
     transitivePeerDependencies:
@@ -13087,20 +13110,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  babel-plugin-remove-graphql-queries@5.16.0(@babel/core@7.29.0)(gatsby@5.16.1(babel-eslint@10.1.0(eslint@10.3.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)):
+  babel-plugin-remove-graphql-queries@5.16.0(@babel/core@7.29.0)(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)):
     dependencies:
       '@babel/core': 7.29.0
       '@babel/runtime': 7.29.2
       '@babel/types': 7.29.0
-      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@10.3.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)
+      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)
       gatsby-core-utils: 4.16.0
 
-  babel-plugin-remove-graphql-queries@5.16.0(@babel/core@7.29.0)(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)):
+  babel-plugin-remove-graphql-queries@5.16.0(@babel/core@7.29.0)(gatsby@5.16.1(babel-eslint@10.1.0(eslint@9.39.4))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)):
     dependencies:
       '@babel/core': 7.29.0
       '@babel/runtime': 7.29.2
       '@babel/types': 7.29.0
-      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)
+      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@9.39.4))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)
       gatsby-core-utils: 4.16.0
 
   babel-plugin-syntax-trailing-function-commas@7.0.0-beta.0: {}
@@ -14505,27 +14528,11 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
-  eslint-config-prettier@10.1.8(eslint@10.3.0):
+  eslint-config-prettier@10.1.8(eslint@9.39.4):
     dependencies:
-      eslint: 10.3.0
+      eslint: 9.39.4
 
-  eslint-config-react-app@6.0.0(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.9.3))(eslint@7.32.0)(typescript@5.9.3))(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.9.3))(babel-eslint@10.1.0(eslint@10.3.0))(eslint-plugin-flowtype@5.10.0(eslint@7.32.0))(eslint-plugin-import@2.32.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.9.3))(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(eslint-plugin-jsx-a11y@6.10.2(eslint@10.3.0))(eslint-plugin-react-hooks@4.6.2(eslint@7.32.0))(eslint-plugin-react@7.37.5(eslint@10.3.0))(eslint@7.32.0)(typescript@5.9.3):
-    dependencies:
-      '@typescript-eslint/eslint-plugin': 5.62.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.9.3))(eslint@7.32.0)(typescript@5.9.3)
-      '@typescript-eslint/parser': 5.62.0(eslint@7.32.0)(typescript@5.9.3)
-      babel-eslint: 10.1.0(eslint@10.3.0)
-      confusing-browser-globals: 1.0.11
-      eslint: 7.32.0
-      eslint-plugin-flowtype: 5.10.0(eslint@7.32.0)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.9.3))(eslint@7.32.0)
-      eslint-plugin-jsx-a11y: 6.10.2(eslint@10.3.0)
-      eslint-plugin-react: 7.37.5(eslint@10.3.0)
-      eslint-plugin-react-hooks: 4.6.2(eslint@7.32.0)
-    optionalDependencies:
-      eslint-plugin-jest: 29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3)
-      typescript: 5.9.3
-
-  eslint-config-react-app@6.0.0(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.9.3))(eslint@7.32.0)(typescript@5.9.3))(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.9.3))(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-flowtype@5.10.0(eslint@7.32.0))(eslint-plugin-import@2.32.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.9.3))(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(eslint-plugin-jsx-a11y@6.10.2(eslint@7.32.0))(eslint-plugin-react-hooks@4.6.2(eslint@7.32.0))(eslint-plugin-react@7.37.5(eslint@7.32.0))(eslint@7.32.0)(typescript@5.9.3):
+  eslint-config-react-app@6.0.0(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.9.3))(eslint@7.32.0)(typescript@5.9.3))(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.9.3))(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-flowtype@5.10.0(eslint@7.32.0))(eslint-plugin-import@2.32.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.9.3))(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(eslint-plugin-jsx-a11y@6.10.2(eslint@7.32.0))(eslint-plugin-react-hooks@4.6.2(eslint@7.32.0))(eslint-plugin-react@7.37.5(eslint@7.32.0))(eslint@7.32.0)(typescript@5.9.3):
     dependencies:
       '@typescript-eslint/eslint-plugin': 5.62.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.9.3))(eslint@7.32.0)(typescript@5.9.3)
       '@typescript-eslint/parser': 5.62.0(eslint@7.32.0)(typescript@5.9.3)
@@ -14538,7 +14545,23 @@ snapshots:
       eslint-plugin-react: 7.37.5(eslint@7.32.0)
       eslint-plugin-react-hooks: 4.6.2(eslint@7.32.0)
     optionalDependencies:
-      eslint-plugin-jest: 29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3)
+      eslint-plugin-jest: 29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3)
+      typescript: 5.9.3
+
+  eslint-config-react-app@6.0.0(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.9.3))(eslint@7.32.0)(typescript@5.9.3))(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.9.3))(babel-eslint@10.1.0(eslint@9.39.4))(eslint-plugin-flowtype@5.10.0(eslint@7.32.0))(eslint-plugin-import@2.32.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.9.3))(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(eslint-plugin-jsx-a11y@6.10.2(eslint@9.39.4))(eslint-plugin-react-hooks@4.6.2(eslint@7.32.0))(eslint-plugin-react@7.37.5(eslint@9.39.4))(eslint@7.32.0)(typescript@5.9.3):
+    dependencies:
+      '@typescript-eslint/eslint-plugin': 5.62.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.9.3))(eslint@7.32.0)(typescript@5.9.3)
+      '@typescript-eslint/parser': 5.62.0(eslint@7.32.0)(typescript@5.9.3)
+      babel-eslint: 10.1.0(eslint@9.39.4)
+      confusing-browser-globals: 1.0.11
+      eslint: 7.32.0
+      eslint-plugin-flowtype: 5.10.0(eslint@7.32.0)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.9.3))(eslint@7.32.0)
+      eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4)
+      eslint-plugin-react: 7.37.5(eslint@9.39.4)
+      eslint-plugin-react-hooks: 4.6.2(eslint@7.32.0)
+    optionalDependencies:
+      eslint-plugin-jest: 29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3)
       typescript: 5.9.3
 
   eslint-import-resolver-node@0.3.10:
@@ -14594,12 +14617,12 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3):
+  eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3):
     dependencies:
-      '@typescript-eslint/utils': 8.59.2(eslint@10.3.0)(typescript@5.9.3)
-      eslint: 10.3.0
+      '@typescript-eslint/utils': 8.59.2(eslint@9.39.4)(typescript@5.9.3)
+      eslint: 9.39.4
     optionalDependencies:
-      '@typescript-eslint/eslint-plugin': 8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(typescript@5.9.3)
+      '@typescript-eslint/eslint-plugin': 8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3)
       jest: 30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0)
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -14609,25 +14632,6 @@ snapshots:
     dependencies:
       lodash: 4.18.1
       vscode-json-languageservice: 4.2.1
-
-  eslint-plugin-jsx-a11y@6.10.2(eslint@10.3.0):
-    dependencies:
-      aria-query: 5.3.2
-      array-includes: 3.1.9
-      array.prototype.flatmap: 1.3.3
-      ast-types-flow: 0.0.8
-      axe-core: 4.11.4
-      axobject-query: 4.1.0
-      damerau-levenshtein: 1.0.8
-      emoji-regex: 9.2.2
-      eslint: 10.3.0
-      hasown: 2.0.3
-      jsx-ast-utils: 3.3.5
-      language-tags: 1.0.9
-      minimatch: 3.1.5
-      object.fromentries: 2.0.8
-      safe-regex-test: 1.1.0
-      string.prototype.includes: 2.0.1
 
   eslint-plugin-jsx-a11y@6.10.2(eslint@7.32.0):
     dependencies:
@@ -14648,52 +14652,49 @@ snapshots:
       safe-regex-test: 1.1.0
       string.prototype.includes: 2.0.1
 
-  eslint-plugin-prettier@5.5.5(@types/eslint@9.6.1)(eslint-config-prettier@10.1.8(eslint@10.3.0))(eslint@10.3.0)(prettier@3.8.3):
+  eslint-plugin-jsx-a11y@6.10.2(eslint@9.39.4):
     dependencies:
-      eslint: 10.3.0
+      aria-query: 5.3.2
+      array-includes: 3.1.9
+      array.prototype.flatmap: 1.3.3
+      ast-types-flow: 0.0.8
+      axe-core: 4.11.4
+      axobject-query: 4.1.0
+      damerau-levenshtein: 1.0.8
+      emoji-regex: 9.2.2
+      eslint: 9.39.4
+      hasown: 2.0.3
+      jsx-ast-utils: 3.3.5
+      language-tags: 1.0.9
+      minimatch: 3.1.5
+      object.fromentries: 2.0.8
+      safe-regex-test: 1.1.0
+      string.prototype.includes: 2.0.1
+
+  eslint-plugin-prettier@5.5.5(@types/eslint@9.6.1)(eslint-config-prettier@10.1.8(eslint@9.39.4))(eslint@9.39.4)(prettier@3.8.3):
+    dependencies:
+      eslint: 9.39.4
       prettier: 3.8.3
       prettier-linter-helpers: 1.0.1
       synckit: 0.11.12
     optionalDependencies:
       '@types/eslint': 9.6.1
-      eslint-config-prettier: 10.1.8(eslint@10.3.0)
+      eslint-config-prettier: 10.1.8(eslint@9.39.4)
 
   eslint-plugin-react-hooks@4.6.2(eslint@7.32.0):
     dependencies:
       eslint: 7.32.0
 
-  eslint-plugin-react-hooks@7.1.1(eslint@10.3.0):
+  eslint-plugin-react-hooks@7.1.1(eslint@9.39.4):
     dependencies:
       '@babel/core': 7.29.0
       '@babel/parser': 7.29.3
-      eslint: 10.3.0
+      eslint: 9.39.4
       hermes-parser: 0.25.1
       zod: 4.4.3
       zod-validation-error: 4.0.2(zod@4.4.3)
     transitivePeerDependencies:
       - supports-color
-
-  eslint-plugin-react@7.37.5(eslint@10.3.0):
-    dependencies:
-      array-includes: 3.1.9
-      array.prototype.findlast: 1.2.5
-      array.prototype.flatmap: 1.3.3
-      array.prototype.tosorted: 1.1.4
-      doctrine: 2.1.0
-      es-iterator-helpers: 1.3.2
-      eslint: 10.3.0
-      estraverse: 5.3.0
-      hasown: 2.0.3
-      jsx-ast-utils: 3.3.5
-      minimatch: 3.1.5
-      object.entries: 1.1.9
-      object.fromentries: 2.0.8
-      object.values: 1.2.1
-      prop-types: 15.8.1
-      resolve: 2.0.0-next.6
-      semver: 6.3.1
-      string.prototype.matchall: 4.0.12
-      string.prototype.repeat: 1.0.0
 
   eslint-plugin-react@7.37.5(eslint@7.32.0):
     dependencies:
@@ -14717,15 +14718,35 @@ snapshots:
       string.prototype.matchall: 4.0.12
       string.prototype.repeat: 1.0.0
 
+  eslint-plugin-react@7.37.5(eslint@9.39.4):
+    dependencies:
+      array-includes: 3.1.9
+      array.prototype.findlast: 1.2.5
+      array.prototype.flatmap: 1.3.3
+      array.prototype.tosorted: 1.1.4
+      doctrine: 2.1.0
+      es-iterator-helpers: 1.3.2
+      eslint: 9.39.4
+      estraverse: 5.3.0
+      hasown: 2.0.3
+      jsx-ast-utils: 3.3.5
+      minimatch: 3.1.5
+      object.entries: 1.1.9
+      object.fromentries: 2.0.8
+      object.values: 1.2.1
+      prop-types: 15.8.1
+      resolve: 2.0.0-next.6
+      semver: 6.3.1
+      string.prototype.matchall: 4.0.12
+      string.prototype.repeat: 1.0.0
+
   eslint-scope@5.1.1:
     dependencies:
       esrecurse: 4.3.0
       estraverse: 4.3.0
 
-  eslint-scope@9.1.2:
+  eslint-scope@8.4.0:
     dependencies:
-      '@types/esrecurse': 4.3.1
-      '@types/estree': 1.0.9
       esrecurse: 4.3.0
       estraverse: 5.3.0
 
@@ -14739,6 +14760,8 @@ snapshots:
 
   eslint-visitor-keys@3.4.3: {}
 
+  eslint-visitor-keys@4.2.1: {}
+
   eslint-visitor-keys@5.0.1: {}
 
   eslint-webpack-plugin@2.7.0(eslint@7.32.0)(webpack@5.98.0(postcss@8.5.14)):
@@ -14751,41 +14774,6 @@ snapshots:
       normalize-path: 3.0.0
       schema-utils: 3.3.0
       webpack: 5.98.0(postcss@8.5.14)
-
-  eslint@10.3.0:
-    dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.3.0)
-      '@eslint-community/regexpp': 4.12.2
-      '@eslint/config-array': 0.23.5
-      '@eslint/config-helpers': 0.5.5
-      '@eslint/core': 1.2.1
-      '@eslint/plugin-kit': 0.7.1
-      '@humanfs/node': 0.16.8
-      '@humanwhocodes/module-importer': 1.0.1
-      '@humanwhocodes/retry': 0.4.3
-      '@types/estree': 1.0.9
-      ajv: 6.15.0
-      cross-spawn: 7.0.6
-      debug: 4.4.3
-      escape-string-regexp: 4.0.0
-      eslint-scope: 9.1.2
-      eslint-visitor-keys: 5.0.1
-      espree: 11.2.0
-      esquery: 1.7.0
-      esutils: 2.0.3
-      fast-deep-equal: 3.1.3
-      file-entry-cache: 8.0.0
-      find-up: 5.0.0
-      glob-parent: 6.0.2
-      ignore: 5.3.2
-      imurmurhash: 0.1.4
-      is-glob: 4.0.3
-      json-stable-stringify-without-jsonify: 1.0.1
-      minimatch: 10.2.5
-      natural-compare: 1.4.0
-      optionator: 0.9.4
-    transitivePeerDependencies:
-      - supports-color
 
   eslint@7.32.0:
     dependencies:
@@ -14832,6 +14820,45 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  eslint@9.39.4:
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4)
+      '@eslint-community/regexpp': 4.12.2
+      '@eslint/config-array': 0.21.2
+      '@eslint/config-helpers': 0.4.2
+      '@eslint/core': 0.17.0
+      '@eslint/eslintrc': 3.3.5
+      '@eslint/js': 9.39.4
+      '@eslint/plugin-kit': 0.4.1
+      '@humanfs/node': 0.16.8
+      '@humanwhocodes/module-importer': 1.0.1
+      '@humanwhocodes/retry': 0.4.3
+      '@types/estree': 1.0.9
+      ajv: 6.15.0
+      chalk: 4.1.2
+      cross-spawn: 7.0.6
+      debug: 4.4.3
+      escape-string-regexp: 4.0.0
+      eslint-scope: 8.4.0
+      eslint-visitor-keys: 4.2.1
+      espree: 10.4.0
+      esquery: 1.7.0
+      esutils: 2.0.3
+      fast-deep-equal: 3.1.3
+      file-entry-cache: 8.0.0
+      find-up: 5.0.0
+      glob-parent: 6.0.2
+      ignore: 5.3.2
+      imurmurhash: 0.1.4
+      is-glob: 4.0.3
+      json-stable-stringify-without-jsonify: 1.0.1
+      lodash.merge: 4.6.2
+      minimatch: 3.1.5
+      natural-compare: 1.4.0
+      optionator: 0.9.4
+    transitivePeerDependencies:
+      - supports-color
+
   esniff@2.0.1:
     dependencies:
       d: 1.0.2
@@ -14839,11 +14866,11 @@ snapshots:
       event-emitter: 0.3.5
       type: 2.7.3
 
-  espree@11.2.0:
+  espree@10.4.0:
     dependencies:
       acorn: 8.16.0
       acorn-jsx: 5.3.2(acorn@8.16.0)
-      eslint-visitor-keys: 5.0.1
+      eslint-visitor-keys: 4.2.1
 
   espree@7.3.1:
     dependencies:
@@ -15374,23 +15401,23 @@ snapshots:
       '@parcel/transformer-js': 2.8.3(@parcel/core@2.8.3)
       '@parcel/transformer-json': 2.8.3(@parcel/core@2.8.3)
 
-  gatsby-plugin-emotion@8.16.0(@babel/core@7.29.0)(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)):
+  gatsby-plugin-emotion@8.16.0(@babel/core@7.29.0)(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)):
     dependencies:
       '@babel/core': 7.29.0
       '@babel/runtime': 7.29.2
       '@emotion/babel-preset-css-prop': 11.12.0(@babel/core@7.29.0)
       '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.6)
-      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)
+      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)
     transitivePeerDependencies:
       - supports-color
 
-  gatsby-plugin-feed@5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3))(graphql@16.14.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+  gatsby-plugin-feed@5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3))(graphql@16.14.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
       '@babel/runtime': 7.29.2
       common-tags: 1.8.2
       fs-extra: 11.3.5
-      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)
-      gatsby-plugin-utils: 4.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3))(graphql@16.14.0)
+      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)
+      gatsby-plugin-utils: 4.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3))(graphql@16.14.0)
       lodash.merge: 4.6.2
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
@@ -15401,20 +15428,20 @@ snapshots:
       - graphql
       - react-native-b4a
 
-  gatsby-plugin-google-gtag@5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@10.3.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+  gatsby-plugin-google-gtag@5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@9.39.4))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
       '@babel/runtime': 7.29.2
-      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@10.3.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)
+      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@9.39.4))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)
       minimatch: 3.1.5
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
 
-  gatsby-plugin-manifest@5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3))(graphql@16.14.0):
+  gatsby-plugin-manifest@5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3))(graphql@16.14.0):
     dependencies:
       '@babel/runtime': 7.29.2
-      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)
+      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)
       gatsby-core-utils: 4.16.0
-      gatsby-plugin-utils: 4.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3))(graphql@16.14.0)
+      gatsby-plugin-utils: 4.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3))(graphql@16.14.0)
       semver: 7.8.0
       sharp: 0.32.6
     transitivePeerDependencies:
@@ -15423,7 +15450,7 @@ snapshots:
       - graphql
       - react-native-b4a
 
-  gatsby-plugin-mdx@5.16.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6))(gatsby-source-filesystem@5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)))(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3))(graphql@16.14.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+  gatsby-plugin-mdx@5.16.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6))(gatsby-source-filesystem@5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)))(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3))(graphql@16.14.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
       '@mdx-js/mdx': 2.3.0
       '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@19.2.6)
@@ -15433,10 +15460,10 @@ snapshots:
       deepmerge: 4.3.1
       estree-util-build-jsx: 2.2.2
       fs-extra: 11.3.5
-      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)
+      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)
       gatsby-core-utils: 4.16.0
-      gatsby-plugin-utils: 4.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3))(graphql@16.14.0)
-      gatsby-source-filesystem: 5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3))
+      gatsby-plugin-utils: 4.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3))(graphql@16.14.0)
+      gatsby-source-filesystem: 5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3))
       gray-matter: 4.0.3
       mdast-util-mdx: 2.0.1
       mdast-util-to-hast: 10.2.0
@@ -15456,7 +15483,7 @@ snapshots:
       - react-native-b4a
       - supports-color
 
-  gatsby-plugin-page-creator@5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@10.3.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3))(graphql@16.14.0):
+  gatsby-plugin-page-creator@5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3))(graphql@16.14.0):
     dependencies:
       '@babel/runtime': 7.29.2
       '@babel/traverse': 7.29.0
@@ -15464,10 +15491,10 @@ snapshots:
       chokidar: 3.6.0
       fs-exists-cached: 1.0.0
       fs-extra: 11.3.5
-      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@10.3.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)
+      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)
       gatsby-core-utils: 4.16.0
       gatsby-page-utils: 3.16.0
-      gatsby-plugin-utils: 4.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@10.3.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3))(graphql@16.14.0)
+      gatsby-plugin-utils: 4.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3))(graphql@16.14.0)
       globby: 11.1.0
       lodash: 4.18.1
     transitivePeerDependencies:
@@ -15477,7 +15504,7 @@ snapshots:
       - react-native-b4a
       - supports-color
 
-  gatsby-plugin-page-creator@5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3))(graphql@16.14.0):
+  gatsby-plugin-page-creator@5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@9.39.4))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3))(graphql@16.14.0):
     dependencies:
       '@babel/runtime': 7.29.2
       '@babel/traverse': 7.29.0
@@ -15485,10 +15512,10 @@ snapshots:
       chokidar: 3.6.0
       fs-exists-cached: 1.0.0
       fs-extra: 11.3.5
-      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)
+      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@9.39.4))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)
       gatsby-core-utils: 4.16.0
       gatsby-page-utils: 3.16.0
-      gatsby-plugin-utils: 4.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3))(graphql@16.14.0)
+      gatsby-plugin-utils: 4.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@9.39.4))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3))(graphql@16.14.0)
       globby: 11.1.0
       lodash: 4.18.1
     transitivePeerDependencies:
@@ -15498,13 +15525,13 @@ snapshots:
       - react-native-b4a
       - supports-color
 
-  gatsby-plugin-robots-txt@1.8.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@10.3.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)):
+  gatsby-plugin-robots-txt@1.8.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@9.39.4))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)):
     dependencies:
       '@babel/runtime': 7.29.2
-      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@10.3.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)
+      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@9.39.4))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)
       generate-robotstxt: 8.0.3
 
-  gatsby-plugin-sharp@5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3))(graphql@16.14.0):
+  gatsby-plugin-sharp@5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3))(graphql@16.14.0):
     dependencies:
       '@babel/runtime': 7.29.2
       async: 3.2.6
@@ -15512,9 +15539,9 @@ snapshots:
       debug: 4.4.3
       filenamify: 4.3.0
       fs-extra: 11.3.5
-      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)
+      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)
       gatsby-core-utils: 4.16.0
-      gatsby-plugin-utils: 4.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3))(graphql@16.14.0)
+      gatsby-plugin-utils: 4.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3))(graphql@16.14.0)
       lodash: 4.18.1
       probe-image-size: 7.3.0
       semver: 7.8.0
@@ -15526,27 +15553,27 @@ snapshots:
       - react-native-b4a
       - supports-color
 
-  gatsby-plugin-sitemap@6.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@10.3.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+  gatsby-plugin-sitemap@6.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@9.39.4))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
       '@babel/runtime': 7.29.2
       common-tags: 1.8.2
-      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@10.3.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)
+      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@9.39.4))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)
       minimatch: 3.1.5
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
       sitemap: 7.1.3
 
-  gatsby-plugin-theme-ui@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6))(@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6)))(@theme-ui/mdx@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/mdx@2.0.13)(react@19.2.6))(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3))(react@19.2.6)(theme-ui@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)):
+  gatsby-plugin-theme-ui@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6))(@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6)))(@theme-ui/mdx@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/mdx@2.0.13)(react@19.2.6))(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3))(react@19.2.6)(theme-ui@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)):
     dependencies:
       '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.6)
       '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@19.2.6)
       '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))
       '@theme-ui/mdx': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/mdx@2.0.13)(react@19.2.6)
-      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)
+      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)
       react: 19.2.6
       theme-ui: 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
 
-  gatsby-plugin-typescript@5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@10.3.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)):
+  gatsby-plugin-typescript@5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)):
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-proposal-nullish-coalescing-operator': 7.18.6(@babel/core@7.29.0)
@@ -15554,12 +15581,12 @@ snapshots:
       '@babel/plugin-proposal-optional-chaining': 7.21.0(@babel/core@7.29.0)
       '@babel/preset-typescript': 7.28.5(@babel/core@7.29.0)
       '@babel/runtime': 7.29.2
-      babel-plugin-remove-graphql-queries: 5.16.0(@babel/core@7.29.0)(gatsby@5.16.1(babel-eslint@10.1.0(eslint@10.3.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3))
-      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@10.3.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)
+      babel-plugin-remove-graphql-queries: 5.16.0(@babel/core@7.29.0)(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3))
+      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)
     transitivePeerDependencies:
       - supports-color
 
-  gatsby-plugin-typescript@5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)):
+  gatsby-plugin-typescript@5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@9.39.4))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)):
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-proposal-nullish-coalescing-operator': 7.18.6(@babel/core@7.29.0)
@@ -15567,17 +15594,17 @@ snapshots:
       '@babel/plugin-proposal-optional-chaining': 7.21.0(@babel/core@7.29.0)
       '@babel/preset-typescript': 7.28.5(@babel/core@7.29.0)
       '@babel/runtime': 7.29.2
-      babel-plugin-remove-graphql-queries: 5.16.0(@babel/core@7.29.0)(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3))
-      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)
+      babel-plugin-remove-graphql-queries: 5.16.0(@babel/core@7.29.0)(gatsby@5.16.1(babel-eslint@10.1.0(eslint@9.39.4))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3))
+      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@9.39.4))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)
     transitivePeerDependencies:
       - supports-color
 
-  gatsby-plugin-utils@4.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@10.3.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3))(graphql@16.14.0):
+  gatsby-plugin-utils@4.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3))(graphql@16.14.0):
     dependencies:
       '@babel/runtime': 7.29.2
       fastq: 1.20.1
       fs-extra: 11.3.5
-      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@10.3.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)
+      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)
       gatsby-core-utils: 4.16.0
       gatsby-sharp: 1.16.0
       graphql: 16.14.0
@@ -15590,12 +15617,12 @@ snapshots:
       - bare-buffer
       - react-native-b4a
 
-  gatsby-plugin-utils@4.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3))(graphql@16.14.0):
+  gatsby-plugin-utils@4.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@9.39.4))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3))(graphql@16.14.0):
     dependencies:
       '@babel/runtime': 7.29.2
       fastq: 1.20.1
       fs-extra: 11.3.5
-      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)
+      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@9.39.4))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)
       gatsby-core-utils: 4.16.0
       gatsby-sharp: 1.16.0
       graphql: 16.14.0
@@ -15616,10 +15643,10 @@ snapshots:
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
 
-  gatsby-remark-autolink-headers@6.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+  gatsby-remark-autolink-headers@6.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
       '@babel/runtime': 7.29.2
-      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)
+      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)
       github-slugger: 1.5.0
       lodash: 4.18.1
       mdast-util-to-string: 2.0.0
@@ -15627,12 +15654,12 @@ snapshots:
       react-dom: 19.2.6(react@19.2.6)
       unist-util-visit: 2.0.3
 
-  gatsby-remark-copy-linked-files@6.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)):
+  gatsby-remark-copy-linked-files@6.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)):
     dependencies:
       '@babel/runtime': 7.29.2
       cheerio: 1.0.0-rc.12
       fs-extra: 11.3.5
-      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)
+      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)
       is-relative-url: 3.0.0
       lodash: 4.18.1
       path-is-inside: 1.0.2
@@ -15647,14 +15674,14 @@ snapshots:
       remark-burger: 1.0.1
       unist-util-visit: 2.0.3
 
-  gatsby-remark-images@7.16.0(gatsby-plugin-sharp@5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3))(graphql@16.14.0))(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)):
+  gatsby-remark-images@7.16.0(gatsby-plugin-sharp@5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3))(graphql@16.14.0))(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)):
     dependencies:
       '@babel/runtime': 7.29.2
       chalk: 4.1.2
       cheerio: 1.0.0-rc.12
-      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)
+      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)
       gatsby-core-utils: 4.16.0
-      gatsby-plugin-sharp: 5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3))(graphql@16.14.0)
+      gatsby-plugin-sharp: 5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3))(graphql@16.14.0)
       is-relative-url: 3.0.0
       lodash: 4.18.1
       mdast-util-definitions: 4.0.0
@@ -15662,10 +15689,10 @@ snapshots:
       unist-util-select: 3.0.4
       unist-util-visit-parents: 3.1.1
 
-  gatsby-remark-prismjs@7.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3))(prismjs@1.30.0):
+  gatsby-remark-prismjs@7.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3))(prismjs@1.30.0):
     dependencies:
       '@babel/runtime': 7.29.2
-      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)
+      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)
       parse-numeric-range: 1.3.0
       prismjs: 1.30.0
       unist-util-visit: 2.0.3
@@ -15684,24 +15711,24 @@ snapshots:
       - bare-buffer
       - react-native-b4a
 
-  gatsby-source-filesystem@5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)):
+  gatsby-source-filesystem@5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)):
     dependencies:
       '@babel/runtime': 7.29.2
       chokidar: 3.6.0
       file-type: 16.5.4
       fs-extra: 11.3.5
-      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)
+      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)
       gatsby-core-utils: 4.16.0
       mime: 3.0.0
       pretty-bytes: 5.6.0
       valid-url: 1.0.9
       xstate: 4.38.3
 
-  gatsby-theme-style-guide@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6)))(@types/mdx@2.0.13)(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+  gatsby-theme-style-guide@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6)))(@types/mdx@2.0.13)(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
       '@theme-ui/mdx': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/mdx@2.0.13)(react@19.2.6)
       '@theme-ui/style-guide': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6)))(react@19.2.6)(theme-ui@0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))
-      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)
+      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
       theme-ui: 0.17.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
@@ -15710,16 +15737,16 @@ snapshots:
       - '@theme-ui/css'
       - '@types/mdx'
 
-  gatsby-transformer-json@5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)):
+  gatsby-transformer-json@5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)):
     dependencies:
       '@babel/runtime': 7.29.2
       bluebird: 3.7.2
-      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)
+      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)
 
-  gatsby-transformer-remark@6.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)):
+  gatsby-transformer-remark@6.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)):
     dependencies:
       '@babel/runtime': 7.29.2
-      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)
+      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)
       gatsby-core-utils: 4.16.0
       gray-matter: 4.0.3
       hast-util-raw: 6.1.0
@@ -15744,15 +15771,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  gatsby-transformer-sharp@5.16.0(gatsby-plugin-sharp@5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3))(graphql@16.14.0))(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3))(graphql@16.14.0):
+  gatsby-transformer-sharp@5.16.0(gatsby-plugin-sharp@5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3))(graphql@16.14.0))(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3))(graphql@16.14.0):
     dependencies:
       '@babel/runtime': 7.29.2
       bluebird: 3.7.2
       common-tags: 1.8.2
       fs-extra: 11.3.5
-      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)
-      gatsby-plugin-sharp: 5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3))(graphql@16.14.0)
-      gatsby-plugin-utils: 4.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3))(graphql@16.14.0)
+      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)
+      gatsby-plugin-sharp: 5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3))(graphql@16.14.0)
+      gatsby-plugin-utils: 4.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3))(graphql@16.14.0)
       probe-image-size: 7.3.0
       semver: 7.8.0
       sharp: 0.32.6
@@ -15772,7 +15799,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  gatsby@5.16.1(babel-eslint@10.1.0(eslint@10.3.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3):
+  gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3):
     dependencies:
       '@babel/code-frame': 7.29.0
       '@babel/core': 7.29.0
@@ -15813,7 +15840,7 @@ snapshots:
       babel-loader: 8.4.1(@babel/core@7.29.0)(webpack@5.98.0(postcss@8.5.14))
       babel-plugin-add-module-exports: 1.0.4
       babel-plugin-dynamic-import-node: 2.3.3
-      babel-plugin-remove-graphql-queries: 5.16.0(@babel/core@7.29.0)(gatsby@5.16.1(babel-eslint@10.1.0(eslint@10.3.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3))
+      babel-plugin-remove-graphql-queries: 5.16.0(@babel/core@7.29.0)(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3))
       babel-preset-gatsby: 3.16.0(@babel/core@7.29.0)(core-js@3.49.0)
       better-opn: 2.1.1
       bluebird: 3.7.2
@@ -15838,7 +15865,7 @@ snapshots:
       enhanced-resolve: 5.21.2
       error-stack-parser: 2.1.4
       eslint: 7.32.0
-      eslint-config-react-app: 6.0.0(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.9.3))(eslint@7.32.0)(typescript@5.9.3))(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.9.3))(babel-eslint@10.1.0(eslint@10.3.0))(eslint-plugin-flowtype@5.10.0(eslint@7.32.0))(eslint-plugin-import@2.32.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.9.3))(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(eslint-plugin-jsx-a11y@6.10.2(eslint@10.3.0))(eslint-plugin-react-hooks@4.6.2(eslint@7.32.0))(eslint-plugin-react@7.37.5(eslint@10.3.0))(eslint@7.32.0)(typescript@5.9.3)
+      eslint-config-react-app: 6.0.0(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.9.3))(eslint@7.32.0)(typescript@5.9.3))(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.9.3))(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-flowtype@5.10.0(eslint@7.32.0))(eslint-plugin-import@2.32.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.9.3))(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(eslint-plugin-jsx-a11y@6.10.2(eslint@7.32.0))(eslint-plugin-react-hooks@4.6.2(eslint@7.32.0))(eslint-plugin-react@7.37.5(eslint@7.32.0))(eslint@7.32.0)(typescript@5.9.3)
       eslint-plugin-flowtype: 5.10.0(eslint@7.32.0)
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.9.3))(eslint@7.32.0)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@7.32.0)
@@ -15862,9 +15889,9 @@ snapshots:
       gatsby-link: 5.16.0(@gatsbyjs/reach-router@2.0.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       gatsby-page-utils: 3.16.0
       gatsby-parcel-config: 1.16.0(@parcel/core@2.8.3)
-      gatsby-plugin-page-creator: 5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@10.3.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3))(graphql@16.14.0)
-      gatsby-plugin-typescript: 5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@10.3.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3))
-      gatsby-plugin-utils: 4.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@10.3.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3))(graphql@16.14.0)
+      gatsby-plugin-page-creator: 5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3))(graphql@16.14.0)
+      gatsby-plugin-typescript: 5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3))
+      gatsby-plugin-utils: 4.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3))(graphql@16.14.0)
       gatsby-react-router-scroll: 6.16.0(@gatsbyjs/reach-router@2.0.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       gatsby-script: 2.16.0(@gatsbyjs/reach-router@2.0.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       gatsby-worker: 2.16.0
@@ -15978,7 +16005,7 @@ snapshots:
       - webpack-hot-middleware
       - webpack-plugin-serve
 
-  gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3):
+  gatsby@5.16.1(babel-eslint@10.1.0(eslint@9.39.4))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3):
     dependencies:
       '@babel/code-frame': 7.29.0
       '@babel/core': 7.29.0
@@ -16019,7 +16046,7 @@ snapshots:
       babel-loader: 8.4.1(@babel/core@7.29.0)(webpack@5.98.0(postcss@8.5.14))
       babel-plugin-add-module-exports: 1.0.4
       babel-plugin-dynamic-import-node: 2.3.3
-      babel-plugin-remove-graphql-queries: 5.16.0(@babel/core@7.29.0)(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3))
+      babel-plugin-remove-graphql-queries: 5.16.0(@babel/core@7.29.0)(gatsby@5.16.1(babel-eslint@10.1.0(eslint@9.39.4))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3))
       babel-preset-gatsby: 3.16.0(@babel/core@7.29.0)(core-js@3.49.0)
       better-opn: 2.1.1
       bluebird: 3.7.2
@@ -16044,7 +16071,7 @@ snapshots:
       enhanced-resolve: 5.21.2
       error-stack-parser: 2.1.4
       eslint: 7.32.0
-      eslint-config-react-app: 6.0.0(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.9.3))(eslint@7.32.0)(typescript@5.9.3))(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.9.3))(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-flowtype@5.10.0(eslint@7.32.0))(eslint-plugin-import@2.32.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.9.3))(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(eslint-plugin-jsx-a11y@6.10.2(eslint@7.32.0))(eslint-plugin-react-hooks@4.6.2(eslint@7.32.0))(eslint-plugin-react@7.37.5(eslint@7.32.0))(eslint@7.32.0)(typescript@5.9.3)
+      eslint-config-react-app: 6.0.0(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.9.3))(eslint@7.32.0)(typescript@5.9.3))(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.9.3))(babel-eslint@10.1.0(eslint@9.39.4))(eslint-plugin-flowtype@5.10.0(eslint@7.32.0))(eslint-plugin-import@2.32.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.9.3))(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(eslint-plugin-jsx-a11y@6.10.2(eslint@9.39.4))(eslint-plugin-react-hooks@4.6.2(eslint@7.32.0))(eslint-plugin-react@7.37.5(eslint@9.39.4))(eslint@7.32.0)(typescript@5.9.3)
       eslint-plugin-flowtype: 5.10.0(eslint@7.32.0)
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.9.3))(eslint@7.32.0)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@7.32.0)
@@ -16068,9 +16095,9 @@ snapshots:
       gatsby-link: 5.16.0(@gatsbyjs/reach-router@2.0.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       gatsby-page-utils: 3.16.0
       gatsby-parcel-config: 1.16.0(@parcel/core@2.8.3)
-      gatsby-plugin-page-creator: 5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3))(graphql@16.14.0)
-      gatsby-plugin-typescript: 5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3))
-      gatsby-plugin-utils: 4.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3))(graphql@16.14.0)
+      gatsby-plugin-page-creator: 5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@9.39.4))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3))(graphql@16.14.0)
+      gatsby-plugin-typescript: 5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@9.39.4))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3))
+      gatsby-plugin-utils: 4.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@9.39.4))(eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(jest@30.4.2(@types/node@25.6.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3))(graphql@16.14.0)
       gatsby-react-router-scroll: 6.16.0(@gatsbyjs/reach-router@2.0.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       gatsby-script: 2.16.0(@gatsbyjs/reach-router@2.0.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       gatsby-worker: 2.16.0
@@ -16289,6 +16316,8 @@ snapshots:
   globals@13.24.0:
     dependencies:
       type-fest: 0.20.2
+
+  globals@14.0.0: {}
 
   globalthis@1.0.4:
     dependencies:
@@ -17466,6 +17495,10 @@ snapshots:
     dependencies:
       argparse: 1.0.10
       esprima: 4.0.1
+
+  js-yaml@4.1.1:
+    dependencies:
+      argparse: 2.0.1
 
   jsdom@26.1.0:
     dependencies:

--- a/websites/www.chrisvogt.me/package.json
+++ b/websites/www.chrisvogt.me/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "www.chrisvogt.me",
-  "version": "1.22.6",
+  "version": "1.22.7",
   "license": "GPL",
   "scripts": {
     "build": "gatsby build",

--- a/websites/www.chronogrove.com/package.json
+++ b/websites/www.chronogrove.com/package.json
@@ -1,6 +1,6 @@
 {
   "name": "www.chronogrove.com",
-  "version": "1.9.5",
+  "version": "1.9.6",
   "description": "Official demo site for gatsby-theme-chronogrove",
   "scripts": {
     "develop": "gatsby develop",


### PR DESCRIPTION
## Tracking

Part of **Phase 1 (PropTypes)** in the incremental TypeScript migration epic: [#630](https://github.com/chrisvogt/gatsby-theme-chronogrove/issues/630).

This PR does **not** close that issue; it contributes the bulk of the Phase 1 groundwork so we can tick items there after merge.

### Epic checklist — items covered by this PR

- [x] ESLint `react/prop-types` scopes for theme / `@chronogrove/ui` / `examples/chronogrove-next` (see root `eslint.config.js`)
- [x] Theme: broad PropTypes pass (components, widgets, shortcodes, key pages/templates; nullable / MDX-aware shapes where needed)
- [x] `@chronogrove/ui`: PropTypes on shared `src` components
- [x] Next.js reference app: `prop-types` + local `propTypes` where applicable
- [x] Shared nullable validators: `@chronogrove/ui/prop-types-helpers` (single import path for theme + UI)
- [x] README: incremental TypeScript / PropTypes contributor note

Follow-up work (still Phase 1) stays on #630: drive lint warnings toward zero, website `src` audit, optional extraction of helpers to a dedicated workspace package.

## Summary

- Enable and scope ESLint `react/prop-types` for `packages/theme/src`, `packages/ui/src`, and `examples/chronogrove-next/app`, with a fixed React version for ESLint settings to avoid the detect-version warning.
- Add `prop-types` to portable UI components and align shapes with real runtime data (e.g. nullable widget payloads, MDX-backed values) across the Gatsby theme and shared UI package.
- Wire the Chronogrove Next.js reference app with `prop-types` and explicit `propTypes` on local layout/provider/showcase components.
- Document the incremental PropTypes / future TypeScript story in the root README.
- Centralize repeated PropTypes patterns via `@chronogrove/ui/prop-types-helpers`.

## Test plan

- [x] `pnpm lint`
- [x] `pnpm test` (or `pnpm --filter gatsby-theme-chronogrove test` and `pnpm --filter @chronogrove/ui test` if you prefer scoped runs)
- [x] Optional: `pnpm --filter chronogrove-next build` to confirm the App Router example still compiles


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly adds runtime `propTypes` annotations and ESLint scoping; behavior changes are minimal but the wide file touch surface could surface missing/incorrect prop assumptions at runtime.
> 
> **Overview**
> Adds scoped `react/prop-types` linting for `packages/theme/src`, `packages/ui/src`, and the Next.js example, and pins ESLint React version detection to avoid monorepo root warnings.
> 
> Introduces `@chronogrove/ui/prop-types-helpers` (nullable + MDX-aware validators) and applies PropTypes broadly across theme components/widgets/shortcodes, shared `@chronogrove/ui` primitives (including Next helpers), and the `examples/chronogrove-next` app; also adds `prop-types` dependencies where needed and updates root ESLint devDependency versions.
> 
> Documents the incremental TypeScript/PropTypes contributor guideline in `README.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab153c9e9b186ed1096797cd8824d87eb993aafa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->