### PR TITLE
[codex] Fix Head runtime error in local MDX templates

### DIFF
--- a/packages/theme/src/templates/media.js
+++ b/packages/theme/src/templates/media.js
@@ -176,12 +176,6 @@ export function Head({ data }) {
   )
 }
 
-Head.propTypes = {
-  data: PropTypes.shape({
-    mdx: mediaMdxPropType
-  }).isRequired
-}
-
 export const pageQuery = graphql`
   query ($id: String!) {
     mdx(fields: { id: { eq: $id } }) {

--- a/packages/theme/src/templates/post.js
+++ b/packages/theme/src/templates/post.js
@@ -132,12 +132,6 @@ export function Head({ data }) {
   )
 }
 
-Head.propTypes = {
-  data: PropTypes.shape({
-    mdx: mdxHeadPropType
-  }).isRequired
-}
-
 export const pageQuery = graphql`
   query ($id: String!) {
     mdx(fields: { id: { eq: $id } }) {


### PR DESCRIPTION
## Summary
- remove Head.propTypes assignments from shared post and media templates
- keep main template prop validation in place
- avoid Gatsby develop runtime failures in MDX-wrapped templates

## Root cause
Gatsby's local MDX template wrapper was evaluating the Head.propTypes attachment in a way that left Head undefined at runtime in develop mode.

## Validation
- confirmed the runtime error disappeared in local develop after the template change
- automated test reruns were blocked in the Codex shell because it was picking up a broken Node 22 binary, while this repo expects Node 24